### PR TITLE
Remove duplicate gc routes

### DIFF
--- a/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,944 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":998,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"da6b4d9f-3328-4512-9bb8-ff75d0e5f3a6\",{\"client\":{\"user\":{\"id\":\"klzli0cw7@example.com}\",\"name\":\"jz1tbflj7jcei2x\",\"email\":\"vr9d9eycb@example.com}\"}},\"sequenceNumber\":828}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bb9e2ce9-a124-406e-b2e4-21e8a66691e1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69228a44-4edf-46da-a61e-cc8e04aacea4",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "cf344c73-866d-4898-8b7f-eef33576cd21",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c292a822-0c39-48d3-b393-0c8cdd53ab02\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c292a822-0c39-48d3-b393-0c8cdd53ab02\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/cf344c73-866d-4898-8b7f-eef33576cd21\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/75e02f67-1195-41ee-841b-787e60b24b40\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/71854446-42b7-40ee-bb23-a6ff32401ee1\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46adc1de-7103-4acf-9f49-e9e3f1ba6f9c\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b1a5c6f5-3034-42d8-a9c1-fc836626c588\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6f480985-7587-4039-ba4b-8746ec4126be\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "75e02f67-1195-41ee-841b-787e60b24b40",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c292a822-0c39-48d3-b393-0c8cdd53ab02\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":43,\"refSeqNumber\":820}},\"da6b4d9f-3328-4512-9bb8-ff75d0e5f3a6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":43,\"refSeqNumber\":997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "71854446-42b7-40ee-bb23-a6ff32401ee1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b1a5c6f5-3034-42d8-a9c1-fc836626c588",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0bf30675-6853-4346-a1b1-7a4f2d8feb41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/def76a5c-2d37-4873-b732-1225eb348a89\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fbcaa955-9dc2-4409-b306-369ae7dc57df\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dafc6b1-158b-44d4-b0dd-b7ae11d6e9a5\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4ffbe092-be32-4e79-abf9-060ae067b993\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b7823bb-bf20-4845-a7a7-6cf08fa05b5a\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9eb85b04-792b-4683-b4fc-0cbde75aabc3\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0bf30675-6853-4346-a1b1-7a4f2d8feb41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "def76a5c-2d37-4873-b732-1225eb348a89",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fbcaa955-9dc2-4409-b306-369ae7dc57df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dafc6b1-158b-44d4-b0dd-b7ae11d6e9a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4ffbe092-be32-4e79-abf9-060ae067b993",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b7823bb-bf20-4845-a7a7-6cf08fa05b5a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9eb85b04-792b-4683-b4fc-0cbde75aabc3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6f480985-7587-4039-ba4b-8746ec4126be",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-14\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/26a7c7bb-191b-494b-9849-5033cd985508\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/efada06a-55bd-485b-b155-8c73437bbfe4\"}},\"listRegistryList53\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e2be283c-7bb2-4695-8be5-7ea2842283ea\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6b18e2d8-bc47-4b52-94a8-f326bef42321\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "26a7c7bb-191b-494b-9849-5033cd985508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-14\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "efada06a-55bd-485b-b155-8c73437bbfe4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e2be283c-7bb2-4695-8be5-7ea2842283ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList53\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6b18e2d8-bc47-4b52-94a8-f326bef42321",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46adc1de-7103-4acf-9f49-e9e3f1ba6f9c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":52,\"chunkLengthChars\":1568,\"totalLengthChars\":1568,\"totalSegmentCount\":52,\"chunkSequenceNumber\":998,\"segmentTexts\":[{\"text\":\"y8alepmflmm15uirum0s8uts\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2d1441cf-c6a6-4f33-bc0a-6d2aad85eb5e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"ngx5ymmtgm52g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"eb17fa9f-d2f9-45eb-a434-b7a0fa7f3cfa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a9bde47-51c3-4613-82a8-d1e88b46fd7a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},\"9w\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"66f00868-6102-4428-a6d1-a3c89a318d5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"770bbcf0-aa81-4542-aadb-5de2ee911203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"vegn7fhkq5lb4o3g7l6jatudkkxc\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b6700b02-71e3-442b-9e81-2abd4a423b2f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"kunezvusfustjlinu1gt0hek9cw5otsh5ei4ruxf1pxqoo0ser6px86ebgvwwljg150qm57dmub08waxc3i02wpcflbvvux83o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f4b0ec3-0dda-4009-932d-d8fcc524ac7c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\",\"bold\":false}}},{\"text\":\"myyus74i54r68w76zuu6zot2rk0o6uxnbbgmvc9trskytte\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"511f4425-47dc-43e9-89eb-1497e91fe8ef\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"4ek62tpaz2iflhwb29p3mjp91caiwanaotry1d3wegsgjdrln\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09ed93aa-521c-41b4-aa7c-f1e016b5b0dd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"ayer8p6kgrt1kapjhhidpnyckg2fgl86p8s775iaczrcnhi3xasjcpp15qvu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"29a41512-5d1f-481d-bca5-4338a4d4352d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"kg27a1wvw2lr0hkajf5gaie9rs20d7hm4bn5lezvgs4jj0a3i21yzsxpzklo1j8onpy1059ff46m0vf9vx54anekxfi1h4k1s9gknqd9n52o8bf2ku\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02e6bb1b-d63a-4f6e-858e-a7bf8b05e16e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"9nhniwlcq8xsg5zxqw6zslyilkd35l821xznja6nmnq66japcvixyiv671aockkfedfoornfwh9zf1pu3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85fe345b-fe19-4212-b468-4ab609f74bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"dqjfqjhdqxhw8ib21if496flrrkvs8tochusdpc0x4t4yytsoqmlykgibb3wp3gmvyt4usv3gkf34k6ltlor6xru1h4e8uyied\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"01809c04-0b59-40f8-ac4d-412091b261d1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"4jd7oqh4w8nra6la4fz5wsl64yg6725tpijk17hd147nxvpkjgumlvwqgyqo8s1dg3xwgz9m819x5ywjfltur15nkea\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c748231d-7333-4730-9615-2da5c80b71c1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"got1bydxtttskcpg32z5nuybgxpplazd4h9x86\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d1fdb764-64b0-4db4-ab44-eeb78e434ce4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"sjn7koghmproazku9ldjzml7pow9ij16qi6j3gjwyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a676621a-4d69-4ad0-8650-d32eb109da5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"neek2f8l3v9hg4az9c3cyfdoe6npyf006euy18xsukd29z7uaabdww7ftie9nwnu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3880e819-d7e3-4eec-b67c-ffc0b8faa0d0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"d13dmtyqqbzigmw8s4dob5jp875p044t3y3tidj5a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"70b3129f-b06a-4b43-8587-cebfff66a4fc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"2d8dkg283zyrdu8uat1pse4q1vh80kcpylcbphmjejpr8fp1q3152h4aowd21pcu60e856mj5j59yg1tndonagiuttyqpoht37ztikcfvjzk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"470c848f-1db5-4a1e-a3a5-0012541e8aef\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"mbimjga2kuvumgl4175eoeubsrgybwigpy8gzi729qmpr9s3p2verh4cyk1xph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e95d6a2-0858-4f58-ba00-ed6ef5c7b9be\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"tzjp9qgs5lpcx9kc\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"05a3308f-2333-404f-beb5-6a94506c8674\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"4cyg3dadbunopbi43l3czgp6p1x5xd0j0wstigxniqus7coglxr7l4krgbk2tpsw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"afa3e314-3fce-422d-88d2-d96b7af67ecc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList53\"}}},{\"text\":\"vfllfpta687nh2in7765c6zepgmih7en39mfusqnovff17\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0ccd7238-522b-44c2-8be2-4db97b0b7226\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList53\"}}},{\"text\":\"tjit2wnhmf7578m52l6urc457qw1hhzw8n4e5umee708k30depj2sg04699zep0ih93wqkhxn4xw5wabhdpnkva7c1l1d9gl6ifjxobqr1oyabwhkvx41bfzhw8alckm932au3qi2ibvplg\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2b36928c-65af-466a-8411-443778911eb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"sjfdn4bmyj66uhtdeqnjc8um3cie\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bfce4477-7350-4b98-aace-1e371ba00e61\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"z5iegc0u0os404ottv584sidee3j05831zrdvtlejt6ycxpkikdbwewl9scd5a6j0xu68gtoiqonqq5hno7clcrgpodcw5sh9ftg6p5kags5qbt2c4tvi7pwbk0q27ng3kwwowqemdgqix8xpm7ji8oayvh6l4fdn3yx53ojxu855v9n2uzhaoe\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"beb5862a-c65e-4e56-b128-6e61dab55d62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-11\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"769af812-0349-4a17-bfeb-6a68e3bdd152\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-11\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be8dda3e-d115-485d-852f-0759a169293f\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":998,\"totalLength\":1568,\"totalSegmentCount\":52}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"da6b4d9f-3328-4512-9bb8-ff75d0e5f3a6\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":42,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1565282853456,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"da6b4d9f-3328-4512-9bb8-ff75d0e5f3a6\",\"clientSequenceNumber\":172,\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1565282853456,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshot_1344_0.json
+++ b/snapshotTestContent/Authoring-MVP3-(created-Aug-8)/src_snapshots/0.59.3000/snapshot_1344_0.json
@@ -1,0 +1,989 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1343,\"sequenceNumber\":1344,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"f29dcfe8-ff05-47a8-86f9-87facb160547\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"k9cd2p640@example.com}\",\"name\":\"0zlh742ntpks68c\",\"email\":\"tcni0yadx@example.com}\"}},\"sequenceNumber\":1344}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/cf344c73-866d-4898-8b7f-eef33576cd21\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf344c73-866d-4898-8b7f-eef33576cd21",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c292a822-0c39-48d3-b393-0c8cdd53ab02\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c292a822-0c39-48d3-b393-0c8cdd53ab02\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/75e02f67-1195-41ee-841b-787e60b24b40\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/71854446-42b7-40ee-bb23-a6ff32401ee1\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46adc1de-7103-4acf-9f49-e9e3f1ba6f9c\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b1a5c6f5-3034-42d8-a9c1-fc836626c588\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6f480985-7587-4039-ba4b-8746ec4126be\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "75e02f67-1195-41ee-841b-787e60b24b40",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c292a822-0c39-48d3-b393-0c8cdd53ab02\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":43,\"refSeqNumber\":820}},\"da6b4d9f-3328-4512-9bb8-ff75d0e5f3a6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":81,\"refSeqNumber\":1183}},\"e1cf5a57-d9f7-4830-8e8f-0baafeac9858\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":737,\"refSeqNumber\":1263}},\"5d9c5ee5-b548-4909-9edc-38533cee3026\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1270}},\"38aefb30-85de-4445-ac8a-09b2ccb90e25\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":69,\"refSeqNumber\":1270}},\"80547df1-0438-4a55-b81d-00f7214937aa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":754,\"refSeqNumber\":1307}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "71854446-42b7-40ee-bb23-a6ff32401ee1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46adc1de-7103-4acf-9f49-e9e3f1ba6f9c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":50,\"chunkLengthChars\":1565,\"totalLengthChars\":1565,\"totalSegmentCount\":50,\"chunkSequenceNumber\":1343,\"segmentTexts\":[{\"text\":\"y8alepmflmm15uirum0s8uts\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2d1441cf-c6a6-4f33-bc0a-6d2aad85eb5e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"ngx5ymmtgm52g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef6f02a7-76b4-4126-b6cc-4c6bc5a0fac7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"770bbcf0-aa81-4542-aadb-5de2ee911203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"vegn7fhkq5lb4o3g7l6jatudkkxc\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b6700b02-71e3-442b-9e81-2abd4a423b2f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"kunezvusfustjlinu1gt0hek9cw5otsh5ei4ruxf1pxqoo0ser6px86ebgvwwljg150qm57dmub08waxc3i02wpcflbvvux83o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f4b0ec3-0dda-4009-932d-d8fcc524ac7c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"myyus74i54r68w76zuu6zot2rk0o6uxnbbgmvc9trskytte\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"511f4425-47dc-43e9-89eb-1497e91fe8ef\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"4ek62tpaz2iflhwb29p3mjp91caiwanaotry1d3wegsgjdrln\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09ed93aa-521c-41b4-aa7c-f1e016b5b0dd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"ayer8p6kgrt1kapjhhidpnyckg2fgl86p8s775iaczrcnhi3xasjcpp15qvu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"29a41512-5d1f-481d-bca5-4338a4d4352d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"kg27a1wvw2lr0hkajf5gaie9rs20d7hm4bn5lezvgs4jj0a3i21yzsxpzklo1j8onpy1059ff46m0vf9vx54anekxfi1h4k1s9gknqd9n52o8bf2ku\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02e6bb1b-d63a-4f6e-858e-a7bf8b05e16e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"9nhniwlcq8xsg5zxqw6zslyilkd35l821xznja6nmnq66japcvixyiv671aockkfedfoornfwh9zf1pu3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85fe345b-fe19-4212-b468-4ab609f74bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"dqjfqjhdqxhw8ib21if496flrrkvs8tochusdpc0x4t4yytsoqmlykgibb3wp3gmvyt4usv3gkf34k6ltlor6xru1h4e8uyied\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"01809c04-0b59-40f8-ac4d-412091b261d1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"text\":\"4jd7oqh4w8nra6la4fz5wsl64yg6725tpijk17hd147nxvpkjgumlvwqgyqo8s1dg3xwgz9m819x5ywjfltur15nkea\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c748231d-7333-4730-9615-2da5c80b71c1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-14\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d522fe0c-7379-4e14-9315-9b8ae72abd8b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"got1bydxtttskcpg32z5nuybgxpplazd4h9x86\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d1fdb764-64b0-4db4-ab44-eeb78e434ce4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"sjn7koghmproazku9ldjzml7pow9ij16qi6j3gjwyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a676621a-4d69-4ad0-8650-d32eb109da5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"neek2f8l3v9hg4az9c3cyfdoe6npyf006euy18xsukd29z7uaabdww7ftie9nwnu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3880e819-d7e3-4eec-b67c-ffc0b8faa0d0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"d13dmtyqqbzigmw8s4dob5jp875p044t3y3tidj5a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"70b3129f-b06a-4b43-8587-cebfff66a4fc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"2d8dkg283zyrdu8uat1pse4q1vh80kcpylcbphmjejpr8fp1q3152h4aowd21pcu60e856mj5j59yg1tndonagiuttyqpoht37ztikcfvjzk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"470c848f-1db5-4a1e-a3a5-0012541e8aef\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"mbimjga2kuvumgl4175eoeubsrgybwigpy8gzi729qmpr9s3p2verh4cyk1xph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e95d6a2-0858-4f58-ba00-ed6ef5c7b9be\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"tzjp9qgs5lpcx9kc\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"05a3308f-2333-404f-beb5-6a94506c8674\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"4cyg3dadbunopbi43l3czgp6p1x5xd0j0wstigxniqus7coglxr7l4krgbk2tpsw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"afa3e314-3fce-422d-88d2-d96b7af67ecc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList53\"}}},{\"text\":\"vfllfpta687nh2in7765c6zepgmih7en39mfusqnovff17\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0ccd7238-522b-44c2-8be2-4db97b0b7226\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList53\"}}},{\"text\":\"tjit2wnhmf7578m52l6urc457qw1hhzw8n4e5umee708k30depj2sg04699zep0ih93wqkhxn4xw5wabhdpnkva7c1l1d9gl6ifjxobqr1oyabwhkvx41bfzhw8alckm932au3qi2ibvplg\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2b36928c-65af-466a-8411-443778911eb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}}},{\"text\":\"sjfdn4bmyj66uhtdeqnjc8um3cie\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bfce4477-7350-4b98-aace-1e371ba00e61\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"z5iegc0u0os404ottv584sidee3j05831zrdvtlejt6ycxpkikdbwewl9scd5a6j0xu68gtoiqonqq5hno7clcrgpodcw5sh9ftg6p5kags5qbt2c4tvi7pwbk0q27ng3kwwowqemdgqix8xpm7ji8oayvh6l4fdn3yx53ojxu855v9n2uzhaoe\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"beb5862a-c65e-4e56-b128-6e61dab55d62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-11\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"769af812-0349-4a17-bfeb-6a68e3bdd152\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-11\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be8dda3e-d115-485d-852f-0759a169293f\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1343,\"totalLength\":1565,\"totalSegmentCount\":50}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b1a5c6f5-3034-42d8-a9c1-fc836626c588",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0bf30675-6853-4346-a1b1-7a4f2d8feb41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/def76a5c-2d37-4873-b732-1225eb348a89\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fbcaa955-9dc2-4409-b306-369ae7dc57df\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dafc6b1-158b-44d4-b0dd-b7ae11d6e9a5\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4ffbe092-be32-4e79-abf9-060ae067b993\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b7823bb-bf20-4845-a7a7-6cf08fa05b5a\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9eb85b04-792b-4683-b4fc-0cbde75aabc3\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0bf30675-6853-4346-a1b1-7a4f2d8feb41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "def76a5c-2d37-4873-b732-1225eb348a89",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fbcaa955-9dc2-4409-b306-369ae7dc57df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dafc6b1-158b-44d4-b0dd-b7ae11d6e9a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4ffbe092-be32-4e79-abf9-060ae067b993",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b7823bb-bf20-4845-a7a7-6cf08fa05b5a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9eb85b04-792b-4683-b4fc-0cbde75aabc3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6f480985-7587-4039-ba4b-8746ec4126be",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-14\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/26a7c7bb-191b-494b-9849-5033cd985508\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/efada06a-55bd-485b-b155-8c73437bbfe4\"}},\"listRegistryList53\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e2be283c-7bb2-4695-8be5-7ea2842283ea\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6b18e2d8-bc47-4b52-94a8-f326bef42321\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "26a7c7bb-191b-494b-9849-5033cd985508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-14\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "efada06a-55bd-485b-b155-8c73437bbfe4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e2be283c-7bb2-4695-8be5-7ea2842283ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList53\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6b18e2d8-bc47-4b52-94a8-f326bef42321",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bb9e2ce9-a124-406e-b2e4-21e8a66691e1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69228a44-4edf-46da-a61e-cc8e04aacea4",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "14af70ee-92c4-4478-bac5-feb00aff5af1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":1343,\"referenceSequenceNumber\":-1,\"sequenceNumber\":1344,\"timestamp\":1565366518810,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_10000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_10000_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":9993,\"sequenceNumber\":10000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"67ffdad7-a873-41f0-a70e-3af92f175d68\",{\"client\":{\"user\":{\"id\":\"whfv5xh62@example.com}\",\"name\":\"cdyjprvbly615xf\",\"email\":\"i65rb66dk@example.com}\"}},\"sequenceNumber\":7032}],[\"b8f286b2-098b-4973-a7b7-04aabbfcfec9\",{\"client\":{\"user\":{\"id\":\"5u3v7wndj@example.com}\",\"name\":\"a81rwp83eso2j2h\",\"email\":\"ci26io60s@example.com}\"}},\"sequenceNumber\":7033}],[\"1f74a538-7a95-4a8f-84a5-c9830171bced\",{\"client\":{\"user\":{\"id\":\"r89h085re@example.com}\",\"name\":\"29k0s6d30puejpa\",\"email\":\"k0p1ts8qp@example.com}\"}},\"sequenceNumber\":7083}],[\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",{\"client\":{\"user\":{\"id\":\"jz79jdxkz@example.com}\",\"name\":\"iy7ft65cbwreadt\",\"email\":\"39b08igmg@example.com}\"}},\"sequenceNumber\":7122}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":896,\"pos\":908,\"refSeqNumber\":9985}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":54,\"chunkLengthChars\":1258,\"totalLengthChars\":1258,\"totalSegmentCount\":54,\"chunkSequenceNumber\":9993,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"ec6bj7t\",{\"text\":\"96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqv\",\"props\":{}},\"wjw1k7vc6ckvadz31ff0m753x2l60ynvsrul1jj\",{\"text\":\"8\",\"props\":{}},\"1obh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"772c3nypxbr7v9068wsbwivwek6hppfei7t4b99b4y16s02m5ubpztqrgszmoiaazds9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1e53b1-cdaa-4b5e-bd4e-54a4b3902789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-30\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vrpuix1hlxi2lahxtfs3ihkhgynlp2efeos4e0l5657vjk49yj4bji4mvou1dlg17z57p5ncs7shy8l5ods5kk1do03qu288lb1lzmiftl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1znd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ebbf6613-48c9-46b7-8962-23df8d83c31c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"uewbcm1ujwh042dxupgedasht1j2knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h2h9rutc3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"vu45d4pwqbirhv27iske48cezul89g1gtaa3ytrkmyhu74\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2dbaf226-3998-48d9-9a3e-14b896995e97\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stq\",\"props\":{}},\"e\",{\"text\":\"ytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uoar921fy\",{\"text\":\"bfun4n0k7zi6w6e5wj6lwimpa8rgoe0s\",\"props\":{}},\"bdahyu0f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoocowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2oo3a\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"5celzjvr8i78m4ajhu76umbtaaj55h4rj9utzyq3\",{\"text\":\"ryidwx58y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"j65tepef5fkvm8forr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0984c6eb-557b-4fa7-bd48-0af2b6eb80b5\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca312f54-0365-4a79-9369-b340a5d182b3\",\"ItemType\":\"Paragraph\"}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":9993,\"totalLength\":1258,\"totalSegmentCount\":54}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}},\"listRegistryList-30\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecebb598-f967-4224-8d0b-0201d65fd127\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecebb598-f967-4224-8d0b-0201d65fd127",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-30\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",\"clientSequenceNumber\":2916,\"minimumSequenceNumber\":9993,\"referenceSequenceNumber\":9995,\"sequenceNumber\":10000,\"timestamp\":1564514228602,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,818 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":999,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":111,\"refSeqNumber\":996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":6,\"chunkLengthChars\":112,\"totalLengthChars\":112,\"totalSegmentCount\":6,\"chunkSequenceNumber\":999,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"nhmv369y1sy8jz79r4a5ypgb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7ceac80e-b2e6-4740-9a79-f507c8bfc239\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3ed4f79c-c117-432c-83cd-d26aafb4e758\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":999,\"totalLength\":112,\"totalSegmentCount\":6}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c3931334-2f54-414d-932d-002cee6f4280\",\"clientSequenceNumber\":1051,\"contents\":{\"pos1\":111,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":999,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1564433223162,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c3931334-2f54-414d-932d-002cee6f4280\",\"clientSequenceNumber\":1051,\"minimumSequenceNumber\":999,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1564433223162,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_11000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_11000_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":10996,\"sequenceNumber\":11000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"7e1d6274-7513-4c8b-b975-e51252e6b1d6\",{\"client\":{\"user\":{\"id\":\"pxn6akusm@example.com}\",\"name\":\"83s91m01a1mudq3\",\"email\":\"t3ji1x0lp@example.com}\"}},\"sequenceNumber\":10391}],[\"d73e2bcc-93a8-4d8f-be77-4c6523242a4c\",{\"client\":{\"user\":{\"id\":\"b5jckqwqi@example.com}\",\"name\":\"xqm9yam1xbxjm0d\",\"email\":\"xsxxstoeu@example.com}\"}},\"sequenceNumber\":10951}],[\"7f2fa709-5f9b-4c49-9db0-aabc8539d881\",{\"client\":{\"user\":{\"id\":\"0ji0hunj3@example.com}\",\"name\":\"85uddwxet7jioic\",\"email\":\"ja1t81d04@example.com}\"}},\"sequenceNumber\":10954}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1305,\"refSeqNumber\":10304}},\"0a343251-2df2-478d-8071-3ef6eb023a3c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":342,\"refSeqNumber\":10870}},\"7f2fa709-5f9b-4c49-9db0-aabc8539d881\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1021,\"pos\":826,\"refSeqNumber\":10989}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":54,\"chunkLengthChars\":1318,\"totalLengthChars\":1318,\"totalSegmentCount\":54,\"chunkSequenceNumber\":10996,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"6xao4is\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5546ea35-4da0-41b1-b512-041b0fcbba06\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"ec6bj7t96ph429ua7r5xjy3rxpsv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqv\",\"props\":{}},\"wjw1k7vc6ckvako4dz31ff0m753x2l60ynvsrul1jj\",{\"text\":\"8\",\"props\":{}},\"1ob\",{\"text\":\"pmme2j6g94q5otdizzmgkb27o46o38\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1e53b1-cdaa-4b5e-bd4e-54a4b3902789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vrpuix1hlxi2lahxtfs3ihkhgynlp2efeos4e0l5657vjk49yj4bji4mvou1dlg17z57p5ncs7shy8l5ods5kk1do03qu288lb1lzmovccnl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1znd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f9d94a5-1f8d-48c9-90bf-d368954bb8f0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},\"tnaara0qu3uw00s9teffnqttkfl0v2k697ggn32f3nm8dhqg3czlk2ldjoh9kl3ul2lco6hmzeir2ns9r76a9r0h0xdfz9esqe27tzkmzg04\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"190c1216-9be1-4783-a508-550f78886c68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"uewbcm1ujwh042dxupgedasht1j2knjxzt75c2\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"k13d8eokohkwgahthmhsum3c1919h2h9rutc3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"vu45d4pwqbirhv27iske48cezul89g1gtaa3ytrkmyhu74\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2dbaf226-3998-48d9-9a3e-14b896995e97\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stq\",\"props\":{}},\"e\",{\"text\":\"ytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5uhzt4f30uoar921fy\",{\"text\":\"bfun4n0k7zi6w6e5wj6lwimpa8rgoe0s\",\"props\":{}},\"bdahyu0f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoo104is4wcowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2oo3a\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"5celzjvr8i78m4ajhu76umbtaaj55h4rj9utzyq3\",{\"text\":\"ryidwx58y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"j65tepef5fkvm8forr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0984c6eb-557b-4fa7-bd48-0af2b6eb80b5\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca312f54-0365-4a79-9369-b340a5d182b3\",\"ItemType\":\"Paragraph\"}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":10996,\"totalLength\":1318,\"totalSegmentCount\":54}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}},\"listRegistryList-30\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecebb598-f967-4224-8d0b-0201d65fd127\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecebb598-f967-4224-8d0b-0201d65fd127",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-30\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"7f2fa709-5f9b-4c49-9db0-aabc8539d881\",\"clientSequenceNumber\":50,\"minimumSequenceNumber\":10996,\"referenceSequenceNumber\":10997,\"sequenceNumber\":11000,\"timestamp\":1564524451897,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_12000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_12000_0.json
@@ -1,0 +1,1115 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":11922,\"sequenceNumber\":12000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"a4e91f02-5116-4b6b-8cef-b0be8f0c6c8f\",{\"client\":{\"user\":{\"id\":\"h3rlq39em@example.com}\",\"name\":\"jllm4q08ugkadtj\",\"email\":\"bzjbfqmne@example.com}\"}},\"sequenceNumber\":11855}],[\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",{\"client\":{\"user\":{\"id\":\"rx5fnwug7@example.com}\",\"name\":\"j5g3emzx3icwxwe\",\"email\":\"eqrcfvwaj@example.com}\"}},\"sequenceNumber\":11861}],[\"535ad82a-f481-468d-9b22-75fe16618673\",{\"client\":{\"user\":{\"id\":\"x3bn23wln@example.com}\",\"name\":\"rqrt1hwqpd8q3rq\",\"email\":\"jtd3lm8kq@example.com}\"}},\"sequenceNumber\":11874}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1305,\"refSeqNumber\":10304}},\"0a343251-2df2-478d-8071-3ef6eb023a3c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":342,\"refSeqNumber\":10870}},\"7f2fa709-5f9b-4c49-9db0-aabc8539d881\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":390,\"refSeqNumber\":10989}},\"c594e2fe-e7a2-4179-bd12-e8d6f87cee65\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":667,\"refSeqNumber\":11318}},\"adbb5507-ebbf-4cd2-96b0-be8e78de17e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11606}},\"5f3c52ed-6117-4dcb-8e6e-f31d5cde1a59\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":359,\"refSeqNumber\":11743}},\"3618340a-4ac6-4eaf-93dd-3a8e5f8ea761\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11752}},\"77a8ca49-7bcb-42c2-9fee-907e2fd26562\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":63,\"refSeqNumber\":11752}},\"4b1faeb1-e59d-4724-9fcc-45df2ee94a38\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":63,\"refSeqNumber\":11836}},\"a4e91f02-5116-4b6b-8cef-b0be8f0c6c8f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":33,\"refSeqNumber\":11836}},\"535ad82a-f481-468d-9b22-75fe16618673\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11862}},\"06694063-b672-4841-83a9-d753326efef4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":34,\"refSeqNumber\":11877}},\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":289,\"refSeqNumber\":11996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":56,\"chunkLengthChars\":1336,\"totalLengthChars\":1336,\"totalSegmentCount\":56,\"chunkSequenceNumber\":11922,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"6xao4isd\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5546ea35-4da0-41b1-b512-041b0fcbba06\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"ec6bj7t96ph429ua7r5xjy3rxpsv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqv\",\"props\":{}},\"wjw1k7vc6ckvako4dz31ff0m753x2l60ynvsrul1jj\",{\"text\":\"8\",\"props\":{}},\"1ob\",{\"text\":\"pmme2j6g94q5otdizzmgkb27o46o38\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1e53b1-cdaa-4b5e-bd4e-54a4b3902789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vrpuix1hlxi2lahxtfs3ihkhgynlp2efeos4e0l5657vjk49yj4bji4mvou1dlg17z57p5ncs7shy8l5ods5kk1do03qu288lb1lzmovccnl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1znd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"49c429f1-985f-48bf-b94e-de4ab2ef423a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},\"Version History?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"04a6d960-c9a5-4518-8efa-6abc57ed8e38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},\"tnaara0qu3uw00s9teffnqttkfl0v2k697ggn32f3nm8dhqg3czlk2ldjoh9kl3ul2lco6hmzeir2ns9r76a9r0h0xdfz9esqe27tzkmzg04\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"190c1216-9be1-4783-a508-550f78886c68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"uewbcm1ujwh042dxupgedasht1j2knjxzt75c2\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"k13d8eokohkwgahthmhsum3c1919h2h9rutc3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"vu45d4pwqbirhv27iske48cezul89g1gtaa3ytrkmyhu74\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2dbaf226-3998-48d9-9a3e-14b896995e97\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stq\",\"props\":{}},\"e\",{\"text\":\"ytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5uhzt4f30uoar921fy\",{\"text\":\"bfun4n0k7zi6w6e5wj6lwimpa8rgoe0s\",\"props\":{}},\"bdahyu0f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoo104is4wcowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2oo3a\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"5celzjvr8i78m4ajhu76umbtaaj55h4rj9utzyq3\",{\"text\":\"ryidwx58y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"j65tepef5fkvm8forr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0984c6eb-557b-4fa7-bd48-0af2b6eb80b5\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca312f54-0365-4a79-9369-b340a5d182b3\",\"ItemType\":\"Paragraph\"}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":11922,\"totalLength\":1336,\"totalSegmentCount\":56}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":40,\"contents\":{\"pos1\":266,\"pos2\":305,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11924,\"sequenceNumber\":11925,\"timestamp\":1564597972766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":42,\"contents\":{\"pos1\":265,\"pos2\":266,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11926,\"sequenceNumber\":11927,\"timestamp\":1564597972891,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":44,\"contents\":{\"pos1\":264,\"pos2\":265,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11928,\"sequenceNumber\":11929,\"timestamp\":1564597973032,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":45,\"contents\":{\"pos1\":264,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11929,\"sequenceNumber\":11930,\"timestamp\":1564597973219,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":48,\"contents\":{\"pos1\":264,\"pos2\":265,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11932,\"sequenceNumber\":11933,\"timestamp\":1564597973282,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":51,\"contents\":{\"pos1\":263,\"pos2\":264,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11934,\"sequenceNumber\":11935,\"timestamp\":1564597973516,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":52,\"contents\":{\"pos1\":263,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11935,\"sequenceNumber\":11936,\"timestamp\":1564597973594,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":56,\"contents\":{\"pos1\":263,\"pos2\":264,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11938,\"sequenceNumber\":11939,\"timestamp\":1564597974016,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":57,\"contents\":{\"pos1\":263,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11939,\"sequenceNumber\":11940,\"timestamp\":1564597974079,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":59,\"contents\":{\"pos1\":264,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11941,\"sequenceNumber\":11942,\"timestamp\":1564597974188,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":61,\"contents\":{\"pos1\":265,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11943,\"sequenceNumber\":11944,\"timestamp\":1564597974204,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":63,\"contents\":{\"pos1\":266,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11945,\"sequenceNumber\":11946,\"timestamp\":1564597974282,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":65,\"contents\":{\"pos1\":267,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11947,\"sequenceNumber\":11948,\"timestamp\":1564597974376,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":67,\"contents\":{\"pos1\":268,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11949,\"sequenceNumber\":11950,\"timestamp\":1564597974469,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":69,\"contents\":{\"pos1\":269,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11951,\"sequenceNumber\":11952,\"timestamp\":1564597974485,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":71,\"contents\":{\"pos1\":270,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11953,\"sequenceNumber\":11954,\"timestamp\":1564597974579,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":73,\"contents\":{\"pos1\":271,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11955,\"sequenceNumber\":11956,\"timestamp\":1564597974626,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":75,\"contents\":{\"pos1\":272,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11957,\"sequenceNumber\":11958,\"timestamp\":1564597974672,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":77,\"contents\":{\"pos1\":273,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11959,\"sequenceNumber\":11960,\"timestamp\":1564597974735,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":79,\"contents\":{\"pos1\":274,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11961,\"sequenceNumber\":11962,\"timestamp\":1564597974782,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":81,\"contents\":{\"pos1\":275,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11963,\"sequenceNumber\":11964,\"timestamp\":1564597974829,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":276,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11965,\"sequenceNumber\":11966,\"timestamp\":1564597974938,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":277,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11967,\"sequenceNumber\":11968,\"timestamp\":1564597974969,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":278,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11969,\"sequenceNumber\":11970,\"timestamp\":1564597975235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":279,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11971,\"sequenceNumber\":11972,\"timestamp\":1564597975298,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":280,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11973,\"sequenceNumber\":11974,\"timestamp\":1564597975454,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":95,\"contents\":{\"pos1\":281,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11975,\"sequenceNumber\":11976,\"timestamp\":1564597975860,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":97,\"contents\":{\"pos1\":282,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11977,\"sequenceNumber\":11978,\"timestamp\":1564597976017,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":282,\"pos2\":283,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11980,\"sequenceNumber\":11981,\"timestamp\":1564597976220,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":281,\"pos2\":282,\"type\":1},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11982,\"sequenceNumber\":11983,\"timestamp\":1564597976345,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":281,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11983,\"sequenceNumber\":11984,\"timestamp\":1564597976517,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":105,\"contents\":{\"pos1\":282,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11985,\"sequenceNumber\":11986,\"timestamp\":1564597976626,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":107,\"contents\":{\"pos1\":283,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11987,\"sequenceNumber\":11988,\"timestamp\":1564597976829,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":109,\"contents\":{\"pos1\":284,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11989,\"sequenceNumber\":11990,\"timestamp\":1564597976845,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":285,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11991,\"sequenceNumber\":11992,\"timestamp\":1564597977001,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":286,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11993,\"sequenceNumber\":11994,\"timestamp\":1564597977063,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":116,\"contents\":{\"pos1\":287,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11995,\"sequenceNumber\":11996,\"timestamp\":1564597977582,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":288,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11997,\"sequenceNumber\":11998,\"timestamp\":1564597977691,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":289,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11999,\"sequenceNumber\":12000,\"timestamp\":1564597977754,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}},\"listRegistryList-30\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecebb598-f967-4224-8d0b-0201d65fd127\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecebb598-f967-4224-8d0b-0201d65fd127",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-30\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\",\"clientSequenceNumber\":120,\"minimumSequenceNumber\":11922,\"referenceSequenceNumber\":11999,\"sequenceNumber\":12000,\"timestamp\":1564597977754,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_12483_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_12483_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":12480,\"sequenceNumber\":12483,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"535ad82a-f481-468d-9b22-75fe16618673\",{\"client\":{\"user\":{\"id\":\"x3bn23wln@example.com}\",\"name\":\"rqrt1hwqpd8q3rq\",\"email\":\"jtd3lm8kq@example.com}\"}},\"sequenceNumber\":11874}],[\"7e276ef5-c53f-4459-b946-09935f57af32\",{\"client\":{\"user\":{\"id\":\"y6uhoyrac@example.com}\",\"name\":\"58ofvd8af59a5mr\",\"email\":\"h2jkar6xg@example.com}\"}},\"sequenceNumber\":12477}],[\"27ec19df-92e8-4e72-83eb-64e696d77a6a\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"e4glvzbrh@example.com}\",\"name\":\"9qm2r9jasmgvnlt\",\"email\":\"xr9asg0np@example.com}\"}},\"sequenceNumber\":12483}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1305,\"refSeqNumber\":10304}},\"0a343251-2df2-478d-8071-3ef6eb023a3c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":342,\"refSeqNumber\":10870}},\"7f2fa709-5f9b-4c49-9db0-aabc8539d881\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":390,\"refSeqNumber\":10989}},\"c594e2fe-e7a2-4179-bd12-e8d6f87cee65\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":667,\"refSeqNumber\":11318}},\"adbb5507-ebbf-4cd2-96b0-be8e78de17e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11606}},\"5f3c52ed-6117-4dcb-8e6e-f31d5cde1a59\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":359,\"refSeqNumber\":11743}},\"3618340a-4ac6-4eaf-93dd-3a8e5f8ea761\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11752}},\"77a8ca49-7bcb-42c2-9fee-907e2fd26562\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":63,\"refSeqNumber\":11752}},\"4b1faeb1-e59d-4724-9fcc-45df2ee94a38\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":63,\"refSeqNumber\":11836}},\"a4e91f02-5116-4b6b-8cef-b0be8f0c6c8f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":33,\"refSeqNumber\":11836}},\"535ad82a-f481-468d-9b22-75fe16618673\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11862}},\"06694063-b672-4841-83a9-d753326efef4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":34,\"refSeqNumber\":11877}},\"14b58cb3-fc86-434b-80fd-98e91e6c1e62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":742,\"refSeqNumber\":12449}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":48,\"chunkLengthChars\":1301,\"totalLengthChars\":1301,\"totalSegmentCount\":48,\"chunkSequenceNumber\":12480,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"6xao4isd\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5546ea35-4da0-41b1-b512-041b0fcbba06\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"ec6bj7t96ph429ua7r5xjy3rxpsv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqtzndbyij2b8igdtcorv3q5cwq2p34hdbfxybe7j4x8gln5htcsrsqvvazibrkcyezkyw6v69jqno2toqasfbt7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1e53b1-cdaa-4b5e-bd4e-54a4b3902789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vrpuix1hlxi2lahxtfs3ihkhgynlp2efeos4e0l5657vjk49yj4bji4mvou1dlg17z57p5ncs7shy8l5ods5kk1do03qu288lb1lzmovccl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1zndyeqfk1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"04a6d960-c9a5-4518-8efa-6abc57ed8e38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\",\"bold\":false,\"highlight\":\"\"}}},\"tnaara0qu3uw00s9teffnqttkfl0v2k697ggn32f3nm8dhqg3czlk2ldjoh9kl3ul2lco6hmzexxxjn6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"190c1216-9be1-4783-a508-550f78886c68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"uewbcm1ujwh042dxupgedasht1j2knjxzt75c2\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"k13d8eokohkwgahthmhsum3c1919h2h9rutc3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"vu45d4pwqbirhv27iske48cezul89g1gtaa3ytrkmyhu74\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2dbaf226-3998-48d9-9a3e-14b896995e97\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stq\",\"props\":{}},\"e\",{\"text\":\"ytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5uhzt4f30uoar921fy\",{\"text\":\"bfun4n0k7zi6w6e5wj6lwimpa8rgoe0s\",\"props\":{}},\"bdahyu0f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoo104is4wcowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2oo3a\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"5celzjvr8i78m4ajhu76umbtaaj55h4rj9utzyq3\",{\"text\":\"ryidwx58y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"j65tepef5fkvm8forr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0984c6eb-557b-4fa7-bd48-0af2b6eb80b5\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca312f54-0365-4a79-9369-b340a5d182b3\",\"ItemType\":\"Paragraph\"}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":12480,\"totalLength\":1301,\"totalSegmentCount\":48}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}},\"listRegistryList-30\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecebb598-f967-4224-8d0b-0201d65fd127\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecebb598-f967-4224-8d0b-0201d65fd127",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-30\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":12480,\"referenceSequenceNumber\":-1,\"sequenceNumber\":12483,\"timestamp\":1564604456541,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,872 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1998,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":256,\"refSeqNumber\":1997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":17,\"chunkLengthChars\":256,\"totalLengthChars\":256,\"totalSegmentCount\":17,\"chunkSequenceNumber\":1998,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"text\":\"9pgulnmrowabkoqr7foj9eorw08of6d2t0zwctn\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee651937-af63-4812-b616-5e2d901b3ee6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"pn091kh08ezbo2eu1pwqlfx5w\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"7v2y7zex5y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd9fa806-3635-418a-809b-430ef1f66e02\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1998,\"totalLength\":256,\"totalSegmentCount\":17}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c3931334-2f54-414d-932d-002cee6f4280\",\"clientSequenceNumber\":2136,\"contents\":{\"pos1\":255,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1998,\"referenceSequenceNumber\":1998,\"sequenceNumber\":1999,\"timestamp\":1564433442125,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c3931334-2f54-414d-932d-002cee6f4280\",\"clientSequenceNumber\":2137,\"minimumSequenceNumber\":1998,\"referenceSequenceNumber\":1998,\"sequenceNumber\":2000,\"timestamp\":1564433442125,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2999,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":404,\"refSeqNumber\":2997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":23,\"chunkLengthChars\":405,\"totalLengthChars\":405,\"totalSegmentCount\":23,\"chunkSequenceNumber\":2999,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"text\":\"9pgulnmrowabkoqr7foj9eorw08of6d2t0zwctn\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee651937-af63-4812-b616-5e2d901b3ee6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"pn091kh08ezbo2eu1pwqlfx5w\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvposalcxbp51d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d5310c1-8497-43d6-9259-d708dbc58310\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"7v2y7zex5ijoqifh77yboqoralg7yi41a68frhkmyge6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd9fa806-3635-418a-809b-430ef1f66e02\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"k13d8eokohkwgahnhmhsum3c1919h29c3goc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"nrverqsdz65w6nz8x1hycu0aea0i3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2dcce2e0-53cd-45a3-a034-534ff3ecb558\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2999,\"totalLength\":405,\"totalSegmentCount\":23}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":2999,\"referenceSequenceNumber\":-1,\"sequenceNumber\":3000,\"timestamp\":1564433912486,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3999,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",{\"client\":{\"user\":{\"id\":\"prjx1kf3f@example.com}\",\"name\":\"c75lsa133xcqwl8\",\"email\":\"gjlq15uyx@example.com}\"}},\"sequenceNumber\":3823}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":108,\"pos\":70,\"refSeqNumber\":3937}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":36,\"chunkLengthChars\":572,\"totalLengthChars\":572,\"totalSegmentCount\":36,\"chunkSequenceNumber\":3999,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"text\":\"9pgulnmrowabkoqr7foj9eorw08of6d2t0zwctn\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee651937-af63-4812-b616-5e2d901b3ee6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkis0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"ogs1oba0ao7g8eo2v2f7myh4q5h\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvposalcxbp51d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d5310c1-8497-43d6-9259-d708dbc58310\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"7v2y7zex5ijoqifh77yboqoralg7yi41a68frhkmyge6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd9fa806-3635-418a-809b-430ef1f66e02\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"k13d8eokohkwgahnhmhsum3c1919h29c3goc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"uac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uoh\",{\"text\":\"p2nxf1i7\",\"props\":{}},\"159iac75bk7eqpoxn90r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c930a00-182e-4ba7-8611-7a1852658aed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"1lqtlmay6lsvzoe\",{\"text\":\"rtk1wyo93ebn8mni7qir35u2eka33v7rdx\",\"props\":{}},\"yhirzk4ez9bt\",{\"text\":\"2\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c7f6e7d6-145b-429e-981e-5a0c92a6437f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3053b4fe-11cb-4850-b141-e6ecdc3b133a\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c9e4884-657d-4908-b8e0-1bb79b439e19\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3999,\"totalLength\":572,\"totalSegmentCount\":36}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":3999,\"referenceSequenceNumber\":-1,\"sequenceNumber\":4000,\"timestamp\":1564443400558,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,953 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4999,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",{\"client\":{\"user\":{\"id\":\"prjx1kf3f@example.com}\",\"name\":\"c75lsa133xcqwl8\",\"email\":\"gjlq15uyx@example.com}\"}},\"sequenceNumber\":3823}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":364,\"refSeqNumber\":4994}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":38,\"chunkLengthChars\":631,\"totalLengthChars\":631,\"totalSegmentCount\":38,\"chunkSequenceNumber\":4999,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpn8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee651937-af63-4812-b616-5e2d901b3ee6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkis01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqvb32eiye32lg3xdozqdgt04pzrlcq1\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvposalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"xsygbjjz98dm7n8d4k3scuz5fewyubkc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5532b6ea-5b51-4fb2-87fe-e5e8bb844911\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"r27guyh32wh042dxuygedasht1j9knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h29c3goc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stqdytae45dqgd5acxus\",\"props\":{}},\"uac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uo\",{\"text\":\"uuolobfun4n0k7zi6w6e5wj6lwimpa8rgoe\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c930a00-182e-4ba7-8611-7a1852658aed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"1lqtlmay6lsvzoe\",{\"text\":\"rtk1wyo93ebn8mni7qir35u2eka33v7rdx\",\"props\":{}},\"yhirzk4ez9bt\",{\"text\":\"2\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c7f6e7d6-145b-429e-981e-5a0c92a6437f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3053b4fe-11cb-4850-b141-e6ecdc3b133a\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c9e4884-657d-4908-b8e0-1bb79b439e19\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4999,\"totalLength\":631,\"totalSegmentCount\":38}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",\"clientSequenceNumber\":1278,\"contents\":{\"pos1\":364,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4999,\"referenceSequenceNumber\":4999,\"sequenceNumber\":5000,\"timestamp\":1564443529608,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",\"clientSequenceNumber\":1278,\"minimumSequenceNumber\":4999,\"referenceSequenceNumber\":4999,\"sequenceNumber\":5000,\"timestamp\":1564443529608,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,980 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5999,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",{\"client\":{\"user\":{\"id\":\"prjx1kf3f@example.com}\",\"name\":\"c75lsa133xcqwl8\",\"email\":\"gjlq15uyx@example.com}\"}},\"sequenceNumber\":3823}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":5995}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":39,\"chunkLengthChars\":865,\"totalLengthChars\":865,\"totalSegmentCount\":39,\"chunkSequenceNumber\":5999,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"j236n2d0tjf8zagzesqp6w24vlsxmryn9p0sjdh2h7uru9pi6h6e4l6b45ml534m2jo5zk9wbjzmn9c\",{\"text\":\"nwx3od6h0yp4t2sc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee651937-af63-4812-b616-5e2d901b3ee6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList104\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkis01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqvb32eiye32lg3xdozqdgt04pzrlcq1\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvposalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vdknara3w349h6ixn7sp1fv7lml64k4hktmdc9ce55gixvsken5oq0sk2yoka3tqww6raxmmbf1k9vvqraufzb48hwm\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"r27guyh32wh042dxuygedasht1j9knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h29c3goczmyavys78fdj15eg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stqdytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uo\",{\"text\":\"uuolobfun4n0k7zi6w6e5wj6lwimpa8rgoe0s98pkv253f\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c930a00-182e-4ba7-8611-7a1852658aed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"1lqtlmay6lsvzoe\",{\"text\":\"rtk1wyo93ebn8mni7qirm3lly0z33v7rdx\",\"props\":{}},\"yhirzk4ez9bt\",{\"text\":\"2\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c9e4884-657d-4908-b8e0-1bb79b439e19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5999,\"totalLength\":865,\"totalSegmentCount\":39}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",\"clientSequenceNumber\":2375,\"contents\":{\"pos1\":585,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":5999,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1564443650811,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\",\"clientSequenceNumber\":2375,\"minimumSequenceNumber\":5999,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1564443650811,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_7000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_7000_0.json
@@ -1,0 +1,1079 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6997,\"sequenceNumber\":7000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":40,\"chunkLengthChars\":965,\"totalLengthChars\":965,\"totalSegmentCount\":40,\"chunkSequenceNumber\":6997,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkis01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqvb32eiye32lg3xdozqdgt04pzrlcq18qojx7xn\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvposalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vdknara3w349h6ixn7sp1fv7lml64k4hktmdc9ce55gixvsken5oq0sk2yoka3tqww6raxmmbf1k9vvqraufzb48hwml48z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez0kq1wayckt9lhlwzq8e8ux1zndgyvfbpj09jrpaln\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ebbf6613-48c9-46b7-8962-23df8d83c31c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"uewbcm1u2wh042dxuygedasht1j9knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h29c3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stqdytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uo\",{\"text\":\"uuolobfun4n0k7zi6w6e5wj6lwimpa8rgoe0s98pkv253f\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c930a00-182e-4ba7-8611-7a1852658aed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"1lqtlmay6lsvzoe\",{\"text\":\"rtk1wyo93ebn8mni7qirm3lly0z33v7rdx\",\"props\":{}},\"yhirzk4ez9bt\",{\"text\":\"2m6ltuxf8i8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c9e4884-657d-4908-b8e0-1bb79b439e19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoocowkpofz73fwta1bo184bl81kw1jnd2frdboa2al4lr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6997,\"totalLength\":965,\"totalSegmentCount\":40}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"be3004e4-4638-4c72-9d26-c68f269c846b\",\"clientSequenceNumber\":1,\"minimumSequenceNumber\":6997,\"referenceSequenceNumber\":6999,\"sequenceNumber\":7000,\"timestamp\":1564505814281,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_8000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_8000_0.json
@@ -1,0 +1,1079 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":7998,\"sequenceNumber\":8000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"67ffdad7-a873-41f0-a70e-3af92f175d68\",{\"client\":{\"user\":{\"id\":\"whfv5xh62@example.com}\",\"name\":\"cdyjprvbly615xf\",\"email\":\"i65rb66dk@example.com}\"}},\"sequenceNumber\":7032}],[\"b8f286b2-098b-4973-a7b7-04aabbfcfec9\",{\"client\":{\"user\":{\"id\":\"5u3v7wndj@example.com}\",\"name\":\"a81rwp83eso2j2h\",\"email\":\"ci26io60s@example.com}\"}},\"sequenceNumber\":7033}],[\"1f74a538-7a95-4a8f-84a5-c9830171bced\",{\"client\":{\"user\":{\"id\":\"r89h085re@example.com}\",\"name\":\"29k0s6d30puejpa\",\"email\":\"k0p1ts8qp@example.com}\"}},\"sequenceNumber\":7083}],[\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",{\"client\":{\"user\":{\"id\":\"jz79jdxkz@example.com}\",\"name\":\"iy7ft65cbwreadt\",\"email\":\"39b08igmg@example.com}\"}},\"sequenceNumber\":7122}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":316,\"pos\":326,\"refSeqNumber\":7959}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":47,\"chunkLengthChars\":1146,\"totalLengthChars\":1146,\"totalSegmentCount\":47,\"chunkSequenceNumber\":7998,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqvb32eiye32lg3xdozqdgt04pzrlcq18qojx7x\",\"props\":{}},\"znfwme\",{\"text\":\"n\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vdknara3w349h6ixn7sp1fv7lml64k4hktmdc9ce55gixvsken5oq0sk2yoka3tqww6raxmmbf1k9vvqraufzb48hwml48z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1znd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ebbf6613-48c9-46b7-8962-23df8d83c31c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"uewbcm1u2wh042dxuygedasht1j9knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h29c3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stqdytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uo\",{\"text\":\"uuolobfun4n0k7zi6w6e5wj6lwimpa8rgoe0s98pkv253f\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"1lqtlmay6lsvzoe\",{\"text\":\"rtk1wyo93ebn8mni7qirm3lly0z33v7rdx\",\"props\":{}},\"yhirzk4ez9bt\",{\"text\":\"2m6ltuxf8i\",\"props\":{}},\"1cfv3r\",{\"text\":\"8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c9e4884-657d-4908-b8e0-1bb79b439e19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoocowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2dyw0ost57q7edtr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":7998,\"totalLength\":1146,\"totalSegmentCount\":47}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",\"clientSequenceNumber\":791,\"minimumSequenceNumber\":7998,\"referenceSequenceNumber\":7998,\"sequenceNumber\":8000,\"timestamp\":1564513671675,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_9000_0.json
+++ b/snapshotTestContent/Authoring-MVP3/src_snapshots/0.59.3000/snapshot_9000_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":8998,\"sequenceNumber\":9000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c3931334-2f54-414d-932d-002cee6f4280\",{\"client\":{\"user\":{\"id\":\"3wqp5ppdl@example.com}\",\"name\":\"r75ryp0nl2dxtdn\",\"email\":\"ex0ua91mx@example.com}\"}},\"sequenceNumber\":1}],[\"30454736-1ff1-4468-87f9-be15811f67ef\",{\"client\":{\"user\":{\"id\":\"4nc346mic@example.com}\",\"name\":\"golmona26ge5o9m\",\"email\":\"kkdi3tejo@example.com}\"}},\"sequenceNumber\":3814}],[\"decfdaf5-54ce-464b-a80a-43a7eb5b881a\",{\"client\":{\"user\":{\"id\":\"v0uj6xm4b@example.com}\",\"name\":\"trf5eeqce0ds0p1\",\"email\":\"b0btxspdw@example.com}\"}},\"sequenceNumber\":6036}],[\"0483808f-f26f-49c8-aa15-66039fe1768e\",{\"client\":{\"user\":{\"id\":\"s0sujigh0@example.com}\",\"name\":\"or9eisia8k3xrty\",\"email\":\"52w4iv0h7@example.com}\"}},\"sequenceNumber\":6038}],[\"be3004e4-4638-4c72-9d26-c68f269c846b\",{\"client\":{\"user\":{\"id\":\"05gk85ey2@example.com}\",\"name\":\"hrly7yzd76oxwqn\",\"email\":\"3jrl3caq4@example.com}\"}},\"sequenceNumber\":6999}],[\"874ecdda-4aec-4f0c-821e-2bc193203408\",{\"client\":{\"user\":{\"id\":\"3lsh44o7m@example.com}\",\"name\":\"u95udwsstb98xse\",\"email\":\"thaezz39j@example.com}\"}},\"sequenceNumber\":7014}],[\"4b5724cd-5df6-4cde-bd34-1d3a90933c6d\",{\"client\":{\"user\":{\"id\":\"vb6ijc9n9@example.com}\",\"name\":\"mnrg3p8x7nlur6c\",\"email\":\"lbve84507@example.com}\"}},\"sequenceNumber\":7015}],[\"96971f36-0b4e-4103-b9c2-eceac0506511\",{\"client\":{\"user\":{\"id\":\"610af2b1t@example.com}\",\"name\":\"54zzgh5uru2ptlv\",\"email\":\"h6r31ehj8@example.com}\"}},\"sequenceNumber\":7016}],[\"e51c2054-1878-4e5d-8144-c51054380632\",{\"client\":{\"user\":{\"id\":\"2itcu8mxf@example.com}\",\"name\":\"mndwqy9xfczeh9w\",\"email\":\"c39mfecky@example.com}\"}},\"sequenceNumber\":7017}],[\"67ffdad7-a873-41f0-a70e-3af92f175d68\",{\"client\":{\"user\":{\"id\":\"whfv5xh62@example.com}\",\"name\":\"cdyjprvbly615xf\",\"email\":\"i65rb66dk@example.com}\"}},\"sequenceNumber\":7032}],[\"b8f286b2-098b-4973-a7b7-04aabbfcfec9\",{\"client\":{\"user\":{\"id\":\"5u3v7wndj@example.com}\",\"name\":\"a81rwp83eso2j2h\",\"email\":\"ci26io60s@example.com}\"}},\"sequenceNumber\":7033}],[\"1f74a538-7a95-4a8f-84a5-c9830171bced\",{\"client\":{\"user\":{\"id\":\"r89h085re@example.com}\",\"name\":\"29k0s6d30puejpa\",\"email\":\"k0p1ts8qp@example.com}\"}},\"sequenceNumber\":7083}],[\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",{\"client\":{\"user\":{\"id\":\"jz79jdxkz@example.com}\",\"name\":\"iy7ft65cbwreadt\",\"email\":\"39b08igmg@example.com}\"}},\"sequenceNumber\":7122}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/3d40ee35-4260-4b98-aa46-817de71d3936\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d40ee35-4260-4b98-aa46-817de71d3936",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c3931334-2f54-414d-932d-002cee6f4280\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "317646ab-8abb-4680-984a-ad8199cf86d7",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4dcc5a14-ef2d-4b44-986a-b58c67809ed5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2e1fc401-26c3-43a4-803c-459e43baa8f9\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53760d85-c29d-4934-8242-400bd664c030\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0a20cce6-c582-435e-9d98-ad54187daa81\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/274b681c-476d-401d-be58-acaf01d2ea0a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4dcc5a14-ef2d-4b44-986a-b58c67809ed5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c3931334-2f54-414d-932d-002cee6f4280\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":540,\"refSeqNumber\":3808}},\"c47745c0-c165-4fb5-9ef0-ffc9c4dd29ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":868,\"refSeqNumber\":6012}},\"be3004e4-4638-4c72-9d26-c68f269c846b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":24,\"refSeqNumber\":6997}},\"50a1616d-2db6-4d8e-95b7-3eab0e081de7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7041}},\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":325,\"refSeqNumber\":8968}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2e1fc401-26c3-43a4-803c-459e43baa8f9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "347f0495-5605-4622-bcf1-0571a2bc2178",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53760d85-c29d-4934-8242-400bd664c030",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/347f0495-5605-4622-bcf1-0571a2bc2178\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":44,\"chunkLengthChars\":1175,\"totalLengthChars\":1175,\"totalSegmentCount\":44,\"chunkSequenceNumber\":8998,\"segmentTexts\":[{\"text\":\"hsf3um6y47s50wofv9kr5x7b\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1802f982-dd83-4409-86fc-1b1db4ce3a59\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"3st82pl5f5dsl7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19c893bf-dd0d-4dd8-a3c2-59d47a5d59aa\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"08ba0d07-a494-4b58-8007-d39efdb6e1ae\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"dg6bz5d96ph429ua7r\",\"props\":{}},\"5xjy3rxpsv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6d4193ab-f583-4529-a302-c6f9fc7d939f\",\"ItemType\":\"Paragraph\"}},\"l98xziutbnbh4mez157o1d723lviubg04ngit2c5knpx15b84864vqpw0ckp9wn648q1c4zws2shz9qixspa097eg2phxn9bseb2t0b\",{\"text\":\"bo86hwfpnms7mb38nh7snwxqb8\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7347cfa1-8c5c-4eed-bb68-16aa91ca291c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList92\"}}},\"pn091kh08ezbo2eu1pwqlfx5w46hxk0iftkiso01uj0u6vav\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a91df3f-494a-43e1-8121-7a10332fe897\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"t1vs\",{\"text\":\"s\",\"props\":{}},\"uj5jcikuje1zqqt\",{\"text\":\"fqv\",\"props\":{}},\"wjw1k7vc6ckvadz31ff0m753x2l60ynvsrul1jj\",{\"text\":\"8qojx7x\",\"props\":{}},\"znfwme\",{\"text\":\"n\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0df5300-bd43-4bd3-bc45-b1b7173f4e5c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},\"twr4pj2yvi5zrtcpntqz4hsfw11gvu8icmvpo7ohsalcxbp51dyd8s7atv14b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"52d60ba7-a9ad-4c03-9d91-bfa6fcc5f68d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"772c3nypxbr7v9068wsbwivwek6hppfei7t4b99b4y16s02m5ubpztqrgszmoiaamnki36h20t939\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1e53b1-cdaa-4b5e-bd4e-54a4b3902789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-30\"}}},\"9d7asatx2gz7ti7c9bvmzdjs4b6qirztc4a8f6vrpuix1hlxi2lahxtfs3ihkhgynlp2efeos4e0l5657vjk49yj4bji4mvou1dlg17z57p5ncs7shy8l5ods5kk1do03qu288lb1lzml481itjiwcgkz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee2f8507-210c-4f6f-9dbe-2fe93c1803f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-102\"}}},{\"text\":\"rw54nd968rl3s7ugoyso25lhrnhfzebc3r4kfjpii9xp32rh44azntsml8rlan3ez01pawfdskq1wayckt9lhlwzq8e8ux1znd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ebbf6613-48c9-46b7-8962-23df8d83c31c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList35\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"11d6b6c4-b6eb-4699-a6b2-7862a6309a68\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"uewbcm1ujwh042dxupgedasht1j2knjxzt75c2\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e3f5413-e36b-4b30-b791-86a30d0352dd\",\"ItemType\":\"Paragraph\"}},\"k13d8eokohkwgahthmhsum3c1919h29c3goczmyaqxbx65vys78fdrumt3ezr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a70b61d8-2d12-4b59-a2fc-fa46cc95d545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"text\":\"20qguwsf61stqdytae45dqgd5acxust\",\"props\":{}},\"ac2sy9qvz851iyg857t5r9p9ksvvfzxl14euhzt4f30uo\",{\"text\":\"uuolobfun4n0k7zi6w6e5wj6lwimpa8rgoe0s98pkv253f\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3eb7ffc2-8713-45ad-9075-647a64b6fcf0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},\"adauozh7z2ovoocowkpofz73fwta1bo184bl81kw1r6khtbycsaznbalizkjnd2frdboa2dyw0ost57q7edtr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"078404a9-c366-4224-95f2-65baaf1e4ae6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"27e1e1ad-d247-497c-a01f-6f5238ac28e8\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"8rx7m2bjraqckavtk5jy9sp6yrd1h8xa470l2tpxgymbj6syyskdu3xv4ku0aljr3e2q9ugoq1oes1ed91j1ogyzcpod3jk2l9dz6cx3hi9kwwuoll7qsbvp67pb23k175affpkhrpgiepl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2fedc53-5920-404c-8d89-811a63ad5472\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":8998,\"totalLength\":1175,\"totalSegmentCount\":44}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0a20cce6-c582-435e-9d98-ad54187daa81",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/156c47f9-c7be-4034-acdb-c364995d39b7\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b85a07a-8f9f-4c25-a12f-f702d152bb64\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e78a57e8-5e63-4aba-b69c-02f03dbc024f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e4dce62f-ce60-4106-8429-0c65002ddb03\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2868bb39-32ac-4194-9568-8e532b9e81cf\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1de003fd-cef2-4c6c-bc9d-608b705d9eeb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fcf58c5f-acae-43e5-ad89-b1cbfbd9bc5c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "156c47f9-c7be-4034-acdb-c364995d39b7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b85a07a-8f9f-4c25-a12f-f702d152bb64",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e78a57e8-5e63-4aba-b69c-02f03dbc024f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4dce62f-ce60-4106-8429-0c65002ddb03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2868bb39-32ac-4194-9568-8e532b9e81cf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1de003fd-cef2-4c6c-bc9d-608b705d9eeb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "274b681c-476d-401d-be58-acaf01d2ea0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-59\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73d302a9-4c73-4c0b-b1d3-a8656e046ffb\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f1b5490-4e70-4de7-afde-356847fe33a0\"}},\"listRegistryList-116\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bff4f72f-10b3-4d8b-ab7d-abe074a36540\"}},\"listRegistryList92\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fdf4415b-9614-46cd-b266-4dc7a2a620b4\"}},\"listRegistryList-102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8dbc3df2-bafa-47f8-bae8-520fa9205fa1\"}},\"listRegistryList95\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7901ab10-d61a-41f0-89da-8625b8155dc2\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/36470095-c1f6-4688-910a-a4adef764891\"}},\"listRegistryList104\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/833baed0-4bac-44e1-b546-1645d7f6cd46\"}},\"listRegistryList35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e1c5b52-e922-4776-93a0-a461c76f2a75\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e77c957-5201-4537-9309-05bcc3002b30\"}},\"listRegistryList-23\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d626eb1-e9cc-40dc-bc94-7c423ba16e8f\"}},\"listRegistryList-105\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e295a564-6257-4a46-a2b5-e5945f1a6a2a\"}},\"listRegistryList-30\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecebb598-f967-4224-8d0b-0201d65fd127\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73d302a9-4c73-4c0b-b1d3-a8656e046ffb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-59\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f1b5490-4e70-4de7-afde-356847fe33a0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bff4f72f-10b3-4d8b-ab7d-abe074a36540",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-116\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fdf4415b-9614-46cd-b266-4dc7a2a620b4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList92\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8dbc3df2-bafa-47f8-bae8-520fa9205fa1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7901ab10-d61a-41f0-89da-8625b8155dc2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList95\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "36470095-c1f6-4688-910a-a4adef764891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "833baed0-4bac-44e1-b546-1645d7f6cd46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList104\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e1c5b52-e922-4776-93a0-a461c76f2a75",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e77c957-5201-4537-9309-05bcc3002b30",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d626eb1-e9cc-40dc-bc94-7c423ba16e8f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-23\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e295a564-6257-4a46-a2b5-e5945f1a6a2a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-105\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecebb598-f967-4224-8d0b-0201d65fd127",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-30\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"6c466c03-c6a6-494a-9c4a-38b5c6baf8fe\",\"clientSequenceNumber\":1844,\"minimumSequenceNumber\":8998,\"referenceSequenceNumber\":8999,\"sequenceNumber\":9000,\"timestamp\":1564513948379,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.45.0/snapshot_461_0.json
+++ b/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.45.0/snapshot_461_0.json
@@ -2768,7 +2768,7 @@
                     "mode": "100644",
                     "type": "Blob",
                     "value": {
-                      "contents": "{\"usedRoutes\":[\"\",\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/root\"],\"gcData\":{\"gcNodes\":{\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/root\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]}}}",
+                      "contents": "{\"usedRoutes\":[\"\",\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/root\"],\"gcData\":{\"gcNodes\":{\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"],\"/root\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]}}}",
                       "encoding": "utf-8"
                     }
                   }
@@ -4670,7 +4670,7 @@
                     "mode": "100644",
                     "type": "Blob",
                     "value": {
-                      "contents": "{\"usedRoutes\":[],\"gcData\":{\"gcNodes\":{\"/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":[\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/root\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"]}}}",
+                      "contents": "{\"usedRoutes\":[],\"gcData\":{\"gcNodes\":{\"/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\",\"/b25b9b04-5740-4043-873b-793aff3e439c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\",\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"/root\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"]}}}",
                       "encoding": "utf-8"
                     }
                   }

--- a/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.47.0/snapshot_461_0.json
+++ b/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.47.0/snapshot_461_0.json
@@ -2768,7 +2768,7 @@
                     "mode": "100644",
                     "type": "Blob",
                     "value": {
-                      "contents": "{\"usedRoutes\":[\"\",\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/root\"],\"gcData\":{\"gcNodes\":{\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/root\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]}}}",
+                      "contents": "{\"usedRoutes\":[\"\",\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/root\"],\"gcData\":{\"gcNodes\":{\"/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"],\"/root\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"],\"/\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]}}}",
                       "encoding": "utf-8"
                     }
                   }
@@ -4670,7 +4670,7 @@
                     "mode": "100644",
                     "type": "Blob",
                     "value": {
-                      "contents": "{\"usedRoutes\":[],\"gcData\":{\"gcNodes\":{\"/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":[\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/root\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"]}}}",
+                      "contents": "{\"usedRoutes\":[],\"gcData\":{\"gcNodes\":{\"/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\",\"/b25b9b04-5740-4043-873b-793aff3e439c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\",\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"/root\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"/\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"]}}}",
                       "encoding": "utf-8"
                     }
                   }

--- a/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.59.3000/snapshot_461_0.json
+++ b/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.59.3000/snapshot_461_0.json
@@ -47,366 +47,6 @@
           "entries": [
             {
               "mode": "040000",
-              "path": "_scheduler",
-              "type": "Tree",
-              "value": {
-                "entries": [
-                  {
-                    "mode": "040000",
-                    "path": ".channels",
-                    "type": "Tree",
-                    "value": {
-                      "entries": [
-                        {
-                          "mode": "040000",
-                          "path": "root",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\"}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "mode": "040000",
-                          "path": "0bb02397-c776-416a-a096-df6946029cf7",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":9,\"value\":{\"type\":\"Plain\",\"value\":\"a090e8d2-bcd7-4a07-a04d-2fb9f52d1ced\"}},\"versions\":[{\"sequenceNumber\":9,\"value\":{\"type\":\"Plain\",\"value\":\"a090e8d2-bcd7-4a07-a04d-2fb9f52d1ced\"}}]}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "mode": "100644",
-                    "path": ".component",
-                    "type": "Blob",
-                    "value": {
-                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
-                      "encoding": "utf-8"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "mode": "040000",
-              "path": "defaultComponent",
-              "type": "Tree",
-              "value": {
-                "entries": [
-                  {
-                    "mode": "040000",
-                    "path": ".channels",
-                    "type": "Tree",
-                    "value": {
-                      "entries": [
-                        {
-                          "mode": "040000",
-                          "path": "root",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"}}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "mode": "100644",
-                    "path": ".component",
-                    "type": "Blob",
-                    "value": {
-                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
-                      "encoding": "utf-8"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "mode": "040000",
-              "path": "bf951bc3-71c5-4fdf-a1af-0cb0623a60f3",
-              "type": "Tree",
-              "value": {
-                "entries": [
-                  {
-                    "mode": "040000",
-                    "path": ".channels",
-                    "type": "Tree",
-                    "value": {
-                      "entries": [
-                        {
-                          "mode": "040000",
-                          "path": "root",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"oid\":\"160mpbh77msc8sulh6doxvv595wni8onb41v\"},\"timestamp\":1627344127288}}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "mode": "040000",
-                          "path": "f96b4cd6-f0a3-43f9-bb13-24942f8c9e52",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "mode": "100644",
-                    "path": ".component",
-                    "type": "Blob",
-                    "value": {
-                      "contents": "{\"pkg\":\"[\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
-                      "encoding": "utf-8"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "mode": "040000",
-              "path": "c04b0495-9718-4adf-8298-cdc4e23dc49d",
-              "type": "Tree",
-              "value": {
-                "entries": [
-                  {
-                    "mode": "040000",
-                    "path": ".channels",
-                    "type": "Tree",
-                    "value": {
-                      "entries": [
-                        {
-                          "mode": "040000",
-                          "path": "root",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"},\"text:style!registry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\"}}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "mode": "040000",
-                          "path": "822aa050-2af4-4ae0-be9d-e1a254afab8d",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "040000",
-                                "path": "content",
-                                "type": "Tree",
-                                "value": {
-                                  "entries": [
-                                    {
-                                      "mode": "100644",
-                                      "path": "header",
-                                      "type": "Blob",
-                                      "value": {
-                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":11,\"chunkLengthChars\":39,\"totalLengthChars\":39,\"totalSegmentCount\":11,\"chunkSequenceNumber\":461,\"segmentTexts\":[{\"text\":\"Snapshot Test Document\",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"style!reference\":\"Heading 1\",\"nodeType\":\"Paragraph\",\"markerId\":\"59a9be1b-3da5-407c-9635-ab5fa8d82aa7\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"3e4e1fa4-4eb7-4aca-9329-31a8e680ebd9\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"text\":\"Table 1\",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"style!reference\":\"Heading 1\",\"nodeType\":\"Paragraph\",\"markerId\":\"b46f420d-8b33-461a-84b4-7d4eeb3a6588\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"nodeType\":\"FluidComponent\",\"markerId\":\"2660caa5-8659-4910-9c32-c8c835af190b\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000},\"component!display\":\"block\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/47f40f9c-adee-4b90-a65a-796f447c8117\"},\"content!locale\":\"en-us\"}},{\"text\":\"  \",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"68e181f5-4448-4310-be55-861773228235\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"a146a335-80c3-4b3e-9b32-db8db409163d\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000},\"style!reference\":\"Heading 1\"}},{\"marker\":{\"refType\":1},\"props\":{\"component!display\":\"inline-block\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/dias/2c0270e5-6bc3-4c3e-926a-c5c52dc7e658\"},\"content!locale\":\"en-us\",\"nodeType\":\"FluidComponent\",\"markerId\":\"c8cc3c9b-996b-4872-b3dd-451fb77fdad9\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"bb22e285-bb45-4333-9ad3-eed785057bee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":461,\"totalLength\":39,\"totalSegmentCount\":11}}",
-                                        "encoding": "utf-8"
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "mode": "040000",
-                          "path": "27e5232b-81b5-4f6e-8981-27036760167b",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"style!style-Heading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\"}}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "mode": "040000",
-                          "path": "3d73a77f-46a0-44a4-b775-2551e765569e",
-                          "type": "Tree",
-                          "value": {
-                            "entries": [
-                              {
-                                "mode": "100644",
-                                "path": "header",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"style!id\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"style!target\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"style!level\":{\"type\":\"Plain\",\"value\":1},\"style!property-format!fontName\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontFamilyHeading1,Segoe UI, Segoe UI Emoji, sans-serif)\"},\"style!property-format!fontSize\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontSizeHeading1,24px)\"},\"style!property-format!bold\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontWeightHeading1,700)\"},\"style!property-format!fontColor\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeColorHeadingText,var(--ms-themeColorBodyTextChecked, var(--ms-themeColorBodyText, var(--ms-themeColorPaletteNeutralPrimary, #323130))))\"},\"style!property-paragraph!marginTop\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeMarginTopHeading1)\"},\"style!property-paragraph!lineSpacing\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeLineHeightHeading1,normal)\"},\"style!property-aria!role\":{\"type\":\"Plain\",\"value\":\"heading\"},\"style!property-aria!level\":{\"type\":\"Plain\",\"value\":\"1\"},\"style!property-page!outline\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeOutlineHeading1)\"},\"style!property-format!highlight\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeColorBodyBackground,transparent)\"}}}}",
-                                  "encoding": "utf-8"
-                                }
-                              },
-                              {
-                                "mode": "100644",
-                                "path": ".attributes",
-                                "type": "Blob",
-                                "value": {
-                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
-                                  "encoding": "utf-8"
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "mode": "100644",
-                    "path": ".component",
-                    "type": "Blob",
-                    "value": {
-                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
-                      "encoding": "utf-8"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "mode": "040000",
               "path": "990d9c6e-2e52-455f-98ec-ec738f1744e7",
               "type": "Tree",
               "value": {
@@ -5153,6 +4793,366 @@
                   }
                 ]
               }
+            },
+            {
+              "mode": "040000",
+              "path": "bf951bc3-71c5-4fdf-a1af-0cb0623a60f3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"oid\":\"160mpbh77msc8sulh6doxvv595wni8onb41v\"},\"timestamp\":1627344127288}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f96b4cd6-f0a3-43f9-bb13-24942f8c9e52",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "0bb02397-c776-416a-a096-df6946029cf7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":9,\"value\":{\"type\":\"Plain\",\"value\":\"a090e8d2-bcd7-4a07-a04d-2fb9f52d1ced\"}},\"versions\":[{\"sequenceNumber\":9,\"value\":{\"type\":\"Plain\",\"value\":\"a090e8d2-bcd7-4a07-a04d-2fb9f52d1ced\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c04b0495-9718-4adf-8298-cdc4e23dc49d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "822aa050-2af4-4ae0-be9d-e1a254afab8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":11,\"chunkLengthChars\":39,\"totalLengthChars\":39,\"totalSegmentCount\":11,\"chunkSequenceNumber\":461,\"segmentTexts\":[{\"text\":\"Snapshot Test Document\",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"style!reference\":\"Heading 1\",\"nodeType\":\"Paragraph\",\"markerId\":\"59a9be1b-3da5-407c-9635-ab5fa8d82aa7\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"3e4e1fa4-4eb7-4aca-9329-31a8e680ebd9\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"text\":\"Table 1\",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"style!reference\":\"Heading 1\",\"nodeType\":\"Paragraph\",\"markerId\":\"b46f420d-8b33-461a-84b4-7d4eeb3a6588\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"nodeType\":\"FluidComponent\",\"markerId\":\"2660caa5-8659-4910-9c32-c8c835af190b\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000},\"component!display\":\"block\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/47f40f9c-adee-4b90-a65a-796f447c8117\"},\"content!locale\":\"en-us\"}},{\"text\":\"  \",\"props\":{\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"68e181f5-4448-4310-be55-861773228235\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"nodeType\":\"Paragraph\",\"markerId\":\"a146a335-80c3-4b3e-9b32-db8db409163d\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000},\"style!reference\":\"Heading 1\"}},{\"marker\":{\"refType\":1},\"props\":{\"component!display\":\"inline-block\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/dias/2c0270e5-6bc3-4c3e-926a-c5c52dc7e658\"},\"content!locale\":\"en-us\",\"nodeType\":\"FluidComponent\",\"markerId\":\"c8cc3c9b-996b-4872-b3dd-451fb77fdad9\",\"attribution\":{\"id\":\"zq2hczyqu9qhfc66map1@test.com\",\"name\":\"3oqjj zpwbk3f\",\"email\":\"zq2hczyqu9qhfc66map1@test.com\",\"timestamp\":1627344000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"bb22e285-bb45-4333-9ad3-eed785057bee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":461,\"totalLength\":39,\"totalSegmentCount\":11}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "27e5232b-81b5-4f6e-8981-27036760167b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"style!style-Heading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3d73a77f-46a0-44a4-b775-2551e765569e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"style!id\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"style!target\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"style!level\":{\"type\":\"Plain\",\"value\":1},\"style!property-format!fontName\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontFamilyHeading1,Segoe UI, Segoe UI Emoji, sans-serif)\"},\"style!property-format!fontSize\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontSizeHeading1,24px)\"},\"style!property-format!bold\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeFontWeightHeading1,700)\"},\"style!property-format!fontColor\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeColorHeadingText,var(--ms-themeColorBodyTextChecked, var(--ms-themeColorBodyText, var(--ms-themeColorPaletteNeutralPrimary, #323130))))\"},\"style!property-paragraph!marginTop\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeMarginTopHeading1)\"},\"style!property-paragraph!lineSpacing\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeLineHeightHeading1,normal)\"},\"style!property-aria!role\":{\"type\":\"Plain\",\"value\":\"heading\"},\"style!property-aria!level\":{\"type\":\"Plain\",\"value\":\"1\"},\"style!property-page!outline\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeOutlineHeading1)\"},\"style!property-format!highlight\":{\"type\":\"Plain\",\"value\":\"var(--ms-themeColorBodyBackground,transparent)\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"},\"text:style!registry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.43.1\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
             }
           ]
         }
@@ -5177,7 +5177,7 @@
               "path": "__gc_root",
               "type": "Blob",
               "value": {
-                "contents": "{\"gcNodes\":{\"/47f40f9c-adee-4b90-a65a-796f447c8117/root\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\",\"/47f40f9c-adee-4b90-a65a-796f447c8117\"]},\"/47f40f9c-adee-4b90-a65a-796f447c8117\":{\"outboundRoutes\":[\"/47f40f9c-adee-4b90-a65a-796f447c8117/root\"]},\"/a34a8254-a054-414d-a875-981630e36afa/root\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\",\"/a34a8254-a054-414d-a875-981630e36afa\"],\"unreferencedTimestampMs\":1627344403198},\"/a34a8254-a054-414d-a875-981630e36afa\":{\"outboundRoutes\":[\"/a34a8254-a054-414d-a875-981630e36afa/root\"],\"unreferencedTimestampMs\":1627344403198},\"/atMentions/instances\":{\"outboundRoutes\":[\"/atMentions\"]},\"/atMentions\":{\"outboundRoutes\":[\"/atMentions/instances\"]},\"/dias/instances\":{\"outboundRoutes\":[\"/dias\"]},\"/dias\":{\"outboundRoutes\":[\"/dias/instances\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/root\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/root\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\"]},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/root\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/root\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\"],\"unreferencedTimestampMs\":1627344403198},\"/f1928366-db84-4fa1-b725-b6c48b7d088e/root\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\"]},\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e\"]},\"/f1928366-db84-4fa1-b725-b6c48b7d088e\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e/root\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/root\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/root\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\"]},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/root\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/root\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/root\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\",\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c/root\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/root\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/root\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\"],\"unreferencedTimestampMs\":1627344403198},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/root\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/root\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\"]},\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00/root\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\",\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00/root\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/root\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/root\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/root\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/root\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/root\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/root\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/root\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/root\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/root\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5/root\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/root\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/root\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\"],\"unreferencedTimestampMs\":1627344403198},\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03/root\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\",\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03/root\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\"]},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/root\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/root\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/root\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/root\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/root\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2/root\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/root\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/root\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/root\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/root\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/root\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\",\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\",\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e/root\",\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\",\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/root\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/root\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/root\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/root\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/root\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\",\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\",\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976/root\",\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\",\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/root\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\",\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\",\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45/root\",\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\",\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/root\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/root\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/root\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea/root\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/root\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/root\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/root\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\",\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\",\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c/root\",\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\",\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/root\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/root\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/root\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/root\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/root\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\",\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47/root\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/root\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/root\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/root\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/root\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/root\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\",\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb/root\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\"],\"unreferencedTimestampMs\":1627344403198},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"]},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\",\"/25dd2996-f667-472f-8c6a-5f4859216e03\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"]},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]},\"/d69d488b-b408-43a1-8692-d016afc6474b/root\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"unreferencedTimestampMs\":1627344403198},\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\",\"/dbaee072-68e0-443f-a670-9111a803988e\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\",\"/b25b9b04-5740-4043-873b-793aff3e439c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"unreferencedTimestampMs\":1627344403198},\"/d69d488b-b408-43a1-8692-d016afc6474b\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"],\"unreferencedTimestampMs\":1627344403198},\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\",\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/root\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\",\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/root\",\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/root\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\":{\"outboundRoutes\":[\"/47f40f9c-adee-4b90-a65a-796f447c8117\",\"/dias/2c0270e5-6bc3-4c3e-926a-c5c52dc7e658\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/root\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\",\"/atMentions\",\"/dias\"]}}}",
+                "contents": "{\"gcNodes\":{\"/defaultComponent/root\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/47f40f9c-adee-4b90-a65a-796f447c8117/root\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\",\"/47f40f9c-adee-4b90-a65a-796f447c8117\"]},\"/47f40f9c-adee-4b90-a65a-796f447c8117\":{\"outboundRoutes\":[\"/47f40f9c-adee-4b90-a65a-796f447c8117/root\"]},\"/a34a8254-a054-414d-a875-981630e36afa/root\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\",\"/a34a8254-a054-414d-a875-981630e36afa\"],\"unreferencedTimestampMs\":1627344403198},\"/a34a8254-a054-414d-a875-981630e36afa\":{\"outboundRoutes\":[\"/a34a8254-a054-414d-a875-981630e36afa/root\"],\"unreferencedTimestampMs\":1627344403198},\"/atMentions/instances\":{\"outboundRoutes\":[\"/atMentions\"]},\"/atMentions\":{\"outboundRoutes\":[\"/atMentions/instances\"]},\"/dias/instances\":{\"outboundRoutes\":[\"/dias\"]},\"/dias\":{\"outboundRoutes\":[\"/dias/instances\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/root\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\"]},\"/62b6b8f2-e234-4861-8e37-0609cb9330c2\":{\"outboundRoutes\":[\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/root\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/rowSequence-cb8c5892-eec6-490c-a4a7-1b6f4303230b\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/colSequence-740106b4-4dd8-4d5e-98fd-0bd8b3a43ee4\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/sharedSignal-4e6786ec-7308-420d-a497-be235b914672\",\"/62b6b8f2-e234-4861-8e37-0609cb9330c2/viewDataPropertyBag-0ae20e8b-c3c1-4885-805f-94d74cc98770\"]},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/root\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e\":{\"outboundRoutes\":[\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/root\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/rowSequence-ec1908d3-659f-4f52-889d-98b0f71b66e9\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/colSequence-e2b728f8-fd76-4700-8509-2316a6bb4db6\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/sharedSignal-ce5c1c0b-c8b1-4edc-8fd3-0913ac15848a\",\"/5ce39c57-7bdc-400c-96ee-5bcf1a4e6d8e/viewDataPropertyBag-a521bc44-427d-4d8b-be23-d5a1c1395351\"],\"unreferencedTimestampMs\":1627344403198},\"/f1928366-db84-4fa1-b725-b6c48b7d088e/root\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\"]},\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e\"]},\"/f1928366-db84-4fa1-b725-b6c48b7d088e\":{\"outboundRoutes\":[\"/f1928366-db84-4fa1-b725-b6c48b7d088e/root\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e/28bdd517-6d4d-4c45-ab92-43ab1a15ca9d\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/root\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\"]},\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/root\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/037b0481-8e91-4471-890c-45d3b0dccc59\",\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3/9c673278-e689-409c-a822-d901ef79b3fc\"]},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/root\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\"],\"unreferencedTimestampMs\":1627344403198},\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e\":{\"outboundRoutes\":[\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/root\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/afc51452-05ea-44ac-91ed-9f09356abea0\",\"/c74a8094-5f54-424f-ac53-ecf6bb684d8e/51fb46c1-1037-4975-8c3b-0d8a9a888b43\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/root\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\",\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c\"],\"unreferencedTimestampMs\":1627344403198},\"/93801721-3bf4-4e5c-ac75-606205c9731c\":{\"outboundRoutes\":[\"/93801721-3bf4-4e5c-ac75-606205c9731c/root\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/0ab85213-3338-4feb-ba57-7983b6ce604e\",\"/93801721-3bf4-4e5c-ac75-606205c9731c/c07a65c9-627c-4376-ae5d-d5a23985499b\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/root\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\"],\"unreferencedTimestampMs\":1627344403198},\"/038df8d8-56f0-435e-ba60-c1a276fd52ff\":{\"outboundRoutes\":[\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/root\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/0aac5d80-ade7-4bf0-b4b4-e91ddbc35ce9\",\"/038df8d8-56f0-435e-ba60-c1a276fd52ff/08e651c9-f609-462c-954d-da5612cc58dc\"],\"unreferencedTimestampMs\":1627344403198},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/root\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\"]},\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\":{\"outboundRoutes\":[\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/root\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/b7f8a1e8-687e-4588-8104-ee9a8e3b4cd5\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e/44d3c249-7d1f-4890-bd26-af566b1521ad\"]},\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00/root\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\",\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00\"],\"unreferencedTimestampMs\":1627344403198},\"/715f7dad-2976-4960-aa34-6049d0f86b00\":{\"outboundRoutes\":[\"/715f7dad-2976-4960-aa34-6049d0f86b00/root\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/f8739d43-5c15-4af8-a207-e9bc6cdddad4\",\"/715f7dad-2976-4960-aa34-6049d0f86b00/80e86bfb-a4f1-4094-9832-efd1d6a9502c\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/root\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\"],\"unreferencedTimestampMs\":1627344403198},\"/b815ddc4-654e-4774-baf4-59d404b0c9d2\":{\"outboundRoutes\":[\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/root\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/dc138ab0-5a79-45b4-a17f-e61a44463c39\",\"/b815ddc4-654e-4774-baf4-59d404b0c9d2/7e6fd881-8c90-4c5b-ae91-e874e8fe6a74\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/root\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\"],\"unreferencedTimestampMs\":1627344403198},\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63\":{\"outboundRoutes\":[\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/root\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/7be63467-02d3-4c2f-9a4b-3a3af1b6a868\",\"/d0f9851f-eeed-4173-b5e4-8044fe3b2e63/cc761590-1272-4762-ac04-fad7067a6409\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/root\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\"],\"unreferencedTimestampMs\":1627344403198},\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990\":{\"outboundRoutes\":[\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/root\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/0637c360-f385-4811-a72a-5b3caa205530\",\"/f2c16a83-07f8-4d0e-bff4-084ad3ac3990/c2a3383c-02c9-4fa0-8312-ae8ad22cc9e2\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/root\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\"],\"unreferencedTimestampMs\":1627344403198},\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa\":{\"outboundRoutes\":[\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/root\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/f60e319f-c3d7-4a13-9065-373e67b5fede\",\"/79f6225c-b55f-4af4-9dd7-eaac8b8179fa/0fb690f8-edb5-42ce-b6fe-3805ecc14036\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/root\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5\"],\"unreferencedTimestampMs\":1627344403198},\"/d23d026e-7689-4a56-a31a-3f21242df6f5\":{\"outboundRoutes\":[\"/d23d026e-7689-4a56-a31a-3f21242df6f5/root\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/ea40557f-2e97-437a-bf58-4c867bdb2ee6\",\"/d23d026e-7689-4a56-a31a-3f21242df6f5/99b5f6a5-5c6a-46a5-af6a-a78635ffb9c4\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/root\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\"],\"unreferencedTimestampMs\":1627344403198},\"/722d0ea2-7d55-429d-8e3b-1537820c34e9\":{\"outboundRoutes\":[\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/root\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/d15527fc-d584-42d7-a169-38fff051aad6\",\"/722d0ea2-7d55-429d-8e3b-1537820c34e9/cf19a35f-ca44-40f5-82a8-3f63320f3085\"],\"unreferencedTimestampMs\":1627344403198},\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03/root\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\",\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03\"]},\"/25dd2996-f667-472f-8c6a-5f4859216e03\":{\"outboundRoutes\":[\"/25dd2996-f667-472f-8c6a-5f4859216e03/root\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/cf8168f5-ac44-46a4-98d4-3eb099b041ab\",\"/25dd2996-f667-472f-8c6a-5f4859216e03/d5051ede-e680-4b14-9d4f-db98732bbd9a\"]},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/root\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\"],\"unreferencedTimestampMs\":1627344403198},\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa\":{\"outboundRoutes\":[\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/root\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/af49b947-5519-40e6-b0de-aafd50e7c5dd\",\"/576deba3-fae8-4c8a-bb5a-a173ecb733fa/8d2e79e5-8319-4b0e-9c9d-272a22a70a19\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/root\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\"],\"unreferencedTimestampMs\":1627344403198},\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda\":{\"outboundRoutes\":[\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/root\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/03a1d7e0-ac49-4dd1-aa1f-4e8044e6d9a2\",\"/fcb5a319-361f-4d3f-9c27-5ba676ab7eda/62c32192-f09d-42cf-b25c-cf0cbdde2c85\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/root\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2\"],\"unreferencedTimestampMs\":1627344403198},\"/f099caf6-cb13-44a3-884e-7f2029e766b2\":{\"outboundRoutes\":[\"/f099caf6-cb13-44a3-884e-7f2029e766b2/root\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/0d4c7349-24cf-43b5-b6cb-c55bc41d0a28\",\"/f099caf6-cb13-44a3-884e-7f2029e766b2/9d4c3288-d51b-40f3-9652-aaa2391401da\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/root\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\"],\"unreferencedTimestampMs\":1627344403198},\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\":{\"outboundRoutes\":[\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/root\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c/1d53db8e-502c-44f7-b4b4-40a1c449b625\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/root\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\"],\"unreferencedTimestampMs\":1627344403198},\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/root\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/6680e275-5631-455a-98c0-53474cbc342b\",\"/7ff5662e-90e9-4972-9b63-de3a1612fad2/9b6bd275-8993-4f87-98d3-96e0fa21b411\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/root\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\",\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\",\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e\"],\"unreferencedTimestampMs\":1627344403198},\"/dbaee072-68e0-443f-a670-9111a803988e\":{\"outboundRoutes\":[\"/dbaee072-68e0-443f-a670-9111a803988e/root\",\"/dbaee072-68e0-443f-a670-9111a803988e/e47e6e9a-7489-468a-8320-af3e616b6b80\",\"/dbaee072-68e0-443f-a670-9111a803988e/9468577d-8946-478f-ac47-a9a63ccaa6ff\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/root\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\"],\"unreferencedTimestampMs\":1627344403198},\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47\":{\"outboundRoutes\":[\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/root\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/cc73913f-f9cf-44c2-8560-c6e5a8aa1086\",\"/b8ad7d8b-e538-40ec-a950-33d6eb717a47/c9843e49-0a1b-446c-b0e3-b31055b154e8\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/root\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\"],\"unreferencedTimestampMs\":1627344403198},\"/d927a697-1cc9-43fc-9cd5-8db9189ef823\":{\"outboundRoutes\":[\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/root\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/dec0b723-f0a1-47d7-a416-0665734d032a\",\"/d927a697-1cc9-43fc-9cd5-8db9189ef823/0c8fa677-6d62-4071-abc1-6f5ea69d8382\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/root\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\",\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\",\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976\"],\"unreferencedTimestampMs\":1627344403198},\"/95a8e567-cb97-45c3-a478-47e257a27976\":{\"outboundRoutes\":[\"/95a8e567-cb97-45c3-a478-47e257a27976/root\",\"/95a8e567-cb97-45c3-a478-47e257a27976/68ff855a-f52e-4407-acd6-33a685a40114\",\"/95a8e567-cb97-45c3-a478-47e257a27976/ed765493-129b-46d5-9ad1-b5482a902052\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/root\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\",\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\",\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45\"],\"unreferencedTimestampMs\":1627344403198},\"/d56fb018-5172-4759-a462-cbc40585ea45\":{\"outboundRoutes\":[\"/d56fb018-5172-4759-a462-cbc40585ea45/root\",\"/d56fb018-5172-4759-a462-cbc40585ea45/e1505c7e-7539-4464-834d-1c0f5e3a03d6\",\"/d56fb018-5172-4759-a462-cbc40585ea45/11b40d4d-76d4-4f3b-b527-509cb9b7fd35\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/root\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\"],\"unreferencedTimestampMs\":1627344403198},\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134\":{\"outboundRoutes\":[\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/root\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/8e64e894-5528-4d7c-95a5-007b03b196c3\",\"/09c96cd9-3c4a-4808-96ce-5dfd49c1c134/733808cf-549b-443b-9af1-b04f5e43dfc0\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/root\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea\"],\"unreferencedTimestampMs\":1627344403198},\"/960591c0-21b6-4924-8ec1-603beb7d97ea\":{\"outboundRoutes\":[\"/960591c0-21b6-4924-8ec1-603beb7d97ea/root\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/02c00124-8a30-42bf-83f3-e08f96c4629a\",\"/960591c0-21b6-4924-8ec1-603beb7d97ea/969c0071-6edc-4646-8b59-502593eec1cb\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/root\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\"],\"unreferencedTimestampMs\":1627344403198},\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\":{\"outboundRoutes\":[\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/root\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/ab6f3bc9-e5d4-4032-934a-68c824601bae\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d/3d9e85d0-478c-4276-9109-056ea1dc3f26\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/root\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\",\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\",\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c\"],\"unreferencedTimestampMs\":1627344403198},\"/b25b9b04-5740-4043-873b-793aff3e439c\":{\"outboundRoutes\":[\"/b25b9b04-5740-4043-873b-793aff3e439c/root\",\"/b25b9b04-5740-4043-873b-793aff3e439c/0e63cab9-99d8-432f-afc0-11e4bacfdc4e\",\"/b25b9b04-5740-4043-873b-793aff3e439c/a940f755-9945-4eca-88fc-a752c7cb0790\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/root\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\"],\"unreferencedTimestampMs\":1627344403198},\"/39de2b76-0302-4945-ad54-6b5f6c4eded9\":{\"outboundRoutes\":[\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/root\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/b96b1345-052b-4608-a582-65c3119761f4\",\"/39de2b76-0302-4945-ad54-6b5f6c4eded9/defbf869-25aa-4b9e-ad4c-985a9adf2b40\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/root\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\"],\"unreferencedTimestampMs\":1627344403198},\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027\":{\"outboundRoutes\":[\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/root\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/aa782cf0-b62b-4261-8364-8b2b3504c4b0\",\"/bddd2bda-6e23-408f-9f9d-f4b0c8a4e027/d2a03f4f-5692-4e06-b4ef-d9667dd10854\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/root\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\",\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47\"],\"unreferencedTimestampMs\":1627344403198},\"/80499f1e-1abb-4354-8b95-64286e33ee47\":{\"outboundRoutes\":[\"/80499f1e-1abb-4354-8b95-64286e33ee47/root\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/c9da52e9-2268-4d99-89de-4db06f93f594\",\"/80499f1e-1abb-4354-8b95-64286e33ee47/2edfca72-75c2-4925-94eb-eabe51c73313\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/root\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\"],\"unreferencedTimestampMs\":1627344403198},\"/11b0a997-2afe-44f2-a11d-7d193555b7a6\":{\"outboundRoutes\":[\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/root\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/c4acdac4-7f44-4ecf-9cd8-d91e98a34110\",\"/11b0a997-2afe-44f2-a11d-7d193555b7a6/dd5ea075-d4ac-4ca8-a469-584fd0249caf\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/root\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\"],\"unreferencedTimestampMs\":1627344403198},\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34\":{\"outboundRoutes\":[\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/root\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/3acdfaa0-d288-4cb4-8e90-613b585cfcf9\",\"/1d10a893-cacd-4888-acfa-fdfb8fa83b34/a443af9a-210f-40f8-a64c-d89723bcdc2e\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/root\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\",\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb\"],\"unreferencedTimestampMs\":1627344403198},\"/8c0e937d-1e71-4c86-969c-97990d900feb\":{\"outboundRoutes\":[\"/8c0e937d-1e71-4c86-969c-97990d900feb/root\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/7f7b8602-f5b0-492d-b7dd-24e8347608c8\",\"/8c0e937d-1e71-4c86-969c-97990d900feb/f6a5b6a8-73c8-4b5d-b841-3fc4ff901a83\"],\"unreferencedTimestampMs\":1627344403198},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\",\"/f1928366-db84-4fa1-b725-b6c48b7d088e\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"]},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\":{\"outboundRoutes\":[\"/d54bb578-1521-426a-a4b7-61d9c35e0eb3\",\"/8466f652-75d1-4ac3-82a1-47bd80652a2e\",\"/25dd2996-f667-472f-8c6a-5f4859216e03\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\"]},\"/990d9c6e-2e52-455f-98ec-ec738f1744e7\":{\"outboundRoutes\":[\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/root\",\"/990d9c6e-2e52-455f-98ec-ec738f1744e7/matrixId-4214df85-d3a1-42e4-999b-036ee4bc31af\"]},\"/d69d488b-b408-43a1-8692-d016afc6474b/root\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\",\"/b15d3f13-2f2a-4ba7-90f8-a2c08c00503c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"unreferencedTimestampMs\":1627344403198},\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\":{\"outboundRoutes\":[\"/7ff5662e-90e9-4972-9b63-de3a1612fad2\",\"/dbaee072-68e0-443f-a670-9111a803988e\",\"/b07ce5af-7877-4cf8-a299-5c0a350cef3d\",\"/b25b9b04-5740-4043-873b-793aff3e439c\",\"/d69d488b-b408-43a1-8692-d016afc6474b\"],\"unreferencedTimestampMs\":1627344403198},\"/d69d488b-b408-43a1-8692-d016afc6474b\":{\"outboundRoutes\":[\"/d69d488b-b408-43a1-8692-d016afc6474b/root\",\"/d69d488b-b408-43a1-8692-d016afc6474b/matrixId-31bff77e-8bd0-4df3-9b48-fde00c976ce8\"],\"unreferencedTimestampMs\":1627344403198},\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\",\"/_scheduler\",\"/_scheduler\"]},\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/0bb02397-c776-416a-a096-df6946029cf7\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\",\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/root\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\",\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\"]},\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3\":{\"outboundRoutes\":[\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/root\",\"/bf951bc3-71c5-4fdf-a1af-0cb0623a60f3/f96b4cd6-f0a3-43f9-bb13-24942f8c9e52\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/root\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\":{\"outboundRoutes\":[\"/47f40f9c-adee-4b90-a65a-796f447c8117\",\"/dias/2c0270e5-6bc3-4c3e-926a-c5c52dc7e658\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\"]},\"/c04b0495-9718-4adf-8298-cdc4e23dc49d\":{\"outboundRoutes\":[\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/root\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/822aa050-2af4-4ae0-be9d-e1a254afab8d\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/27e5232b-81b5-4f6e-8981-27036760167b\",\"/c04b0495-9718-4adf-8298-cdc4e23dc49d/3d73a77f-46a0-44a4-b775-2551e765569e\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\",\"/atMentions\",\"/dias\"]}}}",
                 "encoding": "utf-8"
               }
             }

--- a/snapshotTestContent/Headings/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/Headings/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/Headings/src_snapshots/0.59.3000/snapshot_978_0.json
+++ b/snapshotTestContent/Headings/src_snapshots/0.59.3000/snapshot_978_0.json
@@ -1,0 +1,800 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":975,\"sequenceNumber\":978,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"1ec4423d-5221-4013-9e8f-e7676522ab58\",{\"client\":{\"user\":{\"id\":\"ou84oip13@example.com}\",\"name\":\"oayrq3sr4udz7eh\",\"email\":\"1nmluzu4b@example.com}\"}},\"sequenceNumber\":954}],[\"e696a7d0-da3b-44e5-9885-c5d38e4b99fd\",{\"client\":{\"user\":{\"id\":\"sg4n8bo1s@example.com}\",\"name\":\"lncxj7g2do30kos\",\"email\":\"0xczznxmh@example.com}\"}},\"sequenceNumber\":974}],[\"816a8117-5c8a-4774-b3b4-53860eb7eee3\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"ry9u4tse4@example.com}\",\"name\":\"vsj2az86wgb81ge\",\"email\":\"7l79wipce@example.com}\"}},\"sequenceNumber\":978}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "79588599-6fbb-4180-a7eb-818170b00c5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":115,\"value\":{\"type\":\"Plain\",\"value\":\"33e618d9-f568-47b2-ad0f-edc7e6e9b460\"}},\"versions\":[{\"sequenceNumber\":115,\"value\":{\"type\":\"Plain\",\"value\":\"33e618d9-f568-47b2-ad0f-edc7e6e9b460\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/79588599-6fbb-4180-a7eb-818170b00c5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/da81c9e7-4b0b-4fdf-8e24-6fda7952a5e4\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/afc21cf3-0195-4c21-8e61-e3dec9fe7cb2\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eec025bb-35b4-4706-92e3-15922afc2bb9\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f241b843-d761-420c-bfff-57199ea371b5\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ed6ca348-f61e-48cd-bcc9-3d171c6841b8\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "da81c9e7-4b0b-4fdf-8e24-6fda7952a5e4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"5b0483b0-fb28-4e2f-b5e5-787f30b8891f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":26,\"refSeqNumber\":103}},\"33e618d9-f568-47b2-ad0f-edc7e6e9b460\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":76,\"refSeqNumber\":251}},\"127afb5f-5f8b-4365-b3da-90dd5829c0d8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":107,\"refSeqNumber\":356}},\"6ce80ac2-c07f-47d6-92b9-1f203780460c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":660,\"pos\":646,\"refSeqNumber\":483}},\"e60151ca-af5b-4dee-af2d-e6d2bc2b4a75\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":632,\"refSeqNumber\":664}},\"cd69b940-ec30-4201-b7fd-d966c71d7e71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1592,\"refSeqNumber\":906}},\"126614f5-3a3d-4a16-ad66-014eccc5e797\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":906}},\"0cc13605-d84f-4719-9438-25f9a8e97442\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":916}},\"dfceef4d-a324-4896-9cf3-b6a87a3915b8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1931,\"refSeqNumber\":952}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "afc21cf3-0195-4c21-8e61-e3dec9fe7cb2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f241b843-d761-420c-bfff-57199ea371b5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/278232d1-89ae-4708-8e02-90a2efcc44b9\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d42633e3-ed50-49a4-8822-da7984a6115f\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4d96b44a-d6e1-4bb4-95fa-1ccf98049ea4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f34e34e-ee9d-4f07-9b89-6c12036a75b8\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bb9dc559-b71c-4d13-a6c8-4c7aed2c058e\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/71dda798-4faf-44cb-a4c0-5d2a2524e879\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a254a0ba-91c8-4990-8bbd-af23993ccad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "278232d1-89ae-4708-8e02-90a2efcc44b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d42633e3-ed50-49a4-8822-da7984a6115f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4d96b44a-d6e1-4bb4-95fa-1ccf98049ea4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f34e34e-ee9d-4f07-9b89-6c12036a75b8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb9dc559-b71c-4d13-a6c8-4c7aed2c058e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "71dda798-4faf-44cb-a4c0-5d2a2524e879",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a254a0ba-91c8-4990-8bbd-af23993ccad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ed6ca348-f61e-48cd-bcc9-3d171c6841b8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7e06bf76-679e-46fe-a41a-1e293663a170\"}},\"listRegistryList-24\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bc2ca9d7-44ca-4f90-9b25-c3b71de89990\"}},\"listRegistryList48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a7278eb4-e0e7-4d46-be1b-1723fbf00be1\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7e06bf76-679e-46fe-a41a-1e293663a170",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc2ca9d7-44ca-4f90-9b25-c3b71de89990",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-24\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a7278eb4-e0e7-4d46-be1b-1723fbf00be1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eec025bb-35b4-4706-92e3-15922afc2bb9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":51,\"chunkLengthChars\":1932,\"totalLengthChars\":1932,\"totalSegmentCount\":51,\"chunkSequenceNumber\":975,\"segmentTexts\":[{\"text\":\"233fmqgpizm8jrh2vxk991in7\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6eaf6a1-7b29-4fbb-8b83-a1e65066f1c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"eirvt7t494uyczghdc04vucrg5ugoybxpewegp5mg2rpwt7s\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"04b75291-4b79-4d7a-8ca4-db1978316df4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6a324c1-8a5a-4cfa-9e6a-533862e662b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true}}},{\"text\":\"3uambvm9swof9hr3y7749pi4autntep\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d850557a-8762-4f0e-83f5-9aa2f7055164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"otmwbt5v\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"vskv782u8nemhbt2b1qtvfwrlkbcof269jy3bo196hc2tn06hyrlbv7ur4nxpi8cz9fq9jxkr4wnd2kqq4kjkgga6l383he7g2xx2ef84kwzc6m8llzdtn2kryt5w02lyavqgmisckg4adrym2nn270sag5armeqh96f7yo\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c4b13dd0-92e2-4f3d-829c-8da873cbd741\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ght7v27tcglrygkaclzysgbaxi144hh8jxf3hqydef\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"gnmpm7nasubu7yddp1m4huh03gnn3nkhkac4gqjprra828dc8glnri8050gv8mesx3695s17xuwx0iot8o5vr9m15yc3kntfbe9j7emlh3m09k21ph3g2kcb3e8uq1hbc8c1x26ey39n2zugbx6nyqxev6n\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e3a0ca9e-5012-4e53-ba35-95541f13aa56\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ihphgz6yv83pba9p1\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"dvx4puxpyebvybfiqo6kjd9mf9shodaif5mjd1ugigif49aao2tlxyxco9y26icmlvawdib57rd14vb1y8k8bjy8cadjqje8af3df31\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"43e2f4a9-90b8-4236-89b7-88e535994958\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ob4ox7\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"txesouyedttjc1yetq194idwj7cawd4m2rax\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b280221-b224-42ea-9886-b3cbded177c6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"c8fc5ozlovta0i\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"wj733jwwiayssew1vmgj8nyfajf81smy2dygnu2on5kayxjqyx3mh0z9cplu9ncsxnlx6jxqvpmy9bh69qe3y7j1dvnzuyntmiiupfjyjnxiktwbxn7ssjs0yrikdcj7kgyu1qmga3kgoyvpc3qhs1c5j0zluq9pjiq97pkyihb9sv17w8x2fbmfnwmqn7cbznvbxtoor93p03zgso2oligl5li1950rz08a76jvggrgsrm390lrj0y3yg4lzwc7ih1umua269mlyc\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"46fe1053-e808-450f-93f8-339d880305ec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"t3prip22zsgl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"jl3a524jmrqn1c7v1a3f8lf9hsgjqowlg69rzqu59pwbcmppjm6cdeacq12unx88zkfdoa9\",{\"text\":\"dgzm1x1fa8\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c711af4-4235-4c96-a8bc-e52a4f69520e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\",\"italic\":false}}},{\"text\":\"bt90rcjgdlfs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"c6pcxykpypaiziuik60ro4zydrui3d7fw7u35hfzwkmgc3xlx9rap75lqbvyxux3nflvq8rw10i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e10bf17f-54e2-4da4-bb0f-e86c43b1b457\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\",\"italic\":false}}},{\"text\":\"89kht\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"qre9lu7yuidxl2utt7gja7bpehh8w7ksuoz973t21qrche3hgd3ikm2i99cyrioii10ngaewrgokw4od81ijr0pqkgfz154g16wn9lsig9xa5iy2z57y69xf2mzsoagp89ezx25bbwwvxgr608cg09ahn88\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a2986933-f73e-4d8d-bc6f-7703052ae4ae\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\",\"italic\":false}}},{\"text\":\"hlyik2q4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wnqodpqj9414zci6ozq4kff4nzxbfc4lto6c097msfwic7lhz4f3gieojf6db20go28rxukzgl2vlndyler0xa25cp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e4f1ad6d-e3ef-4893-8d54-d4aa2c7e6a97\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\",\"italic\":false}}},{\"text\":\"4fkesg\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"jj02qc5w997fsrdk87z384cs4wgbafb9jsjv0ug82j2zcfwmivfdgx5gd65s3szg34rihu1cm2o6jrw8o2wzmgm8ou7jqn44ur1zkl1walxkynkk6ulel7rzgyuyas3ztnhqjetcfsfrpk7o59aexjuooevx0rk9nopxpqye2w4i6k4qs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4ab6ce40-8d63-4f0c-a385-72c7ad83cbc3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\",\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3086d4e5-4ac3-4dd8-be73-f9edcc7ed696\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true}}},{\"text\":\"ok74yg3wxigzu3w3y48cpv9dkopd22leuh\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b77fa56f-3b76-49fc-a32d-f1d2a33d96d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"7awwk3ad3gbszcgz7s5nmu4ksaylh5fw57i3jt7fc7ck6net67gq5xzv8a5ns3nnqhztscijdeduwrzn6ubnb0y72zayifncudr8k9sc66re2x2yymbojhiwceeujkmj6fxf0v3n2f31iydajf3fwyqb8sgktvt7eer59f\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7744247b-7172-416c-91cb-3c352ccc461b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList48\"}}},{\"text\":\"isdaro8m5psa5cf9zg9npa5it51dyb3lvhs727w7pnfqh2ictgrcih\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b61e95db-bd39-483b-afa1-f45e3a551c6b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"17amwdc\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"meb4ic8p5c5mpku5l8ep351rcph00ibt6dw2mm44o8xq8apmzmub9ms14\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40839f26-ab3d-4452-9e85-0aee29a201b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-24\"}}},{\"text\":\"r9om16kcvoiinzx3\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"qcularmxmq087sa24bybf0geu0h7v4pg0y1\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"70e780a6-f70b-4a5c-8a85-f45f80994a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-24\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":975,\"totalLength\":1932,\"totalSegmentCount\":51}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":975,\"referenceSequenceNumber\":-1,\"sequenceNumber\":978,\"timestamp\":1565283345226,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,953 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":510,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"acabd2a1-5ae1-445f-8638-e0d98e42740e\",{\"client\":{\"user\":{\"id\":\"nc6yj4ykn@example.com}\",\"name\":\"6smrk54ra7rpjvc\",\"email\":\"7nmgdr5pd@example.com}\"}},\"sequenceNumber\":110}],[\"6bc18dc7-27f2-44cf-90e7-073362579793\",{\"client\":{\"user\":{\"id\":\"p57p633o5@example.com}\",\"name\":\"owoapm02idp3k8k\",\"email\":\"bkyh5ww8d@example.com}\"}},\"sequenceNumber\":142}],[\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",{\"client\":{\"user\":{\"id\":\"jz3xszzr2@example.com}\",\"name\":\"fwd1zaqm5c5h7wj\",\"email\":\"azsjfgwfo@example.com}\"}},\"sequenceNumber\":149}],[\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",{\"client\":{\"user\":{\"id\":\"llz1q0dd6@example.com}\",\"name\":\"b9jmsv5s156n7og\",\"email\":\"to8pxgxpb@example.com}\"}},\"sequenceNumber\":225}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "663b111f-01a9-4a53-b557-a2ef7502ecc0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":120,\"value\":{\"type\":\"Plain\",\"value\":\"acabd2a1-5ae1-445f-8638-e0d98e42740e\"}},\"versions\":[{\"sequenceNumber\":120,\"value\":{\"type\":\"Plain\",\"value\":\"acabd2a1-5ae1-445f-8638-e0d98e42740e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/663b111f-01a9-4a53-b557-a2ef7502ecc0\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3628d460-1875-4be9-a2be-a64320d66221\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fd7a8855-78e2-49bb-9a00-f13f60687268\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1c868c2e-38a9-4c69-bd74-a461e644ecb6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9530f65-4ea9-4c74-8724-b888bd929c65\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/179fb24a-1187-45eb-8330-5c3e3b6b2598\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3628d460-1875-4be9-a2be-a64320d66221",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cbc66874-4f53-40ac-bbab-01cb0a40dfaa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":935,\"refSeqNumber\":21}},\"acabd2a1-5ae1-445f-8638-e0d98e42740e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":108}},\"d2c7aaea-de7f-4971-9a93-6f6fa168dec7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":131}},\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":992,\"refSeqNumber\":988}},\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1121,\"refSeqNumber\":997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fd7a8855-78e2-49bb-9a00-f13f60687268",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "219bc753-71a8-43ee-aed4-8a71ae7eee46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "87d1481d-e476-43ec-8639-a271dafcf616",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b17a1b79-4a9c-4711-a91a-e9b738967d41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f4c3d94a-653d-4bb3-86cf-a0e9db67ab17\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c896c5c1-e463-44ac-ac8f-f8ad8ac218c4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4acc1217-7bad-472d-892c-f691e5e38795\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/031285c0-a9f4-4f3c-b78f-cf6d90cc374c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8204010d-bf9c-4bf6-a9bd-eccdda2d5501\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c9bcf798-0f35-4a67-87be-6dd269749857\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b17a1b79-4a9c-4711-a91a-e9b738967d41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f4c3d94a-653d-4bb3-86cf-a0e9db67ab17",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c896c5c1-e463-44ac-ac8f-f8ad8ac218c4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4acc1217-7bad-472d-892c-f691e5e38795",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "031285c0-a9f4-4f3c-b78f-cf6d90cc374c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8204010d-bf9c-4bf6-a9bd-eccdda2d5501",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c9bcf798-0f35-4a67-87be-6dd269749857",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9530f65-4ea9-4c74-8724-b888bd929c65",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6863402-5e81-45ac-83f3-03410e959604\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/115d8655-0c3c-43d2-a15f-52d77fd3c918\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a9534c76-92ce-41d2-8682-586a4c1122ba\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ccb9d801-45c5-4f53-8a55-841ae9ffc63f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a0284d80-3d0b-4f31-8e8b-1714c0aa1076\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e3aaafa2-00ea-4b63-a6c8-79605b625b08\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0e81569f-f59f-4102-b69e-8bfcf5e2301e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6863402-5e81-45ac-83f3-03410e959604",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "115d8655-0c3c-43d2-a15f-52d77fd3c918",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a9534c76-92ce-41d2-8682-586a4c1122ba",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ccb9d801-45c5-4f53-8a55-841ae9ffc63f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0284d80-3d0b-4f31-8e8b-1714c0aa1076",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e3aaafa2-00ea-4b63-a6c8-79605b625b08",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0e81569f-f59f-4102-b69e-8bfcf5e2301e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "179fb24a-1187-45eb-8330-5c3e3b6b2598",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-83\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/90e448c6-8d29-4e56-bf6d-126423b700a5\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "90e448c6-8d29-4e56-bf6d-126423b700a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-83\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1c868c2e-38a9-4c69-bd74-a461e644ecb6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/219bc753-71a8-43ee-aed4-8a71ae7eee46\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":22,\"chunkLengthChars\":1008,\"totalLengthChars\":1008,\"totalSegmentCount\":22,\"chunkSequenceNumber\":510,\"segmentTexts\":[{\"text\":\"56d6lfl9inhjepv3nb3u2fkfxe793c0q3dmsmlr8tt9i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"137f3478-5316-4a64-ab70-9629362cdfdd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"ko8y4ctklqjvvptx6533qp55hyblbabgk8equqiyr0nbw8cj98swmxalqjq3yg8zvv0w9ipl4se4vrt1mz2btwf4nco2t43qxwy5q89a2tcmnwmysyysjia5uiawkjazr8nf2pyutxbnl54r1hzmh3bdgxp0lzsffbc25ox4evn2luitx641s7o652di2meyqqg62wtl4gp8rec4p0l9ly7p7u2grfglmgyeaf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ce3a2e-0735-4dce-9c9c-d4df7e829d9b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},\"ovgx\",{\"text\":\"jcbv8ieba\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b477c23-11b7-417e-af03-6b761045b887\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"hqxdz3p2azke7mfzwwlkx7gjbycjzv4jrff42jsimic5wy0gf3o9j87pznl12v13ftchbkyxccumwsea4910ovxp4imprh1p3n46nq7efs104mglrx9esvsvkc1igw3sooqaogvnz1wqehizthcal9gyqgqmzw3jkr6s9yykl1cfb5gsp2vj5geg2g2vfdw5iebm9ovj8cz9ql5dqjqhgef1georplgkelyl6ok8zhofv00\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ed1d89a5-3517-418f-aadf-98e4acae534b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s669uj7vdvqc5jh9pv6zud6rgojr1ltc3jkv5idju\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5ef0ec0a-9cf8-48e1-82a7-ff05413ed832\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"b8u5md3rkmqf7je9g2781ko5yqdeixkbswu216hdoi9qqoy7y54xwwl9yqlldqzpkpbfgfz11v6un6rxz39tk64wrn4i7h5onjkhcr76czzr5mzh5n70i3rea455hb69hstwf8ctkrkwkesxiefk1tp4numn9nrrhpseikz4b6is5hm48rapg7w6vizqaaf1szz3vul5mhrvkmsm87pdtnil9j73dvvsc0hlibb8dn2rqhxgwegb6kp7djqwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab97d858-8e01-458b-a8b0-ca869a7cc443\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},\"212\",{\"text\":\"zjrb1nnziirdze5brwuvile8xuq49yl7pjq4ql8fs4tomkdu1p5npp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d70c410-3762-4dca-a4c7-81cdb3b3a9c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"ykyzig02n5s1gwitk4eo4wcxdutq74iai101p1dj350kv473d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7601f953-36bf-4c7f-b1b7-bffbd83612b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"2np78oiuk75b24uzlmw1rwmdzsf1b98vyx9say9bb5a5ubiztqo21r6syth0n2vikvr8hxc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4128c8d0-bd44-4927-9192-ee97b90542ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d6b8e11-9546-4f46-a25d-0b8244fe5922\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":510,\"totalLength\":1008,\"totalSegmentCount\":22}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":214,\"contents\":{\"pos1\":884,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":512,\"sequenceNumber\":513,\"timestamp\":1564070415648,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":216,\"contents\":{\"pos1\":885,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":514,\"sequenceNumber\":515,\"timestamp\":1564070415842,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":886,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":516,\"sequenceNumber\":517,\"timestamp\":1564070415920,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":887,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":518,\"sequenceNumber\":519,\"timestamp\":1564070416014,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":223,\"contents\":{\"pos1\":888,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":520,\"sequenceNumber\":521,\"timestamp\":1564070416608,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":225,\"contents\":{\"pos1\":889,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":522,\"sequenceNumber\":523,\"timestamp\":1564070416702,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":227,\"contents\":{\"pos1\":890,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":524,\"sequenceNumber\":525,\"timestamp\":1564070416827,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":230,\"contents\":{\"pos1\":891,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":526,\"sequenceNumber\":527,\"timestamp\":1564070417406,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":232,\"contents\":{\"pos1\":892,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":528,\"sequenceNumber\":529,\"timestamp\":1564070417547,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":234,\"contents\":{\"pos1\":893,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":530,\"sequenceNumber\":531,\"timestamp\":1564070417703,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":236,\"contents\":{\"pos1\":894,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":532,\"sequenceNumber\":533,\"timestamp\":1564070417782,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":238,\"contents\":{\"pos1\":895,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":534,\"sequenceNumber\":535,\"timestamp\":1564070417876,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":240,\"contents\":{\"pos1\":896,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":536,\"sequenceNumber\":537,\"timestamp\":1564070418095,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":242,\"contents\":{\"pos1\":897,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":538,\"sequenceNumber\":539,\"timestamp\":1564070418298,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":244,\"contents\":{\"pos1\":898,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":540,\"sequenceNumber\":541,\"timestamp\":1564070418376,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":899,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":542,\"sequenceNumber\":543,\"timestamp\":1564070418657,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":900,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":544,\"sequenceNumber\":545,\"timestamp\":1564070418720,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":251,\"contents\":{\"pos1\":901,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":546,\"sequenceNumber\":547,\"timestamp\":1564070418876,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":902,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":548,\"sequenceNumber\":549,\"timestamp\":1564070418938,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":255,\"contents\":{\"pos1\":903,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":550,\"sequenceNumber\":551,\"timestamp\":1564070419017,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":259,\"contents\":{\"pos1\":903,\"pos2\":904,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":553,\"sequenceNumber\":554,\"timestamp\":1564070419447,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":261,\"contents\":{\"pos1\":902,\"pos2\":903,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":555,\"sequenceNumber\":556,\"timestamp\":1564070419619,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":263,\"contents\":{\"pos1\":901,\"pos2\":902,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":557,\"sequenceNumber\":558,\"timestamp\":1564070419775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":264,\"contents\":{\"pos1\":901,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":558,\"sequenceNumber\":559,\"timestamp\":1564070419869,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":266,\"contents\":{\"pos1\":902,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":560,\"sequenceNumber\":561,\"timestamp\":1564070419994,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":268,\"contents\":{\"pos1\":903,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":562,\"sequenceNumber\":563,\"timestamp\":1564070420197,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":270,\"contents\":{\"pos1\":904,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":564,\"sequenceNumber\":565,\"timestamp\":1564070420337,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":272,\"contents\":{\"pos1\":905,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":566,\"sequenceNumber\":567,\"timestamp\":1564070420431,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":274,\"contents\":{\"pos1\":906,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":568,\"sequenceNumber\":569,\"timestamp\":1564070420603,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":276,\"contents\":{\"pos1\":907,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":570,\"sequenceNumber\":571,\"timestamp\":1564070420681,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":278,\"contents\":{\"pos1\":908,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":572,\"sequenceNumber\":573,\"timestamp\":1564070420869,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":909,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":574,\"sequenceNumber\":575,\"timestamp\":1564070420962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":282,\"contents\":{\"pos1\":910,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":576,\"sequenceNumber\":577,\"timestamp\":1564070421041,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":911,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":578,\"sequenceNumber\":579,\"timestamp\":1564070421134,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":279,\"contents\":{\"pos1\":963,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":580,\"sequenceNumber\":581,\"timestamp\":1564070421150,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":912,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":582,\"sequenceNumber\":583,\"timestamp\":1564070421306,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":281,\"contents\":{\"pos1\":964,\"pos2\":965,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}},\"type\":2},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":584,\"sequenceNumber\":585,\"timestamp\":1564070421337,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":913,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":585,\"sequenceNumber\":586,\"timestamp\":1564070421369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":914,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":587,\"sequenceNumber\":588,\"timestamp\":1564070421509,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":915,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":589,\"sequenceNumber\":590,\"timestamp\":1564070421666,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":916,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":591,\"sequenceNumber\":592,\"timestamp\":1564070421775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":296,\"contents\":{\"pos1\":917,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":593,\"sequenceNumber\":594,\"timestamp\":1564070421916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":918,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":595,\"sequenceNumber\":596,\"timestamp\":1564070421994,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":300,\"contents\":{\"pos1\":919,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":597,\"sequenceNumber\":598,\"timestamp\":1564070422197,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":971,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":599,\"sequenceNumber\":600,\"timestamp\":1564070422291,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":972,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":601,\"sequenceNumber\":602,\"timestamp\":1564070422432,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":920,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":603,\"sequenceNumber\":604,\"timestamp\":1564070422463,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":974,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":605,\"sequenceNumber\":606,\"timestamp\":1564070422557,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":975,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":607,\"sequenceNumber\":608,\"timestamp\":1564070422666,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":976,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":609,\"sequenceNumber\":610,\"timestamp\":1564070422760,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":977,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":611,\"sequenceNumber\":612,\"timestamp\":1564070422853,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":296,\"contents\":{\"pos1\":978,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":613,\"sequenceNumber\":614,\"timestamp\":1564070423010,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":979,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":615,\"sequenceNumber\":616,\"timestamp\":1564070423166,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":300,\"contents\":{\"pos1\":980,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":617,\"sequenceNumber\":618,\"timestamp\":1564070423369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":981,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":619,\"sequenceNumber\":620,\"timestamp\":1564070423447,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":304,\"contents\":{\"pos1\":982,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":621,\"sequenceNumber\":622,\"timestamp\":1564070423525,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":306,\"contents\":{\"pos1\":983,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":623,\"sequenceNumber\":624,\"timestamp\":1564070423650,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":308,\"contents\":{\"pos1\":984,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":625,\"sequenceNumber\":626,\"timestamp\":1564070423775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":310,\"contents\":{\"pos1\":985,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":627,\"sequenceNumber\":628,\"timestamp\":1564070423869,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":312,\"contents\":{\"pos1\":986,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":629,\"sequenceNumber\":630,\"timestamp\":1564070423978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":307,\"contents\":{\"pos1\":920,\"pos2\":921,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":632,\"sequenceNumber\":633,\"timestamp\":1564070423978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":314,\"contents\":{\"pos1\":986,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":633,\"sequenceNumber\":634,\"timestamp\":1564070424150,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":316,\"contents\":{\"pos1\":987,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":635,\"sequenceNumber\":636,\"timestamp\":1564070424291,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":318,\"contents\":{\"pos1\":988,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":637,\"sequenceNumber\":638,\"timestamp\":1564070424338,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":309,\"contents\":{\"pos1\":919,\"pos2\":920,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":640,\"sequenceNumber\":641,\"timestamp\":1564070424478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":320,\"contents\":{\"pos1\":988,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":641,\"sequenceNumber\":642,\"timestamp\":1564070424494,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":311,\"contents\":{\"pos1\":918,\"pos2\":919,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":644,\"sequenceNumber\":645,\"timestamp\":1564070424510,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":313,\"contents\":{\"pos1\":917,\"pos2\":918,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":646,\"sequenceNumber\":647,\"timestamp\":1564070424541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":322,\"contents\":{\"pos1\":987,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":647,\"sequenceNumber\":648,\"timestamp\":1564070424572,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":315,\"contents\":{\"pos1\":916,\"pos2\":917,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":650,\"sequenceNumber\":651,\"timestamp\":1564070424588,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":317,\"contents\":{\"pos1\":915,\"pos2\":916,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":652,\"sequenceNumber\":653,\"timestamp\":1564070424619,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":319,\"contents\":{\"pos1\":914,\"pos2\":915,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":654,\"sequenceNumber\":655,\"timestamp\":1564070424650,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":321,\"contents\":{\"pos1\":913,\"pos2\":914,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":656,\"sequenceNumber\":657,\"timestamp\":1564070424682,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":324,\"contents\":{\"pos1\":984,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":657,\"sequenceNumber\":658,\"timestamp\":1564070424697,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":323,\"contents\":{\"pos1\":912,\"pos2\":913,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":660,\"sequenceNumber\":661,\"timestamp\":1564070424713,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":325,\"contents\":{\"pos1\":911,\"pos2\":912,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":662,\"sequenceNumber\":663,\"timestamp\":1564070424744,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":327,\"contents\":{\"pos1\":910,\"pos2\":911,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":664,\"sequenceNumber\":665,\"timestamp\":1564070424775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":329,\"contents\":{\"pos1\":909,\"pos2\":910,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":666,\"sequenceNumber\":667,\"timestamp\":1564070424807,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":326,\"contents\":{\"pos1\":981,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":667,\"sequenceNumber\":668,\"timestamp\":1564070424807,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":331,\"contents\":{\"pos1\":908,\"pos2\":909,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":670,\"sequenceNumber\":671,\"timestamp\":1564070424838,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":333,\"contents\":{\"pos1\":907,\"pos2\":908,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":672,\"sequenceNumber\":673,\"timestamp\":1564070424869,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":335,\"contents\":{\"pos1\":906,\"pos2\":907,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":674,\"sequenceNumber\":675,\"timestamp\":1564070424916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":328,\"contents\":{\"pos1\":979,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":675,\"sequenceNumber\":676,\"timestamp\":1564070424916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":337,\"contents\":{\"pos1\":905,\"pos2\":906,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":678,\"sequenceNumber\":679,\"timestamp\":1564070424947,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":339,\"contents\":{\"pos1\":904,\"pos2\":905,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":680,\"sequenceNumber\":681,\"timestamp\":1564070424978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":341,\"contents\":{\"pos1\":903,\"pos2\":904,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":682,\"sequenceNumber\":683,\"timestamp\":1564070425010,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":343,\"contents\":{\"pos1\":902,\"pos2\":903,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":684,\"sequenceNumber\":685,\"timestamp\":1564070425041,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":330,\"contents\":{\"pos1\":976,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":685,\"sequenceNumber\":686,\"timestamp\":1564070425057,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":345,\"contents\":{\"pos1\":901,\"pos2\":902,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":688,\"sequenceNumber\":689,\"timestamp\":1564070425072,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":347,\"contents\":{\"pos1\":900,\"pos2\":901,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":690,\"sequenceNumber\":691,\"timestamp\":1564070425103,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":332,\"contents\":{\"pos1\":975,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":691,\"sequenceNumber\":692,\"timestamp\":1564070425103,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":349,\"contents\":{\"pos1\":899,\"pos2\":900,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":694,\"sequenceNumber\":695,\"timestamp\":1564070425135,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":351,\"contents\":{\"pos1\":898,\"pos2\":899,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":696,\"sequenceNumber\":697,\"timestamp\":1564070425182,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":353,\"contents\":{\"pos1\":897,\"pos2\":898,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":698,\"sequenceNumber\":699,\"timestamp\":1564070425213,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":355,\"contents\":{\"pos1\":896,\"pos2\":897,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":700,\"sequenceNumber\":701,\"timestamp\":1564070425244,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":357,\"contents\":{\"pos1\":895,\"pos2\":896,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":702,\"sequenceNumber\":703,\"timestamp\":1564070425277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":359,\"contents\":{\"pos1\":894,\"pos2\":895,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":704,\"sequenceNumber\":705,\"timestamp\":1564070425307,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":361,\"contents\":{\"pos1\":893,\"pos2\":894,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":706,\"sequenceNumber\":707,\"timestamp\":1564070425338,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":363,\"contents\":{\"pos1\":892,\"pos2\":893,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":708,\"sequenceNumber\":709,\"timestamp\":1564070425369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":365,\"contents\":{\"pos1\":891,\"pos2\":892,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":710,\"sequenceNumber\":711,\"timestamp\":1564070425400,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":367,\"contents\":{\"pos1\":890,\"pos2\":891,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":712,\"sequenceNumber\":713,\"timestamp\":1564070425432,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":369,\"contents\":{\"pos1\":889,\"pos2\":890,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":714,\"sequenceNumber\":715,\"timestamp\":1564070425478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":371,\"contents\":{\"pos1\":888,\"pos2\":889,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":716,\"sequenceNumber\":717,\"timestamp\":1564070425510,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":373,\"contents\":{\"pos1\":887,\"pos2\":888,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":718,\"sequenceNumber\":719,\"timestamp\":1564070425541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":334,\"contents\":{\"pos1\":963,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":719,\"sequenceNumber\":720,\"timestamp\":1564070425541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":375,\"contents\":{\"pos1\":886,\"pos2\":887,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":722,\"sequenceNumber\":723,\"timestamp\":1564070425572,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":377,\"contents\":{\"pos1\":885,\"pos2\":886,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":724,\"sequenceNumber\":725,\"timestamp\":1564070425603,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":336,\"contents\":{\"pos1\":962,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":725,\"sequenceNumber\":726,\"timestamp\":1564070425650,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":338,\"contents\":{\"pos1\":963,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":727,\"sequenceNumber\":728,\"timestamp\":1564070425775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":379,\"contents\":{\"pos1\":884,\"pos2\":885,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":730,\"sequenceNumber\":731,\"timestamp\":1564070425791,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":342,\"contents\":{\"pos1\":962,\"pos2\":963,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":732,\"sequenceNumber\":733,\"timestamp\":1564070426182,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":344,\"contents\":{\"pos1\":961,\"pos2\":962,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":734,\"sequenceNumber\":735,\"timestamp\":1564070426307,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":346,\"contents\":{\"pos1\":960,\"pos2\":961,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":736,\"sequenceNumber\":737,\"timestamp\":1564070426416,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":347,\"contents\":{\"pos1\":960,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":737,\"sequenceNumber\":738,\"timestamp\":1564070426542,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":349,\"contents\":{\"pos1\":961,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":739,\"sequenceNumber\":740,\"timestamp\":1564070426620,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":351,\"contents\":{\"pos1\":962,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":741,\"sequenceNumber\":742,\"timestamp\":1564070426714,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":354,\"contents\":{\"pos1\":963,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":743,\"sequenceNumber\":744,\"timestamp\":1564070426980,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":356,\"contents\":{\"pos1\":964,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":745,\"sequenceNumber\":746,\"timestamp\":1564070427027,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":358,\"contents\":{\"pos1\":965,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":747,\"sequenceNumber\":748,\"timestamp\":1564070427183,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":360,\"contents\":{\"pos1\":966,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":749,\"sequenceNumber\":750,\"timestamp\":1564070427292,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":362,\"contents\":{\"pos1\":967,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":751,\"sequenceNumber\":752,\"timestamp\":1564070427371,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":365,\"contents\":{\"pos1\":968,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":753,\"sequenceNumber\":754,\"timestamp\":1564070427840,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":367,\"contents\":{\"pos1\":969,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":755,\"sequenceNumber\":756,\"timestamp\":1564070427980,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":369,\"contents\":{\"pos1\":970,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":757,\"sequenceNumber\":758,\"timestamp\":1564070428105,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":371,\"contents\":{\"pos1\":971,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":759,\"sequenceNumber\":760,\"timestamp\":1564070428199,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":373,\"contents\":{\"pos1\":972,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":761,\"sequenceNumber\":762,\"timestamp\":1564070428293,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":375,\"contents\":{\"pos1\":973,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":763,\"sequenceNumber\":764,\"timestamp\":1564070428387,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":377,\"contents\":{\"pos1\":974,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":765,\"sequenceNumber\":766,\"timestamp\":1564070428496,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":379,\"contents\":{\"pos1\":975,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":767,\"sequenceNumber\":768,\"timestamp\":1564070428590,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":381,\"contents\":{\"pos1\":976,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":769,\"sequenceNumber\":770,\"timestamp\":1564070428746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":385,\"contents\":{\"pos1\":976,\"pos2\":977,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":772,\"sequenceNumber\":773,\"timestamp\":1564070429044,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":387,\"contents\":{\"pos1\":975,\"pos2\":976,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":774,\"sequenceNumber\":775,\"timestamp\":1564070429154,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":388,\"contents\":{\"pos1\":975,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":775,\"sequenceNumber\":776,\"timestamp\":1564070429358,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":390,\"contents\":{\"pos1\":976,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":777,\"sequenceNumber\":778,\"timestamp\":1564070429467,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":392,\"contents\":{\"pos1\":977,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":779,\"sequenceNumber\":780,\"timestamp\":1564070429655,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":394,\"contents\":{\"pos1\":978,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":781,\"sequenceNumber\":782,\"timestamp\":1564070429733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":396,\"contents\":{\"pos1\":979,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":783,\"sequenceNumber\":784,\"timestamp\":1564070429842,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":398,\"contents\":{\"pos1\":980,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":785,\"sequenceNumber\":786,\"timestamp\":1564070429905,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":400,\"contents\":{\"pos1\":981,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":787,\"sequenceNumber\":788,\"timestamp\":1564070430061,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":402,\"contents\":{\"pos1\":982,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":789,\"sequenceNumber\":790,\"timestamp\":1564070430155,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":404,\"contents\":{\"pos1\":983,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":791,\"sequenceNumber\":792,\"timestamp\":1564070430201,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":407,\"contents\":{\"pos1\":984,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":793,\"sequenceNumber\":794,\"timestamp\":1564070430514,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":409,\"contents\":{\"pos1\":985,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":795,\"sequenceNumber\":796,\"timestamp\":1564070430576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":411,\"contents\":{\"pos1\":986,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":797,\"sequenceNumber\":798,\"timestamp\":1564070430623,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":413,\"contents\":{\"pos1\":987,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":799,\"sequenceNumber\":800,\"timestamp\":1564070430780,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":415,\"contents\":{\"pos1\":988,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":801,\"sequenceNumber\":802,\"timestamp\":1564070430858,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":417,\"contents\":{\"pos1\":989,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":803,\"sequenceNumber\":804,\"timestamp\":1564070431030,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":419,\"contents\":{\"pos1\":990,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":805,\"sequenceNumber\":806,\"timestamp\":1564070431108,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":422,\"contents\":{\"pos1\":991,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":807,\"sequenceNumber\":808,\"timestamp\":1564070431530,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":425,\"contents\":{\"pos1\":992,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":809,\"sequenceNumber\":810,\"timestamp\":1564070431842,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":427,\"contents\":{\"pos1\":993,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":811,\"sequenceNumber\":812,\"timestamp\":1564070431905,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":429,\"contents\":{\"pos1\":994,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":813,\"sequenceNumber\":814,\"timestamp\":1564070432095,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":431,\"contents\":{\"pos1\":995,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":815,\"sequenceNumber\":816,\"timestamp\":1564070432189,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":433,\"contents\":{\"pos1\":996,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":817,\"sequenceNumber\":818,\"timestamp\":1564070432283,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":435,\"contents\":{\"pos1\":997,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":819,\"sequenceNumber\":820,\"timestamp\":1564070432330,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":437,\"contents\":{\"pos1\":998,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":821,\"sequenceNumber\":822,\"timestamp\":1564070432470,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":439,\"contents\":{\"pos1\":999,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":823,\"sequenceNumber\":824,\"timestamp\":1564070432677,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":441,\"contents\":{\"pos1\":1000,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":825,\"sequenceNumber\":826,\"timestamp\":1564070432739,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":445,\"contents\":{\"pos1\":1000,\"pos2\":1001,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":828,\"sequenceNumber\":829,\"timestamp\":1564070433161,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":447,\"contents\":{\"pos1\":999,\"pos2\":1000,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":830,\"sequenceNumber\":831,\"timestamp\":1564070433271,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":452,\"contents\":{\"pos1\":999,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":835,\"sequenceNumber\":836,\"timestamp\":1564070434239,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":454,\"contents\":{\"pos1\":1000,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":838,\"sequenceNumber\":839,\"timestamp\":1564070434380,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":456,\"contents\":{\"pos1\":1001,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":840,\"sequenceNumber\":841,\"timestamp\":1564070434458,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":458,\"contents\":{\"pos1\":1002,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":843,\"sequenceNumber\":844,\"timestamp\":1564070434583,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":460,\"contents\":{\"pos1\":1003,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":845,\"sequenceNumber\":846,\"timestamp\":1564070434693,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":462,\"contents\":{\"pos1\":1004,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":847,\"sequenceNumber\":848,\"timestamp\":1564070434849,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":464,\"contents\":{\"pos1\":1005,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":849,\"sequenceNumber\":850,\"timestamp\":1564070434927,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":466,\"contents\":{\"pos1\":1006,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":851,\"sequenceNumber\":852,\"timestamp\":1564070434989,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":468,\"contents\":{\"pos1\":1007,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":853,\"sequenceNumber\":854,\"timestamp\":1564070435161,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":402,\"contents\":{\"pos1\":288,\"pos2\":289,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":856,\"sequenceNumber\":857,\"timestamp\":1564070435193,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":404,\"contents\":{\"pos1\":287,\"pos2\":288,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":858,\"sequenceNumber\":859,\"timestamp\":1564070435333,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":406,\"contents\":{\"pos1\":287,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":859,\"sequenceNumber\":860,\"timestamp\":1564070435849,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":471,\"contents\":{\"pos1\":1007,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":861,\"sequenceNumber\":862,\"timestamp\":1564070435927,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":408,\"contents\":{\"pos1\":288,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":863,\"sequenceNumber\":864,\"timestamp\":1564070436021,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":410,\"contents\":{\"pos1\":289,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":865,\"sequenceNumber\":866,\"timestamp\":1564070436177,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":412,\"contents\":{\"pos1\":290,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":867,\"sequenceNumber\":868,\"timestamp\":1564070436333,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":475,\"contents\":{\"pos1\":1010,\"pos2\":1011,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":870,\"sequenceNumber\":871,\"timestamp\":1564070436458,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":477,\"contents\":{\"pos1\":1009,\"pos2\":1010,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":872,\"sequenceNumber\":873,\"timestamp\":1564070436583,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":480,\"contents\":{\"pos1\":1008,\"pos2\":1009,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":875,\"sequenceNumber\":876,\"timestamp\":1564070437167,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":481,\"contents\":{\"pos1\":1008,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":877,\"sequenceNumber\":878,\"timestamp\":1564070437431,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":483,\"contents\":{\"pos1\":1009,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":880,\"sequenceNumber\":881,\"timestamp\":1564070437525,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":485,\"contents\":{\"pos1\":1010,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":882,\"sequenceNumber\":883,\"timestamp\":1564070437791,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":488,\"contents\":{\"pos1\":1011,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":884,\"sequenceNumber\":885,\"timestamp\":1564070438072,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":490,\"contents\":{\"pos1\":1012,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":886,\"sequenceNumber\":887,\"timestamp\":1564070438088,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":494,\"contents\":{\"pos1\":1012,\"pos2\":1013,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":889,\"sequenceNumber\":890,\"timestamp\":1564070438525,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":496,\"contents\":{\"pos1\":1011,\"pos2\":1012,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":891,\"sequenceNumber\":892,\"timestamp\":1564070438634,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":498,\"contents\":{\"pos1\":1010,\"pos2\":1011,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":893,\"sequenceNumber\":894,\"timestamp\":1564070438759,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":437,\"contents\":{\"pos1\":1084,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35cbe034-a852-4fe0-8610-0008e52675d7\",\"ItemType\":\"Paragraph\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":907,\"sequenceNumber\":908,\"timestamp\":1564070441214,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":439,\"contents\":{\"pos1\":1085,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16da6f34-e617-4a1f-a048-54979804ea46\",\"ItemType\":\"Paragraph\"}},\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":909,\"sequenceNumber\":910,\"timestamp\":1564070441371,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":442,\"contents\":{\"pos1\":1085,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":911,\"sequenceNumber\":912,\"timestamp\":1564070441714,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":445,\"contents\":{\"pos1\":1086,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":913,\"sequenceNumber\":914,\"timestamp\":1564070441980,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":447,\"contents\":{\"pos1\":1087,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":915,\"sequenceNumber\":916,\"timestamp\":1564070442136,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":449,\"contents\":{\"pos1\":1088,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":917,\"sequenceNumber\":918,\"timestamp\":1564070442199,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":451,\"contents\":{\"pos1\":1089,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":919,\"sequenceNumber\":920,\"timestamp\":1564070442324,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":453,\"contents\":{\"pos1\":1090,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":921,\"sequenceNumber\":922,\"timestamp\":1564070442418,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":456,\"contents\":{\"pos1\":1091,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":923,\"sequenceNumber\":924,\"timestamp\":1564070442777,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":458,\"contents\":{\"pos1\":1092,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":925,\"sequenceNumber\":926,\"timestamp\":1564070442902,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":460,\"contents\":{\"pos1\":1093,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":927,\"sequenceNumber\":928,\"timestamp\":1564070442996,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":462,\"contents\":{\"pos1\":1094,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":929,\"sequenceNumber\":930,\"timestamp\":1564070443152,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":464,\"contents\":{\"pos1\":1095,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":931,\"sequenceNumber\":932,\"timestamp\":1564070443355,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":466,\"contents\":{\"pos1\":1096,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":933,\"sequenceNumber\":934,\"timestamp\":1564070443402,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":468,\"contents\":{\"pos1\":1097,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":935,\"sequenceNumber\":936,\"timestamp\":1564070443464,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":471,\"contents\":{\"pos1\":1098,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":937,\"sequenceNumber\":938,\"timestamp\":1564070443683,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":473,\"contents\":{\"pos1\":1099,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":939,\"sequenceNumber\":940,\"timestamp\":1564070443777,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":476,\"contents\":{\"pos1\":1100,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":941,\"sequenceNumber\":942,\"timestamp\":1564070444886,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":478,\"contents\":{\"pos1\":1101,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":943,\"sequenceNumber\":944,\"timestamp\":1564070445043,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":480,\"contents\":{\"pos1\":1102,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":945,\"sequenceNumber\":946,\"timestamp\":1564070445168,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":482,\"contents\":{\"pos1\":1103,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":947,\"sequenceNumber\":948,\"timestamp\":1564070445324,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":486,\"contents\":{\"pos1\":1103,\"pos2\":1104,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":950,\"sequenceNumber\":951,\"timestamp\":1564070445888,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":488,\"contents\":{\"pos1\":1102,\"pos2\":1103,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":952,\"sequenceNumber\":953,\"timestamp\":1564070446044,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":490,\"contents\":{\"pos1\":1101,\"pos2\":1102,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":954,\"sequenceNumber\":955,\"timestamp\":1564070446200,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":492,\"contents\":{\"pos1\":1100,\"pos2\":1101,\"type\":1},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":956,\"sequenceNumber\":957,\"timestamp\":1564070446341,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":493,\"contents\":{\"pos1\":1100,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":957,\"sequenceNumber\":958,\"timestamp\":1564070446545,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":495,\"contents\":{\"pos1\":1101,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":959,\"sequenceNumber\":960,\"timestamp\":1564070446764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":497,\"contents\":{\"pos1\":1102,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":961,\"sequenceNumber\":962,\"timestamp\":1564070446904,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":499,\"contents\":{\"pos1\":1103,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":963,\"sequenceNumber\":964,\"timestamp\":1564070446982,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":502,\"contents\":{\"pos1\":1104,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":965,\"sequenceNumber\":966,\"timestamp\":1564070447295,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":505,\"contents\":{\"pos1\":1105,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":967,\"sequenceNumber\":968,\"timestamp\":1564070447703,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":507,\"contents\":{\"pos1\":1106,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":969,\"sequenceNumber\":970,\"timestamp\":1564070447782,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":510,\"contents\":{\"pos1\":1107,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":971,\"sequenceNumber\":972,\"timestamp\":1564070448141,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":512,\"contents\":{\"pos1\":1108,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":973,\"sequenceNumber\":974,\"timestamp\":1564070448235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":514,\"contents\":{\"pos1\":1109,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":975,\"sequenceNumber\":976,\"timestamp\":1564070448407,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":516,\"contents\":{\"pos1\":1110,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":977,\"sequenceNumber\":978,\"timestamp\":1564070448485,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":518,\"contents\":{\"pos1\":1111,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":979,\"sequenceNumber\":980,\"timestamp\":1564070448579,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":520,\"contents\":{\"pos1\":1112,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":981,\"sequenceNumber\":982,\"timestamp\":1564070448735,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":522,\"contents\":{\"pos1\":1113,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":983,\"sequenceNumber\":984,\"timestamp\":1564070448813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":524,\"contents\":{\"pos1\":1114,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":985,\"sequenceNumber\":986,\"timestamp\":1564070448891,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":526,\"contents\":{\"pos1\":1115,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":987,\"sequenceNumber\":988,\"timestamp\":1564070448969,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":529,\"contents\":{\"pos1\":1116,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":990,\"sequenceNumber\":991,\"timestamp\":1564070449782,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":531,\"contents\":{\"pos1\":1117,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":992,\"sequenceNumber\":993,\"timestamp\":1564070449891,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":533,\"contents\":{\"pos1\":1118,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":994,\"sequenceNumber\":995,\"timestamp\":1564070450016,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":535,\"contents\":{\"pos1\":1119,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":996,\"sequenceNumber\":997,\"timestamp\":1564070450069,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":537,\"contents\":{\"pos1\":1120,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1564070450251,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":538,\"minimumSequenceNumber\":510,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1564070450251,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,953 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1655,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"acabd2a1-5ae1-445f-8638-e0d98e42740e\",{\"client\":{\"user\":{\"id\":\"nc6yj4ykn@example.com}\",\"name\":\"6smrk54ra7rpjvc\",\"email\":\"7nmgdr5pd@example.com}\"}},\"sequenceNumber\":110}],[\"6bc18dc7-27f2-44cf-90e7-073362579793\",{\"client\":{\"user\":{\"id\":\"p57p633o5@example.com}\",\"name\":\"owoapm02idp3k8k\",\"email\":\"bkyh5ww8d@example.com}\"}},\"sequenceNumber\":142}],[\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",{\"client\":{\"user\":{\"id\":\"jz3xszzr2@example.com}\",\"name\":\"fwd1zaqm5c5h7wj\",\"email\":\"azsjfgwfo@example.com}\"}},\"sequenceNumber\":149}],[\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",{\"client\":{\"user\":{\"id\":\"llz1q0dd6@example.com}\",\"name\":\"b9jmsv5s156n7og\",\"email\":\"to8pxgxpb@example.com}\"}},\"sequenceNumber\":225}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/663b111f-01a9-4a53-b557-a2ef7502ecc0\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "663b111f-01a9-4a53-b557-a2ef7502ecc0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":120,\"value\":{\"type\":\"Plain\",\"value\":\"acabd2a1-5ae1-445f-8638-e0d98e42740e\"}},\"versions\":[{\"sequenceNumber\":120,\"value\":{\"type\":\"Plain\",\"value\":\"acabd2a1-5ae1-445f-8638-e0d98e42740e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3628d460-1875-4be9-a2be-a64320d66221\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fd7a8855-78e2-49bb-9a00-f13f60687268\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1c868c2e-38a9-4c69-bd74-a461e644ecb6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9530f65-4ea9-4c74-8724-b888bd929c65\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/179fb24a-1187-45eb-8330-5c3e3b6b2598\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3628d460-1875-4be9-a2be-a64320d66221",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cbc66874-4f53-40ac-bbab-01cb0a40dfaa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":935,\"refSeqNumber\":21}},\"acabd2a1-5ae1-445f-8638-e0d98e42740e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":108}},\"d2c7aaea-de7f-4971-9a93-6f6fa168dec7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":131}},\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":732,\"refSeqNumber\":1995}},\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1404,\"refSeqNumber\":1985}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fd7a8855-78e2-49bb-9a00-f13f60687268",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "219bc753-71a8-43ee-aed4-8a71ae7eee46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1c868c2e-38a9-4c69-bd74-a461e644ecb6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/219bc753-71a8-43ee-aed4-8a71ae7eee46\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":31,\"chunkLengthChars\":1297,\"totalLengthChars\":1297,\"totalSegmentCount\":31,\"chunkSequenceNumber\":1655,\"segmentTexts\":[{\"text\":\"56d6lfl9inhjepv3nb3u2fkfxe793c0q3dmsmlr8tt9i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"137f3478-5316-4a64-ab70-9629362cdfdd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"ko8y4ctklqjvvptx6533qp55hyblbabgk8equqiyr0nbw8cj98swmxalqjq3yg8zvv0w9ipl4se4vrt1mz2btwf4nco2t43qxwy5q89a2tcmnwmysyysjia5uiawkjazr8nf2pyutxbnl54r1hzmh3bdgxp0lzsffbc25ox4evn2luitx641s7o652di2meyqqg62wtl4gp8rec4p0l9ly7p7u2grfglmgyeaf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ce3a2e-0735-4dce-9c9c-d4df7e829d9b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"bsdw1tcy3c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ovgx\",{\"text\":\"jcbv8iekz0r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b477c23-11b7-417e-af03-6b761045b887\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"hqxdz3p2azke7mfzwwlkx7gjbycjzv4jrff42jsimic5wy0gf3o9j87pznl12v13ftchbkyxccumwsea4910ovxp4imprh1p3n46nq7efs104mglrx9esvsvkc1igw3sooqaogvnz1wqehizthcal9gyqgqmzw3jkr6s9yykl1cfb5gsp2vj5geg2g2vfdw5iebm9ovj8cz9ql5dqjqhgef1georplgkelyl6ok8zhofv00\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ed1d89a5-3517-418f-aadf-98e4acae534b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s5kfs8zh6ip5n9js5zcs0mf0ju1jv4zq5e4ldjdk8kzono3sgv8o59lx1xnvi296nzlke7c4omdrydudh50573rsx2mobsacaz7r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dfbe20a1-22d0-46b4-9f25-f9814aae626f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s669uj7vdvqc5jh9pv6zud6rgojr1ltc3jkv5idju\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5ef0ec0a-9cf8-48e1-82a7-ff05413ed832\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"b8u5md3rkmqf7je9g2781ko5yqdeixkbswu216hdoi9qqoy7y54xwwl9yqlldqzpkpbfgfz11v6un6rxz39tk64wrn4i7h5onjkhcr76czzr5mzh5n70i3rea455hb69hstwf8ctkrkwkesxiefk1tp4numn9nrrhpseikz4b6is5hm48rapg7w6vizqaaf1szz3vul5mhrvkmsm87pdtnil9j73dvvsc0hlibb8dn2rqhxgwegb6kp7djqwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab97d858-8e01-458b-a8b0-ca869a7cc443\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"jqv0rzdac8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"212\",{\"text\":\"zjrb1nnziirdze5brwuvile8xuq49yl7pjq4ql8fs4tomkdu1p5npp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d70c410-3762-4dca-a4c7-81cdb3b3a9c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"ykyzig02n5s1gwitk4eo4wcxdutq74iai101p1dj350kv473d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7601f953-36bf-4c7f-b1b7-bffbd83612b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"8fa6jsw8ct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wxx84rttyaf0pcvm78ule0riz\",{\"text\":\"3gn688gh80pqy2gsmwpkn1gvnr8zk2v45d7r19r19c9dm0wz64rukgydxm1i9gj92exwgidmtbu29r9v2l3t3fajmn1eofrz25tavkgk02xtw6ghx8pekju6h1ddlrw3v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"2np78oiuk75b24uzlmw1rwmdzsf1b98vyx9say9bb5a5ubiztqo21r6syth0n2vikvr8hxc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4128c8d0-bd44-4927-9192-ee97b90542ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d6b8e11-9546-4f46-a25d-0b8244fe5922\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16da6f34-e617-4a1f-a048-54979804ea46\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1655,\"totalLength\":1297,\"totalSegmentCount\":31}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1023,\"contents\":{\"pos1\":642,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1655,\"sequenceNumber\":1656,\"timestamp\":1564070519586,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1025,\"contents\":{\"pos1\":643,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1657,\"sequenceNumber\":1658,\"timestamp\":1564070519773,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1027,\"contents\":{\"pos1\":644,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1659,\"sequenceNumber\":1660,\"timestamp\":1564070519930,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1029,\"contents\":{\"pos1\":645,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1661,\"sequenceNumber\":1662,\"timestamp\":1564070520055,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1031,\"contents\":{\"pos1\":646,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1663,\"sequenceNumber\":1664,\"timestamp\":1564070520133,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1033,\"contents\":{\"pos1\":647,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1665,\"sequenceNumber\":1666,\"timestamp\":1564070520195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1035,\"contents\":{\"pos1\":648,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1667,\"sequenceNumber\":1668,\"timestamp\":1564070520242,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1037,\"contents\":{\"pos1\":649,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1669,\"sequenceNumber\":1670,\"timestamp\":1564070520461,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1041,\"contents\":{\"pos1\":649,\"pos2\":650,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1672,\"sequenceNumber\":1673,\"timestamp\":1564070521195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1042,\"contents\":{\"pos1\":649,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1673,\"sequenceNumber\":1674,\"timestamp\":1564070521305,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1045,\"contents\":{\"pos1\":650,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1675,\"sequenceNumber\":1676,\"timestamp\":1564070521617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1047,\"contents\":{\"pos1\":651,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1677,\"sequenceNumber\":1678,\"timestamp\":1564070521727,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1049,\"contents\":{\"pos1\":652,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1679,\"sequenceNumber\":1680,\"timestamp\":1564070521820,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1051,\"contents\":{\"pos1\":653,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1681,\"sequenceNumber\":1682,\"timestamp\":1564070521852,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1053,\"contents\":{\"pos1\":654,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1683,\"sequenceNumber\":1684,\"timestamp\":1564070521945,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1055,\"contents\":{\"pos1\":655,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1685,\"sequenceNumber\":1686,\"timestamp\":1564070522008,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1057,\"contents\":{\"pos1\":656,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1687,\"sequenceNumber\":1688,\"timestamp\":1564070522070,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1059,\"contents\":{\"pos1\":657,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1689,\"sequenceNumber\":1690,\"timestamp\":1564070522180,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1063,\"contents\":{\"pos1\":657,\"pos2\":658,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1692,\"sequenceNumber\":1693,\"timestamp\":1564070522602,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1065,\"contents\":{\"pos1\":656,\"pos2\":657,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1694,\"sequenceNumber\":1695,\"timestamp\":1564070522711,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1067,\"contents\":{\"pos1\":655,\"pos2\":656,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1696,\"sequenceNumber\":1697,\"timestamp\":1564070522852,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1069,\"contents\":{\"pos1\":654,\"pos2\":655,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1698,\"sequenceNumber\":1699,\"timestamp\":1564070522992,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1071,\"contents\":{\"pos1\":653,\"pos2\":654,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1700,\"sequenceNumber\":1701,\"timestamp\":1564070523117,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1073,\"contents\":{\"pos1\":652,\"pos2\":653,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1702,\"sequenceNumber\":1703,\"timestamp\":1564070523227,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1074,\"contents\":{\"pos1\":652,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1703,\"sequenceNumber\":1704,\"timestamp\":1564070523430,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1076,\"contents\":{\"pos1\":653,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1705,\"sequenceNumber\":1706,\"timestamp\":1564070523492,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1078,\"contents\":{\"pos1\":654,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1707,\"sequenceNumber\":1708,\"timestamp\":1564070523602,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1080,\"contents\":{\"pos1\":655,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1709,\"sequenceNumber\":1710,\"timestamp\":1564070523664,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1082,\"contents\":{\"pos1\":656,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1711,\"sequenceNumber\":1712,\"timestamp\":1564070523727,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1084,\"contents\":{\"pos1\":657,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1713,\"sequenceNumber\":1714,\"timestamp\":1564070523867,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1086,\"contents\":{\"pos1\":658,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1715,\"sequenceNumber\":1716,\"timestamp\":1564070524086,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1089,\"contents\":{\"pos1\":659,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1717,\"sequenceNumber\":1718,\"timestamp\":1564070524492,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1091,\"contents\":{\"pos1\":660,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1719,\"sequenceNumber\":1720,\"timestamp\":1564070524648,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1093,\"contents\":{\"pos1\":661,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1721,\"sequenceNumber\":1722,\"timestamp\":1564070524855,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1095,\"contents\":{\"pos1\":662,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1723,\"sequenceNumber\":1724,\"timestamp\":1564070524964,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1097,\"contents\":{\"pos1\":663,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1725,\"sequenceNumber\":1726,\"timestamp\":1564070524995,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1100,\"contents\":{\"pos1\":664,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1727,\"sequenceNumber\":1728,\"timestamp\":1564070525277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1102,\"contents\":{\"pos1\":665,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1729,\"sequenceNumber\":1730,\"timestamp\":1564070525512,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1104,\"contents\":{\"pos1\":666,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1731,\"sequenceNumber\":1732,\"timestamp\":1564070525621,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1106,\"contents\":{\"pos1\":667,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1734,\"sequenceNumber\":1735,\"timestamp\":1564070525871,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1108,\"contents\":{\"pos1\":668,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1736,\"sequenceNumber\":1737,\"timestamp\":1564070525996,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1110,\"contents\":{\"pos1\":669,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1738,\"sequenceNumber\":1739,\"timestamp\":1564070526105,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1112,\"contents\":{\"pos1\":670,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1740,\"sequenceNumber\":1741,\"timestamp\":1564070526262,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1114,\"contents\":{\"pos1\":671,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1742,\"sequenceNumber\":1743,\"timestamp\":1564070526309,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1116,\"contents\":{\"pos1\":672,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1744,\"sequenceNumber\":1745,\"timestamp\":1564070526419,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":866,\"contents\":{\"pos1\":1327,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1746,\"sequenceNumber\":1747,\"timestamp\":1564070526653,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1119,\"contents\":{\"pos1\":673,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1748,\"sequenceNumber\":1749,\"timestamp\":1564070526856,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":868,\"contents\":{\"pos1\":1329,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1750,\"sequenceNumber\":1751,\"timestamp\":1564070526872,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1121,\"contents\":{\"pos1\":674,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1752,\"sequenceNumber\":1753,\"timestamp\":1564070526965,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1123,\"contents\":{\"pos1\":675,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1754,\"sequenceNumber\":1755,\"timestamp\":1564070527044,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":870,\"contents\":{\"pos1\":1332,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1756,\"sequenceNumber\":1757,\"timestamp\":1564070527075,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":872,\"contents\":{\"pos1\":1333,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1758,\"sequenceNumber\":1759,\"timestamp\":1564070527200,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1125,\"contents\":{\"pos1\":676,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1760,\"sequenceNumber\":1761,\"timestamp\":1564070527215,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1127,\"contents\":{\"pos1\":677,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1762,\"sequenceNumber\":1763,\"timestamp\":1564070527309,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":874,\"contents\":{\"pos1\":1336,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1764,\"sequenceNumber\":1765,\"timestamp\":1564070527387,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1129,\"contents\":{\"pos1\":678,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1766,\"sequenceNumber\":1767,\"timestamp\":1564070527387,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":876,\"contents\":{\"pos1\":1338,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1768,\"sequenceNumber\":1769,\"timestamp\":1564070527497,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":878,\"contents\":{\"pos1\":1339,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1770,\"sequenceNumber\":1771,\"timestamp\":1564070527669,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":880,\"contents\":{\"pos1\":1340,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1772,\"sequenceNumber\":1773,\"timestamp\":1564070527747,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":882,\"contents\":{\"pos1\":1341,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1774,\"sequenceNumber\":1775,\"timestamp\":1564070527825,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1131,\"contents\":{\"pos1\":679,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1776,\"sequenceNumber\":1777,\"timestamp\":1564070527904,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":884,\"contents\":{\"pos1\":1343,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1778,\"sequenceNumber\":1779,\"timestamp\":1564070527935,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1133,\"contents\":{\"pos1\":680,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1780,\"sequenceNumber\":1781,\"timestamp\":1564070527951,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1135,\"contents\":{\"pos1\":681,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1782,\"sequenceNumber\":1783,\"timestamp\":1564070528107,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1137,\"contents\":{\"pos1\":682,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1784,\"sequenceNumber\":1785,\"timestamp\":1564070528170,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1139,\"contents\":{\"pos1\":683,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1786,\"sequenceNumber\":1787,\"timestamp\":1564070528264,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":886,\"contents\":{\"pos1\":1348,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1788,\"sequenceNumber\":1789,\"timestamp\":1564070528435,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1141,\"contents\":{\"pos1\":684,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1790,\"sequenceNumber\":1791,\"timestamp\":1564070528607,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":888,\"contents\":{\"pos1\":1350,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1792,\"sequenceNumber\":1793,\"timestamp\":1564070528686,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1143,\"contents\":{\"pos1\":685,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1794,\"sequenceNumber\":1795,\"timestamp\":1564070528717,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1145,\"contents\":{\"pos1\":686,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1796,\"sequenceNumber\":1797,\"timestamp\":1564070528764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":890,\"contents\":{\"pos1\":1353,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1798,\"sequenceNumber\":1799,\"timestamp\":1564070528764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1147,\"contents\":{\"pos1\":687,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1800,\"sequenceNumber\":1801,\"timestamp\":1564070528857,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1149,\"contents\":{\"pos1\":688,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1802,\"sequenceNumber\":1803,\"timestamp\":1564070528951,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":892,\"contents\":{\"pos1\":1356,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1804,\"sequenceNumber\":1805,\"timestamp\":1564070528982,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1151,\"contents\":{\"pos1\":689,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1806,\"sequenceNumber\":1807,\"timestamp\":1564070528998,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1153,\"contents\":{\"pos1\":690,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1808,\"sequenceNumber\":1809,\"timestamp\":1564070529076,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":894,\"contents\":{\"pos1\":1359,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1810,\"sequenceNumber\":1811,\"timestamp\":1564070529092,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1155,\"contents\":{\"pos1\":691,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1812,\"sequenceNumber\":1813,\"timestamp\":1564070529248,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":896,\"contents\":{\"pos1\":1361,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1814,\"sequenceNumber\":1815,\"timestamp\":1564070529326,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1157,\"contents\":{\"pos1\":692,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1816,\"sequenceNumber\":1817,\"timestamp\":1564070529342,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1159,\"contents\":{\"pos1\":693,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1818,\"sequenceNumber\":1819,\"timestamp\":1564070529342,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1161,\"contents\":{\"pos1\":694,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1820,\"sequenceNumber\":1821,\"timestamp\":1564070529482,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":898,\"contents\":{\"pos1\":1365,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1822,\"sequenceNumber\":1823,\"timestamp\":1564070529498,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":900,\"contents\":{\"pos1\":1366,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1824,\"sequenceNumber\":1825,\"timestamp\":1564070529529,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1163,\"contents\":{\"pos1\":695,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1826,\"sequenceNumber\":1827,\"timestamp\":1564070529545,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":902,\"contents\":{\"pos1\":1368,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1828,\"sequenceNumber\":1829,\"timestamp\":1564070529639,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1165,\"contents\":{\"pos1\":696,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1830,\"sequenceNumber\":1831,\"timestamp\":1564070529748,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1167,\"contents\":{\"pos1\":697,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1832,\"sequenceNumber\":1833,\"timestamp\":1564070529951,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1170,\"contents\":{\"pos1\":697,\"pos2\":698,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1835,\"sequenceNumber\":1836,\"timestamp\":1564070530123,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1172,\"contents\":{\"pos1\":696,\"pos2\":697,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1837,\"sequenceNumber\":1838,\"timestamp\":1564070530264,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1174,\"contents\":{\"pos1\":695,\"pos2\":696,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1839,\"sequenceNumber\":1840,\"timestamp\":1564070530389,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1176,\"contents\":{\"pos1\":694,\"pos2\":695,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1841,\"sequenceNumber\":1842,\"timestamp\":1564070530514,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1178,\"contents\":{\"pos1\":693,\"pos2\":694,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1843,\"sequenceNumber\":1844,\"timestamp\":1564070530654,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1180,\"contents\":{\"pos1\":692,\"pos2\":693,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1845,\"sequenceNumber\":1846,\"timestamp\":1564070530779,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1181,\"contents\":{\"pos1\":692,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1846,\"sequenceNumber\":1847,\"timestamp\":1564070530936,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1183,\"contents\":{\"pos1\":693,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1848,\"sequenceNumber\":1849,\"timestamp\":1564070531029,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1185,\"contents\":{\"pos1\":694,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1850,\"sequenceNumber\":1851,\"timestamp\":1564070531108,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":907,\"contents\":{\"pos1\":1368,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1852,\"sequenceNumber\":1853,\"timestamp\":1564070531139,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1187,\"contents\":{\"pos1\":695,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1854,\"sequenceNumber\":1855,\"timestamp\":1564070531217,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":909,\"contents\":{\"pos1\":1370,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1856,\"sequenceNumber\":1857,\"timestamp\":1564070531279,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1189,\"contents\":{\"pos1\":696,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1858,\"sequenceNumber\":1859,\"timestamp\":1564070531420,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":911,\"contents\":{\"pos1\":1372,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1860,\"sequenceNumber\":1861,\"timestamp\":1564070531451,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1191,\"contents\":{\"pos1\":697,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1862,\"sequenceNumber\":1863,\"timestamp\":1564070531483,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1193,\"contents\":{\"pos1\":698,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1864,\"sequenceNumber\":1865,\"timestamp\":1564070531576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1195,\"contents\":{\"pos1\":699,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1866,\"sequenceNumber\":1867,\"timestamp\":1564070531701,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":913,\"contents\":{\"pos1\":1376,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1868,\"sequenceNumber\":1869,\"timestamp\":1564070531717,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":915,\"contents\":{\"pos1\":1377,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1870,\"sequenceNumber\":1871,\"timestamp\":1564070531795,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1197,\"contents\":{\"pos1\":700,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1872,\"sequenceNumber\":1873,\"timestamp\":1564070531873,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1199,\"contents\":{\"pos1\":701,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1874,\"sequenceNumber\":1875,\"timestamp\":1564070531904,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1201,\"contents\":{\"pos1\":702,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1876,\"sequenceNumber\":1877,\"timestamp\":1564070532029,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1203,\"contents\":{\"pos1\":703,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1878,\"sequenceNumber\":1879,\"timestamp\":1564070532186,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":917,\"contents\":{\"pos1\":1382,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1880,\"sequenceNumber\":1881,\"timestamp\":1564070532264,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1205,\"contents\":{\"pos1\":704,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1882,\"sequenceNumber\":1883,\"timestamp\":1564070532420,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1207,\"contents\":{\"pos1\":705,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1884,\"sequenceNumber\":1885,\"timestamp\":1564070532576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1209,\"contents\":{\"pos1\":706,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1886,\"sequenceNumber\":1887,\"timestamp\":1564070532686,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1211,\"contents\":{\"pos1\":707,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1888,\"sequenceNumber\":1889,\"timestamp\":1564070532764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":920,\"contents\":{\"pos1\":1386,\"pos2\":1387,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1891,\"sequenceNumber\":1892,\"timestamp\":1564070532764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1213,\"contents\":{\"pos1\":708,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1892,\"sequenceNumber\":1893,\"timestamp\":1564070532889,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":922,\"contents\":{\"pos1\":1386,\"pos2\":1387,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1895,\"sequenceNumber\":1896,\"timestamp\":1564070532936,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1215,\"contents\":{\"pos1\":709,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1896,\"sequenceNumber\":1897,\"timestamp\":1564070532936,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":924,\"contents\":{\"pos1\":1386,\"pos2\":1387,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1899,\"sequenceNumber\":1900,\"timestamp\":1564070533063,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1217,\"contents\":{\"pos1\":710,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1900,\"sequenceNumber\":1901,\"timestamp\":1564070533170,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1219,\"contents\":{\"pos1\":711,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1902,\"sequenceNumber\":1903,\"timestamp\":1564070533233,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1221,\"contents\":{\"pos1\":712,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1904,\"sequenceNumber\":1905,\"timestamp\":1564070533358,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":927,\"contents\":{\"pos1\":1388,\"pos2\":1389,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1907,\"sequenceNumber\":1908,\"timestamp\":1564070533561,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":929,\"contents\":{\"pos1\":1387,\"pos2\":1388,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1909,\"sequenceNumber\":1910,\"timestamp\":1564070533592,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1223,\"contents\":{\"pos1\":713,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1910,\"sequenceNumber\":1911,\"timestamp\":1564070533608,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":931,\"contents\":{\"pos1\":1387,\"pos2\":1388,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1913,\"sequenceNumber\":1914,\"timestamp\":1564070533623,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":933,\"contents\":{\"pos1\":1386,\"pos2\":1387,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1915,\"sequenceNumber\":1916,\"timestamp\":1564070533670,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":935,\"contents\":{\"pos1\":1385,\"pos2\":1386,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1917,\"sequenceNumber\":1918,\"timestamp\":1564070533686,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1225,\"contents\":{\"pos1\":714,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1918,\"sequenceNumber\":1919,\"timestamp\":1564070533701,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":937,\"contents\":{\"pos1\":1385,\"pos2\":1386,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1921,\"sequenceNumber\":1922,\"timestamp\":1564070533733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":939,\"contents\":{\"pos1\":1384,\"pos2\":1385,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1923,\"sequenceNumber\":1924,\"timestamp\":1564070533764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":941,\"contents\":{\"pos1\":1383,\"pos2\":1384,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1925,\"sequenceNumber\":1926,\"timestamp\":1564070533795,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":943,\"contents\":{\"pos1\":1382,\"pos2\":1383,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1927,\"sequenceNumber\":1928,\"timestamp\":1564070533826,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1227,\"contents\":{\"pos1\":715,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1928,\"sequenceNumber\":1929,\"timestamp\":1564070533842,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":945,\"contents\":{\"pos1\":1382,\"pos2\":1383,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1931,\"sequenceNumber\":1932,\"timestamp\":1564070533858,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1229,\"contents\":{\"pos1\":716,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1932,\"sequenceNumber\":1933,\"timestamp\":1564070533920,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1231,\"contents\":{\"pos1\":717,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1934,\"sequenceNumber\":1935,\"timestamp\":1564070534029,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":947,\"contents\":{\"pos1\":1383,\"pos2\":1384,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1937,\"sequenceNumber\":1938,\"timestamp\":1564070534076,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":949,\"contents\":{\"pos1\":1382,\"pos2\":1383,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1939,\"sequenceNumber\":1940,\"timestamp\":1564070534279,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1234,\"contents\":{\"pos1\":718,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1940,\"sequenceNumber\":1941,\"timestamp\":1564070534389,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1236,\"contents\":{\"pos1\":719,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1942,\"sequenceNumber\":1943,\"timestamp\":1564070534576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1238,\"contents\":{\"pos1\":720,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1944,\"sequenceNumber\":1945,\"timestamp\":1564070534701,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1240,\"contents\":{\"pos1\":721,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1946,\"sequenceNumber\":1947,\"timestamp\":1564070534811,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":951,\"contents\":{\"pos1\":1386,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1948,\"sequenceNumber\":1949,\"timestamp\":1564070534889,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1242,\"contents\":{\"pos1\":722,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1950,\"sequenceNumber\":1951,\"timestamp\":1564070534936,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":953,\"contents\":{\"pos1\":1388,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1952,\"sequenceNumber\":1953,\"timestamp\":1564070534983,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1244,\"contents\":{\"pos1\":723,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1954,\"sequenceNumber\":1955,\"timestamp\":1564070535076,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1246,\"contents\":{\"pos1\":724,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1956,\"sequenceNumber\":1957,\"timestamp\":1564070535123,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":955,\"contents\":{\"pos1\":1391,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1958,\"sequenceNumber\":1959,\"timestamp\":1564070535170,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":957,\"contents\":{\"pos1\":1392,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1960,\"sequenceNumber\":1961,\"timestamp\":1564070535233,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1248,\"contents\":{\"pos1\":725,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1962,\"sequenceNumber\":1963,\"timestamp\":1564070535248,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":959,\"contents\":{\"pos1\":1394,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1964,\"sequenceNumber\":1965,\"timestamp\":1564070535373,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":961,\"contents\":{\"pos1\":1395,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1966,\"sequenceNumber\":1967,\"timestamp\":1564070535451,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":963,\"contents\":{\"pos1\":1396,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1968,\"sequenceNumber\":1969,\"timestamp\":1564070535498,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":965,\"contents\":{\"pos1\":1397,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1970,\"sequenceNumber\":1971,\"timestamp\":1564070535623,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":969,\"contents\":{\"pos1\":1397,\"pos2\":1398,\"type\":1},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1973,\"sequenceNumber\":1974,\"timestamp\":1564070535983,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":970,\"contents\":{\"pos1\":1397,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1974,\"sequenceNumber\":1975,\"timestamp\":1564070536077,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":972,\"contents\":{\"pos1\":1398,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1976,\"sequenceNumber\":1977,\"timestamp\":1564070536186,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":974,\"contents\":{\"pos1\":1399,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1978,\"sequenceNumber\":1979,\"timestamp\":1564070536374,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":976,\"contents\":{\"pos1\":1400,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1980,\"sequenceNumber\":1981,\"timestamp\":1564070536436,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":978,\"contents\":{\"pos1\":1401,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1982,\"sequenceNumber\":1983,\"timestamp\":1564070536592,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":980,\"contents\":{\"pos1\":1402,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1984,\"sequenceNumber\":1985,\"timestamp\":1564070536670,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\",\"clientSequenceNumber\":982,\"contents\":{\"pos1\":1403,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1986,\"sequenceNumber\":1987,\"timestamp\":1564070536764,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1253,\"contents\":{\"pos1\":726,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1988,\"sequenceNumber\":1989,\"timestamp\":1564070536859,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1255,\"contents\":{\"pos1\":727,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1990,\"sequenceNumber\":1991,\"timestamp\":1564070536968,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1257,\"contents\":{\"pos1\":728,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1992,\"sequenceNumber\":1993,\"timestamp\":1564070537015,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1259,\"contents\":{\"pos1\":729,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1994,\"sequenceNumber\":1995,\"timestamp\":1564070537140,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1261,\"contents\":{\"pos1\":730,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1996,\"sequenceNumber\":1997,\"timestamp\":1564070537233,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1263,\"contents\":{\"pos1\":731,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1998,\"sequenceNumber\":1999,\"timestamp\":1564070537280,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "87d1481d-e476-43ec-8639-a271dafcf616",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b17a1b79-4a9c-4711-a91a-e9b738967d41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f4c3d94a-653d-4bb3-86cf-a0e9db67ab17\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c896c5c1-e463-44ac-ac8f-f8ad8ac218c4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4acc1217-7bad-472d-892c-f691e5e38795\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/031285c0-a9f4-4f3c-b78f-cf6d90cc374c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8204010d-bf9c-4bf6-a9bd-eccdda2d5501\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c9bcf798-0f35-4a67-87be-6dd269749857\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b17a1b79-4a9c-4711-a91a-e9b738967d41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f4c3d94a-653d-4bb3-86cf-a0e9db67ab17",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c896c5c1-e463-44ac-ac8f-f8ad8ac218c4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4acc1217-7bad-472d-892c-f691e5e38795",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "031285c0-a9f4-4f3c-b78f-cf6d90cc374c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8204010d-bf9c-4bf6-a9bd-eccdda2d5501",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c9bcf798-0f35-4a67-87be-6dd269749857",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9530f65-4ea9-4c74-8724-b888bd929c65",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6863402-5e81-45ac-83f3-03410e959604\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/115d8655-0c3c-43d2-a15f-52d77fd3c918\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a9534c76-92ce-41d2-8682-586a4c1122ba\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ccb9d801-45c5-4f53-8a55-841ae9ffc63f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a0284d80-3d0b-4f31-8e8b-1714c0aa1076\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e3aaafa2-00ea-4b63-a6c8-79605b625b08\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0e81569f-f59f-4102-b69e-8bfcf5e2301e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6863402-5e81-45ac-83f3-03410e959604",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "115d8655-0c3c-43d2-a15f-52d77fd3c918",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a9534c76-92ce-41d2-8682-586a4c1122ba",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ccb9d801-45c5-4f53-8a55-841ae9ffc63f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0284d80-3d0b-4f31-8e8b-1714c0aa1076",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e3aaafa2-00ea-4b63-a6c8-79605b625b08",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0e81569f-f59f-4102-b69e-8bfcf5e2301e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "179fb24a-1187-45eb-8330-5c3e3b6b2598",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-83\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/90e448c6-8d29-4e56-bf6d-126423b700a5\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "90e448c6-8d29-4e56-bf6d-126423b700a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-83\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\",\"clientSequenceNumber\":1264,\"minimumSequenceNumber\":1655,\"referenceSequenceNumber\":1996,\"sequenceNumber\":2000,\"timestamp\":1564070537280,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,998 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2997,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"d7e3c1a2-4d06-49cd-bc4f-e889fdd47524\",{\"client\":{\"user\":{\"id\":\"akp55qhuq@example.com}\",\"name\":\"v0yi3efr1s3nu7s\",\"email\":\"2meqtuajt@example.com}\"}},\"sequenceNumber\":2996}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/663b111f-01a9-4a53-b557-a2ef7502ecc0\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "663b111f-01a9-4a53-b557-a2ef7502ecc0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":2998,\"value\":{\"type\":\"Plain\",\"value\":null}},\"versions\":[{\"sequenceNumber\":2998,\"value\":{\"type\":\"Plain\",\"value\":null}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3628d460-1875-4be9-a2be-a64320d66221\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fd7a8855-78e2-49bb-9a00-f13f60687268\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1c868c2e-38a9-4c69-bd74-a461e644ecb6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9530f65-4ea9-4c74-8724-b888bd929c65\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/179fb24a-1187-45eb-8330-5c3e3b6b2598\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3628d460-1875-4be9-a2be-a64320d66221",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cbc66874-4f53-40ac-bbab-01cb0a40dfaa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":935,\"refSeqNumber\":21}},\"acabd2a1-5ae1-445f-8638-e0d98e42740e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":108}},\"d2c7aaea-de7f-4971-9a93-6f6fa168dec7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":131}},\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":910,\"refSeqNumber\":2414}},\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":248,\"refSeqNumber\":2427}},\"23da62c9-26dc-493a-b40f-352f4271ada9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2428}},\"2db56f27-00b9-4c6b-af11-cd8e74dad188\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2446}},\"bd7f9e78-7264-49a3-8326-290a42934955\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":392,\"refSeqNumber\":2446}},\"15539bc8-1699-48da-b3b6-4dfa781e0ff1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2472}},\"fe581761-89e2-4c66-8b4c-b0b2778a993f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1285,\"refSeqNumber\":2472}},\"b6f60f45-635b-41e5-b2dc-cfd0fe90ae55\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2535}},\"bc24a1db-73cc-4cd5-95d3-014ab6b42050\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2535}},\"388b2129-067b-41f5-b3b0-17c4ddb1c8df\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2568}},\"b1fe5ca6-a04f-4f75-9a95-7777fbc8c295\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"0d8892fe-b352-435e-ad91-aab3118f4aec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"c0e32bc2-d7ed-4593-8e45-a368c8785fa2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"839ac9d9-6a2b-4b05-9a08-1b200fc8a9f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"c2c60467-7027-4242-b61d-cdeaa9d43b3e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"5b8a75fc-90b8-4640-89b6-79020703ad9f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2706}},\"1ce729d2-0e5d-4b48-93cb-fa99690b9fda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2710}},\"64d94b4b-a652-4d4a-aaee-c79622e63a60\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2760}},\"d8203757-75e0-4f1a-aa27-9460e9b3d219\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2806}},\"cadcd277-68ce-4f75-be2c-10f6cf1f56d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"f31be050-70a0-419e-9ac0-abca2e6ab4f0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5dd66663-9b8a-4e92-99fc-b63ed26c2709\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"38df52a5-a42d-4dd6-bebf-b9a81b67bff2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5a18c3c3-b544-4026-84e7-1304564db6ba\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2849}},\"eb2c9a38-4073-44ca-986d-11321b11cf1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c828bd43-9c4a-47da-857f-184a4fd10402\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c27b4db7-40a8-47b9-9e3b-9a19a9471bf1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2897}},\"64511f20-e3c0-462d-aa10-d394be68d6fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2909}},\"087ede46-6911-42ca-b7a7-0d8d3ad296d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2922}},\"55600fd5-6739-4e11-9c8f-ce9025fb39e3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2937}},\"0f363c5e-720c-4be0-80b2-9bb229e80337\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2945}},\"e5a0307b-5a2d-447e-87ad-79502b318be1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2966}},\"d98521f9-c724-4333-8150-a4b4d9db0349\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2978}},\"d7e3c1a2-4d06-49cd-bc4f-e889fdd47524\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2993}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fd7a8855-78e2-49bb-9a00-f13f60687268",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "219bc753-71a8-43ee-aed4-8a71ae7eee46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1c868c2e-38a9-4c69-bd74-a461e644ecb6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/219bc753-71a8-43ee-aed4-8a71ae7eee46\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":31,\"chunkLengthChars\":1544,\"totalLengthChars\":1544,\"totalSegmentCount\":31,\"chunkSequenceNumber\":2997,\"segmentTexts\":[{\"text\":\"56d6lfl9inhjepv3nb3u2fkfxe793c0q3dmsmlr8tt9i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b477c23-11b7-417e-af03-6b761045b887\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hqxdz3p2azke7mfzwwlkx7gjbycjzv4jrff42jsimic5wy0gf3o9j87pznl12v13ftchbkyxccumwsea4910ovxp4imprh1p3n46nq7efs104mglrx9esvsvkc1igw3sooqaogvnz1wqehizthcal9gyqgqmzw3jkr6s9yykl1cfb5gsp2vj5geg2g2vfdw5iebm9ovj8cz9ql5dqjqhgef1georplgkelyl6ok8zhofv00\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ed1d89a5-3517-418f-aadf-98e4acae534b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s5kfs8zh6ip5n9js5zcs0mf0ju1jv4zq5e4ldjdk8kzono3sgv8o59lx1xnvi296nzlke7c4omdrydudh50573rsx2mobsacaz7rozm6wjy50qfasljwneu7dzhdczpw86zaeu7vt2fr1uaks94srl7ojal4idh8b5x05wqaji87ixrd1hvlbx4q1dba1fcm15ge2t3i6zwx1dl40bsw7itxdxxqg8cd1zl7amn1lom6c1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dfbe20a1-22d0-46b4-9f25-f9814aae626f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s669uj7vdvqc5jh9pv6zud6rgojr1ltc3jkv5idju\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5ef0ec0a-9cf8-48e1-82a7-ff05413ed832\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"b8u5md3rkmqf7je9g2781ko5yqdeixkbswu216hdoi9qqoy7y54xwwl9yqlldqzpkpbfgfz11v6un6rxz39tk64wrn4i7h5onjkhcr76czzr5mzh5n70i3rea455hb69hstwf8ctkrkwkesxiefk1tp4numn9nrrhpseikz4b6is5hm48rapg7w6vizqaaf1szz3vul5mhrvkmsm87pdtnil9j73dvvsc0hlibb8dn2rqhxgwegb6kp7djqwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab97d858-8e01-458b-a8b0-ca869a7cc443\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"jqv0rzdac8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"212\",{\"text\":\"zjrb1nnziirdze5brwuvile8xuq49yl7pjq4ql8fs4tomkdu1p5npp6716euwqbizimpyh5gxo70psbgjp9suy4qmqldin55km7ah43nhfafxin1a7wx4x7f85u3tzp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d70c410-3762-4dca-a4c7-81cdb3b3a9c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"ykyzig02n5s1gwitk4eo4wcxdutq74iai101p1dj350kv473d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7601f953-36bf-4c7f-b1b7-bffbd83612b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"8fa6jsw8ct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wxx84rttyaf0pcvm78ule0riz\",{\"text\":\"3gn688gh80pqy2gsmwpkn1gvnr8zk2v45d7r19r19c9dm0wz64rukgydxm1i9gj92exwgidmtbu29r9v2l3t3fajmn1eofrz25tavkgk02xtw6ghx8pekju6h1ddlrw3v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"2np78oiuk75b24uzlmw1rwmdzsf1b98vyx9say9bb5a5ubiztqo21r6syth0n2vikvr8hxc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4128c8d0-bd44-4927-9192-ee97b90542ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d6b8e11-9546-4f46-a25d-0b8244fe5922\",\"ItemType\":\"Paragraph\"}},\"hfds38b5rcu7kj05yrd55k9i6x6oe9e1vrc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16da6f34-e617-4a1f-a048-54979804ea46\",\"ItemType\":\"Paragraph\"}},{\"text\":\"mlap0mju6r67tjp87zo0c40jy7piy3ybpo863km7yqmcrsouiwfqkjb0rw5d1rsifg0fqhwdcojlunnzw5so3zmwut9g1uzrcgpaa2tc6i6l2n5bmj6kifbvta37tcfg6inc4lsy5tlvtn0wwvegss8hwb28jpfctr2s0npyabdx1xyadldzq71ocxtwm3x40pb0uc3m6e7upcr2wxn71w4bpf5spw46ciaj4e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7ee6110-6c77-4bf2-8bfb-39b9a0cd6743\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"text\":\"dr8ll2q091366bi1o6j6qpf2z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a89af7d-9b96-4c9c-882b-4722459a0c7e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList111\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"eb4becf5-90a5-4bf2-85b2-321c728cb6e7\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2997,\"totalLength\":1544,\"totalSegmentCount\":31}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "87d1481d-e476-43ec-8639-a271dafcf616",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b17a1b79-4a9c-4711-a91a-e9b738967d41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f4c3d94a-653d-4bb3-86cf-a0e9db67ab17\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c896c5c1-e463-44ac-ac8f-f8ad8ac218c4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4acc1217-7bad-472d-892c-f691e5e38795\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/031285c0-a9f4-4f3c-b78f-cf6d90cc374c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8204010d-bf9c-4bf6-a9bd-eccdda2d5501\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c9bcf798-0f35-4a67-87be-6dd269749857\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b17a1b79-4a9c-4711-a91a-e9b738967d41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f4c3d94a-653d-4bb3-86cf-a0e9db67ab17",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c896c5c1-e463-44ac-ac8f-f8ad8ac218c4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4acc1217-7bad-472d-892c-f691e5e38795",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "031285c0-a9f4-4f3c-b78f-cf6d90cc374c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8204010d-bf9c-4bf6-a9bd-eccdda2d5501",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c9bcf798-0f35-4a67-87be-6dd269749857",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9530f65-4ea9-4c74-8724-b888bd929c65",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6863402-5e81-45ac-83f3-03410e959604\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/115d8655-0c3c-43d2-a15f-52d77fd3c918\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a9534c76-92ce-41d2-8682-586a4c1122ba\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ccb9d801-45c5-4f53-8a55-841ae9ffc63f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a0284d80-3d0b-4f31-8e8b-1714c0aa1076\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e3aaafa2-00ea-4b63-a6c8-79605b625b08\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0e81569f-f59f-4102-b69e-8bfcf5e2301e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6863402-5e81-45ac-83f3-03410e959604",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "115d8655-0c3c-43d2-a15f-52d77fd3c918",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a9534c76-92ce-41d2-8682-586a4c1122ba",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ccb9d801-45c5-4f53-8a55-841ae9ffc63f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0284d80-3d0b-4f31-8e8b-1714c0aa1076",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e3aaafa2-00ea-4b63-a6c8-79605b625b08",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0e81569f-f59f-4102-b69e-8bfcf5e2301e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "179fb24a-1187-45eb-8330-5c3e3b6b2598",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-83\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/90e448c6-8d29-4e56-bf6d-126423b700a5\"}},\"listRegistryList111\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/23785c73-3f07-4064-8505-5f3ea078a3f3\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7af81df4-4161-4438-ab89-a68863b3cd1d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "90e448c6-8d29-4e56-bf6d-126423b700a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-83\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "23785c73-3f07-4064-8505-5f3ea078a3f3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList111\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7af81df4-4161-4438-ab89-a68863b3cd1d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"d7e3c1a2-4d06-49cd-bc4f-e889fdd47524\",\"clientSequenceNumber\":4,\"minimumSequenceNumber\":2997,\"referenceSequenceNumber\":2997,\"sequenceNumber\":3000,\"timestamp\":1564088588407,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,998 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3999,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"36ba365c-b5cc-422f-b357-9916725bbe56\",{\"client\":{\"user\":{\"id\":\"uonpiwttv@example.com}\",\"name\":\"onazrlumi7hvmnl\",\"email\":\"4asfhkvn8@example.com}\"}},\"sequenceNumber\":3238}],[\"98ee83e6-fd0e-42db-9ff4-24037977fa26\",{\"client\":{\"user\":{\"id\":\"0eksvdgp3@example.com}\",\"name\":\"ll9churvmyf26j1\",\"email\":\"vslb7cvqi@example.com}\"}},\"sequenceNumber\":3248}],[\"670ffa73-735d-4311-9370-e574a1d256fc\",{\"client\":{\"user\":{\"id\":\"2uxkfz3nc@example.com}\",\"name\":\"miwqy8yv7qon218\",\"email\":\"jixngvmr6@example.com}\"}},\"sequenceNumber\":3825}],[\"dcbee02c-bebf-4f15-b321-d29624ba3cfe\",{\"client\":{\"user\":{\"id\":\"rj7omtf7d@example.com}\",\"name\":\"1irg98dg9wti0mm\",\"email\":\"tz0bzbnnv@example.com}\"}},\"sequenceNumber\":3828}],[\"1fcd6e8a-1a6e-4078-9db5-024379e69c22\",{\"client\":{\"user\":{\"id\":\"bhvai5q63@example.com}\",\"name\":\"5t91h8foldq4mo2\",\"email\":\"j0dnqdd6q@example.com}\"}},\"sequenceNumber\":3856}],[\"1d582949-9ddf-4600-911e-c7bce77c587f\",{\"client\":{\"user\":{\"id\":\"kq5yi9lku@example.com}\",\"name\":\"ek2m5u0klru2w9n\",\"email\":\"eme4tu9nh@example.com}\"}},\"sequenceNumber\":4000}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/663b111f-01a9-4a53-b557-a2ef7502ecc0\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "663b111f-01a9-4a53-b557-a2ef7502ecc0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3243,\"value\":{\"type\":\"Plain\",\"value\":\"36ba365c-b5cc-422f-b357-9916725bbe56\"}},\"versions\":[{\"sequenceNumber\":3243,\"value\":{\"type\":\"Plain\",\"value\":\"36ba365c-b5cc-422f-b357-9916725bbe56\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3628d460-1875-4be9-a2be-a64320d66221\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fd7a8855-78e2-49bb-9a00-f13f60687268\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1c868c2e-38a9-4c69-bd74-a461e644ecb6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9530f65-4ea9-4c74-8724-b888bd929c65\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/179fb24a-1187-45eb-8330-5c3e3b6b2598\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3628d460-1875-4be9-a2be-a64320d66221",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cbc66874-4f53-40ac-bbab-01cb0a40dfaa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":935,\"refSeqNumber\":21}},\"acabd2a1-5ae1-445f-8638-e0d98e42740e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":108}},\"d2c7aaea-de7f-4971-9a93-6f6fa168dec7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":131}},\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":910,\"refSeqNumber\":2414}},\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":248,\"refSeqNumber\":2427}},\"23da62c9-26dc-493a-b40f-352f4271ada9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2428}},\"2db56f27-00b9-4c6b-af11-cd8e74dad188\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2446}},\"bd7f9e78-7264-49a3-8326-290a42934955\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":392,\"refSeqNumber\":2446}},\"15539bc8-1699-48da-b3b6-4dfa781e0ff1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2472}},\"fe581761-89e2-4c66-8b4c-b0b2778a993f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1285,\"refSeqNumber\":2472}},\"b6f60f45-635b-41e5-b2dc-cfd0fe90ae55\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2535}},\"bc24a1db-73cc-4cd5-95d3-014ab6b42050\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2535}},\"388b2129-067b-41f5-b3b0-17c4ddb1c8df\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2568}},\"b1fe5ca6-a04f-4f75-9a95-7777fbc8c295\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"0d8892fe-b352-435e-ad91-aab3118f4aec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"c0e32bc2-d7ed-4593-8e45-a368c8785fa2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"839ac9d9-6a2b-4b05-9a08-1b200fc8a9f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"c2c60467-7027-4242-b61d-cdeaa9d43b3e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"5b8a75fc-90b8-4640-89b6-79020703ad9f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2706}},\"1ce729d2-0e5d-4b48-93cb-fa99690b9fda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2710}},\"64d94b4b-a652-4d4a-aaee-c79622e63a60\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2760}},\"d8203757-75e0-4f1a-aa27-9460e9b3d219\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2806}},\"cadcd277-68ce-4f75-be2c-10f6cf1f56d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"f31be050-70a0-419e-9ac0-abca2e6ab4f0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5dd66663-9b8a-4e92-99fc-b63ed26c2709\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"38df52a5-a42d-4dd6-bebf-b9a81b67bff2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5a18c3c3-b544-4026-84e7-1304564db6ba\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2849}},\"eb2c9a38-4073-44ca-986d-11321b11cf1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c828bd43-9c4a-47da-857f-184a4fd10402\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c27b4db7-40a8-47b9-9e3b-9a19a9471bf1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2897}},\"64511f20-e3c0-462d-aa10-d394be68d6fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2909}},\"087ede46-6911-42ca-b7a7-0d8d3ad296d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2922}},\"55600fd5-6739-4e11-9c8f-ce9025fb39e3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2937}},\"0f363c5e-720c-4be0-80b2-9bb229e80337\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2945}},\"e5a0307b-5a2d-447e-87ad-79502b318be1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2966}},\"d98521f9-c724-4333-8150-a4b4d9db0349\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2978}},\"d7e3c1a2-4d06-49cd-bc4f-e889fdd47524\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2993}},\"80c9caec-d673-4caa-88d2-d804b97a97b4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3029}},\"655b2da8-7266-4b90-afd4-f1e2b175bd98\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3048}},\"7a4596db-2ff0-4e0b-ad00-3cca1b425f91\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":529,\"refSeqNumber\":3095}},\"0444d1a6-df67-4952-a8fc-bf76bf2913b2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1029,\"refSeqNumber\":3107}},\"1c0155bb-fc88-4ce5-b308-ec2aad006d15\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3118}},\"8d4a7ef8-eb4f-43f5-8132-52bce29e31d5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3118}},\"ca8aa503-97aa-435f-92f7-7f4527953cff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":899,\"refSeqNumber\":3123}},\"ab4e7614-cb84-41a5-99ab-18a8ac8d0110\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1259,\"refSeqNumber\":3151}},\"d22f04bf-5102-4e39-b32a-32035730581e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3160}},\"06b65a40-2a1a-41a8-b276-23636f91c894\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3160}},\"56c63834-0bd7-48c1-9d3c-ab92fbd9ab51\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3180}},\"94335fd7-5d2b-477f-9c9d-98f312125d24\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3188}},\"b41072ed-755b-4f97-8ac0-98bd78ce5750\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":3206}},\"292cac96-4031-442c-aa71-5162aa6f5c09\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3381}},\"bcebc3bb-f2ce-462b-854f-fb29440cbdb8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":684,\"refSeqNumber\":3399}},\"fa916d9c-1774-4524-8109-dd75d78760ae\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3413}},\"3033551c-23fd-442e-99aa-2b4d227e0a79\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3440}},\"7e8e77c3-92c8-4002-a5d8-4f9aecdb456d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3456}},\"df80af94-50cb-4fc8-968a-180a7d53f177\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3460}},\"cddadc1d-e284-4d33-a6c2-151272a161f1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3477}},\"885b2f61-5fbd-4d3e-bd00-74ea297b5bb3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3495}},\"7cdcd9b8-5daa-43b5-8467-0561afcc814b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3550}},\"34aa082f-21c5-4527-b60c-58ccb378b48d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3555}},\"53163f2a-648d-47d6-b11d-33aae774e137\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3563}},\"a3d1e301-0037-49d7-9879-454b4096e045\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3579}},\"7f65b051-d43c-44e3-9602-df7dd0a0a4cd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3584}},\"3342a97c-93bb-467a-a218-4a28e951cba7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":3593}},\"3686071d-49ec-4a64-be5d-62037e27620a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3605}},\"e37864cb-5ac0-4e73-af84-255583380cb4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3605}},\"627780cb-151d-42ec-b04c-ce3fc1844a20\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3628}},\"e850deb0-4bba-4315-a8a1-101f28328517\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3637}},\"9f3e7eb5-6a5f-426e-a9e2-8268fc5340c3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3637}},\"40df0877-959b-4a53-9849-b8c121be0ee1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3660}},\"da19c4f4-1c21-4f5f-be1b-cc5fef510d92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3670}},\"4eb1edce-d51b-4432-856a-d12e383cb639\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3679}},\"9379a118-e3b8-4c3e-8847-27b134cd4841\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3690}},\"79a4dac2-0d70-4110-b3d6-45798f320e91\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3702}},\"3812621e-6540-4670-8259-012558dba539\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":796,\"refSeqNumber\":3735}},\"667d6023-fdd7-4460-851e-f241576c3663\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3753}},\"78306f57-be0a-4043-baa5-4307b67b0bb6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3794}},\"5b53fd2e-86ba-4c8e-99ca-59dcda652869\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3862}},\"82e347ed-18aa-4987-a6f9-275a88a39dbe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"3906a794-0356-462d-877c-96c2ca91c8a8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"71b39082-b852-4e21-bd3e-691a8997f781\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"93b121ea-29c8-4047-8db9-ebb7780c0824\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3930}},\"25cac2c7-5b69-4039-9ddd-cdaa068a3a8b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3943}},\"2cfd0cea-14a0-4fac-962e-0ae979fb5fe3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3958}},\"28632f74-0086-4b7a-a3f2-eea2863ce1a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3958}},\"dc6a2b71-f442-455d-94a9-da9d4cc143c3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":644,\"refSeqNumber\":3972}},\"cf36f34d-53fd-4458-8134-3c7062257589\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3983}},\"925efb3e-37a2-4159-a637-398571d1b067\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1012,\"refSeqNumber\":3990}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fd7a8855-78e2-49bb-9a00-f13f60687268",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "219bc753-71a8-43ee-aed4-8a71ae7eee46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1c868c2e-38a9-4c69-bd74-a461e644ecb6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/219bc753-71a8-43ee-aed4-8a71ae7eee46\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":31,\"chunkLengthChars\":1544,\"totalLengthChars\":1544,\"totalSegmentCount\":31,\"chunkSequenceNumber\":3999,\"segmentTexts\":[{\"text\":\"56d6lfl9inhjepv3nb3u2fkfxe793c0q3dmsmlr8tt9i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b477c23-11b7-417e-af03-6b761045b887\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hqxdz3p2azke7mfzwwlkx7gjbycjzv4jrff42jsimic5wy0gf3o9j87pznl12v13ftchbkyxccumwsea4910ovxp4imprh1p3n46nq7efs104mglrx9esvsvkc1igw3sooqaogvnz1wqehizthcal9gyqgqmzw3jkr6s9yykl1cfb5gsp2vj5geg2g2vfdw5iebm9ovj8cz9ql5dqjqhgef1georplgkelyl6ok8zhofv00\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ed1d89a5-3517-418f-aadf-98e4acae534b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s5kfs8zh6ip5n9js5zcs0mf0ju1jv4zq5e4ldjdk8kzono3sgv8o59lx1xnvi296nzlke7c4omdrydudh50573rsx2mobsacaz7rozm6wjy50qfasljwneu7dzhdczpw86zaeu7vt2fr1uaks94srl7ojal4idh8b5x05wqaji87ixrd1hvlbx4q1dba1fcm15ge2t3i6zwx1dl40bsw7itxdxxqg8cd1zl7amn1lom6c1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dfbe20a1-22d0-46b4-9f25-f9814aae626f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s669uj7vdvqc5jh9pv6zud6rgojr1ltc3jkv5idju\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5ef0ec0a-9cf8-48e1-82a7-ff05413ed832\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"b8u5md3rkmqf7je9g2781ko5yqdeixkbswu216hdoi9qqoy7y54xwwl9yqlldqzpkpbfgfz11v6un6rxz39tk64wrn4i7h5onjkhcr76czzr5mzh5n70i3rea455hb69hstwf8ctkrkwkesxiefk1tp4numn9nrrhpseikz4b6is5hm48rapg7w6vizqaaf1szz3vul5mhrvkmsm87pdtnil9j73dvvsc0hlibb8dn2rqhxgwegb6kp7djqwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab97d858-8e01-458b-a8b0-ca869a7cc443\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"jqv0rzdac8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"212\",{\"text\":\"zjrb1nnziirdze5brwuvile8xuq49yl7pjq4ql8fs4tomkdu1p5npp6716euwqbizimpyh5gxo70psbgjp9suy4qmqldin55km7ah43nhfafxin1a7wx4x7f85u3tzp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d70c410-3762-4dca-a4c7-81cdb3b3a9c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"ykyzig02n5s1gwitk4eo4wcxdutq74iai101p1dj350kv473d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7601f953-36bf-4c7f-b1b7-bffbd83612b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"8fa6jsw8ct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wxx84rttyaf0pcvm78ule0riz\",{\"text\":\"3gn688gh80pqy2gsmwpkn1gvnr8zk2v45d7r19r19c9dm0wz64rukgydxm1i9gj92exwgidmtbu29r9v2l3t3fajmn1eofrz25tavkgk02xtw6ghx8pekju6h1ddlrw3v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"2np78oiuk75b24uzlmw1rwmdzsf1b98vyx9say9bb5a5ubiztqo21r6syth0n2vikvr8hxc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4128c8d0-bd44-4927-9192-ee97b90542ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d6b8e11-9546-4f46-a25d-0b8244fe5922\",\"ItemType\":\"Paragraph\"}},\"hfds38b5rcu7kj05yrd55k9i6x6oe9e1vrc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16da6f34-e617-4a1f-a048-54979804ea46\",\"ItemType\":\"Paragraph\"}},{\"text\":\"mlap0mju6r67tjp87zo0c40jy7piy3ybpo863km7yqmcrsouiwfqkjb0rw5d1rsifg0fqhwdcojlunnzw5so3zmwut9g1uzrcgpaa2tc6i6l2n5bmj6kifbvta37tcfg6inc4lsy5tlvtn0wwvegss8hwb28jpfctr2s0npyabdx1xyadldzq71ocxtwm3x40pb0uc3m6e7upcr2wxn71w4bpf5spw46ciaj4e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7ee6110-6c77-4bf2-8bfb-39b9a0cd6743\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"text\":\"dr8ll2q091366bi1o6j6qpf2z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a89af7d-9b96-4c9c-882b-4722459a0c7e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList111\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"eb4becf5-90a5-4bf2-85b2-321c728cb6e7\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3999,\"totalLength\":1544,\"totalSegmentCount\":31}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "87d1481d-e476-43ec-8639-a271dafcf616",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b17a1b79-4a9c-4711-a91a-e9b738967d41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f4c3d94a-653d-4bb3-86cf-a0e9db67ab17\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c896c5c1-e463-44ac-ac8f-f8ad8ac218c4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4acc1217-7bad-472d-892c-f691e5e38795\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/031285c0-a9f4-4f3c-b78f-cf6d90cc374c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8204010d-bf9c-4bf6-a9bd-eccdda2d5501\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c9bcf798-0f35-4a67-87be-6dd269749857\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b17a1b79-4a9c-4711-a91a-e9b738967d41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f4c3d94a-653d-4bb3-86cf-a0e9db67ab17",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c896c5c1-e463-44ac-ac8f-f8ad8ac218c4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4acc1217-7bad-472d-892c-f691e5e38795",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "031285c0-a9f4-4f3c-b78f-cf6d90cc374c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8204010d-bf9c-4bf6-a9bd-eccdda2d5501",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c9bcf798-0f35-4a67-87be-6dd269749857",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9530f65-4ea9-4c74-8724-b888bd929c65",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6863402-5e81-45ac-83f3-03410e959604\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/115d8655-0c3c-43d2-a15f-52d77fd3c918\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a9534c76-92ce-41d2-8682-586a4c1122ba\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ccb9d801-45c5-4f53-8a55-841ae9ffc63f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a0284d80-3d0b-4f31-8e8b-1714c0aa1076\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e3aaafa2-00ea-4b63-a6c8-79605b625b08\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0e81569f-f59f-4102-b69e-8bfcf5e2301e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6863402-5e81-45ac-83f3-03410e959604",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "115d8655-0c3c-43d2-a15f-52d77fd3c918",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a9534c76-92ce-41d2-8682-586a4c1122ba",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ccb9d801-45c5-4f53-8a55-841ae9ffc63f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0284d80-3d0b-4f31-8e8b-1714c0aa1076",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e3aaafa2-00ea-4b63-a6c8-79605b625b08",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0e81569f-f59f-4102-b69e-8bfcf5e2301e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "179fb24a-1187-45eb-8330-5c3e3b6b2598",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-83\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/90e448c6-8d29-4e56-bf6d-126423b700a5\"}},\"listRegistryList111\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/23785c73-3f07-4064-8505-5f3ea078a3f3\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7af81df4-4161-4438-ab89-a68863b3cd1d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "90e448c6-8d29-4e56-bf6d-126423b700a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-83\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "23785c73-3f07-4064-8505-5f3ea078a3f3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList111\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7af81df4-4161-4438-ab89-a68863b3cd1d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":3999,\"referenceSequenceNumber\":-1,\"sequenceNumber\":4000,\"timestamp\":1564766911193,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_4012_0.json
+++ b/snapshotTestContent/HotBugs1/src_snapshots/0.59.3000/snapshot_4012_0.json
@@ -1,0 +1,998 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4011,\"sequenceNumber\":4012,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"36ba365c-b5cc-422f-b357-9916725bbe56\",{\"client\":{\"user\":{\"id\":\"uonpiwttv@example.com}\",\"name\":\"onazrlumi7hvmnl\",\"email\":\"4asfhkvn8@example.com}\"}},\"sequenceNumber\":3238}],[\"98ee83e6-fd0e-42db-9ff4-24037977fa26\",{\"client\":{\"user\":{\"id\":\"0eksvdgp3@example.com}\",\"name\":\"ll9churvmyf26j1\",\"email\":\"vslb7cvqi@example.com}\"}},\"sequenceNumber\":3248}],[\"670ffa73-735d-4311-9370-e574a1d256fc\",{\"client\":{\"user\":{\"id\":\"2uxkfz3nc@example.com}\",\"name\":\"miwqy8yv7qon218\",\"email\":\"jixngvmr6@example.com}\"}},\"sequenceNumber\":3825}],[\"dcbee02c-bebf-4f15-b321-d29624ba3cfe\",{\"client\":{\"user\":{\"id\":\"rj7omtf7d@example.com}\",\"name\":\"1irg98dg9wti0mm\",\"email\":\"tz0bzbnnv@example.com}\"}},\"sequenceNumber\":3828}],[\"1fcd6e8a-1a6e-4078-9db5-024379e69c22\",{\"client\":{\"user\":{\"id\":\"bhvai5q63@example.com}\",\"name\":\"5t91h8foldq4mo2\",\"email\":\"j0dnqdd6q@example.com}\"}},\"sequenceNumber\":3856}],[\"05f5148c-e290-4c57-842c-54b04000c115\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"k28kvtlao@example.com}\",\"name\":\"i270fpziydl5u6t\",\"email\":\"rqqt3l38f@example.com}\"}},\"sequenceNumber\":4012}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/663b111f-01a9-4a53-b557-a2ef7502ecc0\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "663b111f-01a9-4a53-b557-a2ef7502ecc0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3243,\"value\":{\"type\":\"Plain\",\"value\":\"36ba365c-b5cc-422f-b357-9916725bbe56\"}},\"versions\":[{\"sequenceNumber\":3243,\"value\":{\"type\":\"Plain\",\"value\":\"36ba365c-b5cc-422f-b357-9916725bbe56\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3628d460-1875-4be9-a2be-a64320d66221\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fd7a8855-78e2-49bb-9a00-f13f60687268\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1c868c2e-38a9-4c69-bd74-a461e644ecb6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9530f65-4ea9-4c74-8724-b888bd929c65\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/179fb24a-1187-45eb-8330-5c3e3b6b2598\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3628d460-1875-4be9-a2be-a64320d66221",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cbc66874-4f53-40ac-bbab-01cb0a40dfaa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":935,\"refSeqNumber\":21}},\"acabd2a1-5ae1-445f-8638-e0d98e42740e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":108}},\"d2c7aaea-de7f-4971-9a93-6f6fa168dec7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":131}},\"13a2ffa3-69ef-4b11-aa42-ab5b1badbe97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":910,\"refSeqNumber\":2414}},\"7c3f867c-bbdd-4a01-92fe-4e73509a312d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":248,\"refSeqNumber\":2427}},\"23da62c9-26dc-493a-b40f-352f4271ada9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2428}},\"2db56f27-00b9-4c6b-af11-cd8e74dad188\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2446}},\"bd7f9e78-7264-49a3-8326-290a42934955\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":392,\"refSeqNumber\":2446}},\"15539bc8-1699-48da-b3b6-4dfa781e0ff1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2472}},\"fe581761-89e2-4c66-8b4c-b0b2778a993f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":0,\"pos\":1285,\"refSeqNumber\":2472}},\"b6f60f45-635b-41e5-b2dc-cfd0fe90ae55\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2535}},\"bc24a1db-73cc-4cd5-95d3-014ab6b42050\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2535}},\"388b2129-067b-41f5-b3b0-17c4ddb1c8df\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2568}},\"b1fe5ca6-a04f-4f75-9a95-7777fbc8c295\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"0d8892fe-b352-435e-ad91-aab3118f4aec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2627}},\"c0e32bc2-d7ed-4593-8e45-a368c8785fa2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"839ac9d9-6a2b-4b05-9a08-1b200fc8a9f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"c2c60467-7027-4242-b61d-cdeaa9d43b3e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2653}},\"5b8a75fc-90b8-4640-89b6-79020703ad9f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2706}},\"1ce729d2-0e5d-4b48-93cb-fa99690b9fda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2710}},\"64d94b4b-a652-4d4a-aaee-c79622e63a60\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1285,\"pos\":0,\"refSeqNumber\":2760}},\"d8203757-75e0-4f1a-aa27-9460e9b3d219\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2806}},\"cadcd277-68ce-4f75-be2c-10f6cf1f56d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"f31be050-70a0-419e-9ac0-abca2e6ab4f0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5dd66663-9b8a-4e92-99fc-b63ed26c2709\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"38df52a5-a42d-4dd6-bebf-b9a81b67bff2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2812}},\"5a18c3c3-b544-4026-84e7-1304564db6ba\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2849}},\"eb2c9a38-4073-44ca-986d-11321b11cf1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c828bd43-9c4a-47da-857f-184a4fd10402\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2872}},\"c27b4db7-40a8-47b9-9e3b-9a19a9471bf1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2897}},\"64511f20-e3c0-462d-aa10-d394be68d6fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2909}},\"087ede46-6911-42ca-b7a7-0d8d3ad296d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2922}},\"55600fd5-6739-4e11-9c8f-ce9025fb39e3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2937}},\"0f363c5e-720c-4be0-80b2-9bb229e80337\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2945}},\"e5a0307b-5a2d-447e-87ad-79502b318be1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":2966}},\"d98521f9-c724-4333-8150-a4b4d9db0349\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2978}},\"d7e3c1a2-4d06-49cd-bc4f-e889fdd47524\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2993}},\"80c9caec-d673-4caa-88d2-d804b97a97b4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3029}},\"655b2da8-7266-4b90-afd4-f1e2b175bd98\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3048}},\"7a4596db-2ff0-4e0b-ad00-3cca1b425f91\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":529,\"refSeqNumber\":3095}},\"0444d1a6-df67-4952-a8fc-bf76bf2913b2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1029,\"refSeqNumber\":3107}},\"1c0155bb-fc88-4ce5-b308-ec2aad006d15\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3118}},\"8d4a7ef8-eb4f-43f5-8132-52bce29e31d5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3118}},\"ca8aa503-97aa-435f-92f7-7f4527953cff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":899,\"refSeqNumber\":3123}},\"ab4e7614-cb84-41a5-99ab-18a8ac8d0110\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1259,\"refSeqNumber\":3151}},\"d22f04bf-5102-4e39-b32a-32035730581e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3160}},\"06b65a40-2a1a-41a8-b276-23636f91c894\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3160}},\"56c63834-0bd7-48c1-9d3c-ab92fbd9ab51\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3180}},\"94335fd7-5d2b-477f-9c9d-98f312125d24\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3188}},\"b41072ed-755b-4f97-8ac0-98bd78ce5750\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":3206}},\"292cac96-4031-442c-aa71-5162aa6f5c09\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3381}},\"bcebc3bb-f2ce-462b-854f-fb29440cbdb8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":684,\"refSeqNumber\":3399}},\"fa916d9c-1774-4524-8109-dd75d78760ae\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3413}},\"3033551c-23fd-442e-99aa-2b4d227e0a79\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3440}},\"7e8e77c3-92c8-4002-a5d8-4f9aecdb456d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3456}},\"df80af94-50cb-4fc8-968a-180a7d53f177\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3460}},\"cddadc1d-e284-4d33-a6c2-151272a161f1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3477}},\"885b2f61-5fbd-4d3e-bd00-74ea297b5bb3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3495}},\"7cdcd9b8-5daa-43b5-8467-0561afcc814b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3550}},\"34aa082f-21c5-4527-b60c-58ccb378b48d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3555}},\"53163f2a-648d-47d6-b11d-33aae774e137\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3563}},\"a3d1e301-0037-49d7-9879-454b4096e045\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3579}},\"7f65b051-d43c-44e3-9602-df7dd0a0a4cd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3584}},\"3342a97c-93bb-467a-a218-4a28e951cba7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1285,\"refSeqNumber\":3593}},\"3686071d-49ec-4a64-be5d-62037e27620a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3605}},\"e37864cb-5ac0-4e73-af84-255583380cb4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3605}},\"627780cb-151d-42ec-b04c-ce3fc1844a20\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3628}},\"e850deb0-4bba-4315-a8a1-101f28328517\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3637}},\"9f3e7eb5-6a5f-426e-a9e2-8268fc5340c3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3637}},\"40df0877-959b-4a53-9849-b8c121be0ee1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3660}},\"da19c4f4-1c21-4f5f-be1b-cc5fef510d92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3670}},\"4eb1edce-d51b-4432-856a-d12e383cb639\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3679}},\"9379a118-e3b8-4c3e-8847-27b134cd4841\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3690}},\"79a4dac2-0d70-4110-b3d6-45798f320e91\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3702}},\"3812621e-6540-4670-8259-012558dba539\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":796,\"refSeqNumber\":3735}},\"667d6023-fdd7-4460-851e-f241576c3663\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3753}},\"78306f57-be0a-4043-baa5-4307b67b0bb6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3794}},\"5b53fd2e-86ba-4c8e-99ca-59dcda652869\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3862}},\"82e347ed-18aa-4987-a6f9-275a88a39dbe\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"3906a794-0356-462d-877c-96c2ca91c8a8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"71b39082-b852-4e21-bd3e-691a8997f781\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2564}},\"93b121ea-29c8-4047-8db9-ebb7780c0824\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3930}},\"25cac2c7-5b69-4039-9ddd-cdaa068a3a8b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3943}},\"2cfd0cea-14a0-4fac-962e-0ae979fb5fe3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3958}},\"28632f74-0086-4b7a-a3f2-eea2863ce1a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3958}},\"dc6a2b71-f442-455d-94a9-da9d4cc143c3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":644,\"refSeqNumber\":3972}},\"cf36f34d-53fd-4458-8134-3c7062257589\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3983}},\"925efb3e-37a2-4159-a637-398571d1b067\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1012,\"refSeqNumber\":3990}},\"1d582949-9ddf-4600-911e-c7bce77c587f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3990}},\"bdcdff3f-932a-4c35-810b-8a9778f58d71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3990}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fd7a8855-78e2-49bb-9a00-f13f60687268",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "219bc753-71a8-43ee-aed4-8a71ae7eee46",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1c868c2e-38a9-4c69-bd74-a461e644ecb6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/219bc753-71a8-43ee-aed4-8a71ae7eee46\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":31,\"chunkLengthChars\":1544,\"totalLengthChars\":1544,\"totalSegmentCount\":31,\"chunkSequenceNumber\":4011,\"segmentTexts\":[{\"text\":\"56d6lfl9inhjepv3nb3u2fkfxe793c0q3dmsmlr8tt9i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6b477c23-11b7-417e-af03-6b761045b887\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hqxdz3p2azke7mfzwwlkx7gjbycjzv4jrff42jsimic5wy0gf3o9j87pznl12v13ftchbkyxccumwsea4910ovxp4imprh1p3n46nq7efs104mglrx9esvsvkc1igw3sooqaogvnz1wqehizthcal9gyqgqmzw3jkr6s9yykl1cfb5gsp2vj5geg2g2vfdw5iebm9ovj8cz9ql5dqjqhgef1georplgkelyl6ok8zhofv00\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ed1d89a5-3517-418f-aadf-98e4acae534b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s5kfs8zh6ip5n9js5zcs0mf0ju1jv4zq5e4ldjdk8kzono3sgv8o59lx1xnvi296nzlke7c4omdrydudh50573rsx2mobsacaz7rozm6wjy50qfasljwneu7dzhdczpw86zaeu7vt2fr1uaks94srl7ojal4idh8b5x05wqaji87ixrd1hvlbx4q1dba1fcm15ge2t3i6zwx1dl40bsw7itxdxxqg8cd1zl7amn1lom6c1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dfbe20a1-22d0-46b4-9f25-f9814aae626f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"s669uj7vdvqc5jh9pv6zud6rgojr1ltc3jkv5idju\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5ef0ec0a-9cf8-48e1-82a7-ff05413ed832\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"b8u5md3rkmqf7je9g2781ko5yqdeixkbswu216hdoi9qqoy7y54xwwl9yqlldqzpkpbfgfz11v6un6rxz39tk64wrn4i7h5onjkhcr76czzr5mzh5n70i3rea455hb69hstwf8ctkrkwkesxiefk1tp4numn9nrrhpseikz4b6is5hm48rapg7w6vizqaaf1szz3vul5mhrvkmsm87pdtnil9j73dvvsc0hlibb8dn2rqhxgwegb6kp7djqwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab97d858-8e01-458b-a8b0-ca869a7cc443\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"jqv0rzdac8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"212\",{\"text\":\"zjrb1nnziirdze5brwuvile8xuq49yl7pjq4ql8fs4tomkdu1p5npp6716euwqbizimpyh5gxo70psbgjp9suy4qmqldin55km7ah43nhfafxin1a7wx4x7f85u3tzp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d70c410-3762-4dca-a4c7-81cdb3b3a9c9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"ykyzig02n5s1gwitk4eo4wcxdutq74iai101p1dj350kv473d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7601f953-36bf-4c7f-b1b7-bffbd83612b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"8fa6jsw8ct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wxx84rttyaf0pcvm78ule0riz\",{\"text\":\"3gn688gh80pqy2gsmwpkn1gvnr8zk2v45d7r19r19c9dm0wz64rukgydxm1i9gj92exwgidmtbu29r9v2l3t3fajmn1eofrz25tavkgk02xtw6ghx8pekju6h1ddlrw3v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34d04099-a6ed-4a1b-a458-6afb204c23a7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-83\"}}},{\"text\":\"2np78oiuk75b24uzlmw1rwmdzsf1b98vyx9say9bb5a5ubiztqo21r6syth0n2vikvr8hxc\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4128c8d0-bd44-4927-9192-ee97b90542ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-83\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0d6b8e11-9546-4f46-a25d-0b8244fe5922\",\"ItemType\":\"Paragraph\"}},\"hfds38b5rcu7kj05yrd55k9i6x6oe9e1vrc\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16da6f34-e617-4a1f-a048-54979804ea46\",\"ItemType\":\"Paragraph\"}},{\"text\":\"mlap0mju6r67tjp87zo0c40jy7piy3ybpo863km7yqmcrsouiwfqkjb0rw5d1rsifg0fqhwdcojlunnzw5so3zmwut9g1uzrcgpaa2tc6i6l2n5bmj6kifbvta37tcfg6inc4lsy5tlvtn0wwvegss8hwb28jpfctr2s0npyabdx1xyadldzq71ocxtwm3x40pb0uc3m6e7upcr2wxn71w4bpf5spw46ciaj4e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7ee6110-6c77-4bf2-8bfb-39b9a0cd6743\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"text\":\"dr8ll2q091366bi1o6j6qpf2z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7a89af7d-9b96-4c9c-882b-4722459a0c7e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList111\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"eb4becf5-90a5-4bf2-85b2-321c728cb6e7\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4011,\"totalLength\":1544,\"totalSegmentCount\":31}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "87d1481d-e476-43ec-8639-a271dafcf616",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b17a1b79-4a9c-4711-a91a-e9b738967d41\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f4c3d94a-653d-4bb3-86cf-a0e9db67ab17\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c896c5c1-e463-44ac-ac8f-f8ad8ac218c4\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4acc1217-7bad-472d-892c-f691e5e38795\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/031285c0-a9f4-4f3c-b78f-cf6d90cc374c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8204010d-bf9c-4bf6-a9bd-eccdda2d5501\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c9bcf798-0f35-4a67-87be-6dd269749857\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b17a1b79-4a9c-4711-a91a-e9b738967d41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f4c3d94a-653d-4bb3-86cf-a0e9db67ab17",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c896c5c1-e463-44ac-ac8f-f8ad8ac218c4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4acc1217-7bad-472d-892c-f691e5e38795",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "031285c0-a9f4-4f3c-b78f-cf6d90cc374c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8204010d-bf9c-4bf6-a9bd-eccdda2d5501",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c9bcf798-0f35-4a67-87be-6dd269749857",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9530f65-4ea9-4c74-8724-b888bd929c65",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6863402-5e81-45ac-83f3-03410e959604\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/115d8655-0c3c-43d2-a15f-52d77fd3c918\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a9534c76-92ce-41d2-8682-586a4c1122ba\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ccb9d801-45c5-4f53-8a55-841ae9ffc63f\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a0284d80-3d0b-4f31-8e8b-1714c0aa1076\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e3aaafa2-00ea-4b63-a6c8-79605b625b08\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0e81569f-f59f-4102-b69e-8bfcf5e2301e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6863402-5e81-45ac-83f3-03410e959604",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "115d8655-0c3c-43d2-a15f-52d77fd3c918",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a9534c76-92ce-41d2-8682-586a4c1122ba",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ccb9d801-45c5-4f53-8a55-841ae9ffc63f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0284d80-3d0b-4f31-8e8b-1714c0aa1076",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e3aaafa2-00ea-4b63-a6c8-79605b625b08",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0e81569f-f59f-4102-b69e-8bfcf5e2301e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "179fb24a-1187-45eb-8330-5c3e3b6b2598",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-83\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/90e448c6-8d29-4e56-bf6d-126423b700a5\"}},\"listRegistryList111\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/23785c73-3f07-4064-8505-5f3ea078a3f3\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7af81df4-4161-4438-ab89-a68863b3cd1d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "90e448c6-8d29-4e56-bf6d-126423b700a5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-83\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "23785c73-3f07-4064-8505-5f3ea078a3f3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList111\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7af81df4-4161-4438-ab89-a68863b3cd1d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":4011,\"referenceSequenceNumber\":-1,\"sequenceNumber\":4012,\"timestamp\":1564767319925,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":987,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"f12d7016-9055-40b5-b5f4-ecfeefcbde93\",{\"client\":{\"user\":{\"id\":\"0dq0f5zel@example.com}\",\"name\":\"e4ehkipq22lmhwh\",\"email\":\"ao73lx946@example.com}\"}},\"sequenceNumber\":797}],[\"f56a3f29-9dbe-4e13-bad3-c86d3a382d1c\",{\"client\":{\"user\":{\"id\":\"i5qf2oe1s@example.com}\",\"name\":\"ha1zc90n5s4is05\",\"email\":\"lr5nmaklk@example.com}\"}},\"sequenceNumber\":799}],[\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\",{\"client\":{\"user\":{\"id\":\"qtsm3ex40@example.com}\",\"name\":\"k9v3ttlk9xmemnr\",\"email\":\"37viuid7m@example.com}\"}},\"sequenceNumber\":812}],[\"b0ae2681-9d90-4187-97cd-b04a0e538a17\",{\"client\":{\"user\":{\"id\":\"ak17athdd@example.com}\",\"name\":\"e8f1ihq403j95nc\",\"email\":\"dx4ic3v8i@example.com}\"}},\"sequenceNumber\":950}],[\"da508758-647c-4d00-87d4-4881fadd8646\",{\"client\":{\"user\":{\"id\":\"5p96o3s2x@example.com}\",\"name\":\"le3fhshoi1lx6h9\",\"email\":\"mrn14oye0@example.com}\"}},\"sequenceNumber\":974}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "e33e78fc-17c1-4929-8dc3-7898d5ae9b9f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}},\"versions\":[{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/e33e78fc-17c1-4929-8dc3-7898d5ae9b9f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1akwwopbt@example.com}\",\"displayName\":\"n2rmzgs34uq85a3\",\"originalName\":\"4p8w6o1yz15cnw7\",\"dateCreated\":\"2019-07-26T15:43:13.62Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c354bc38-ae1b-4a68-84ff-a52818e506cb\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f6a34084-d2ed-4f9d-915a-1d431cf43349\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4985a5a9-e709-44a1-887a-0d2e4da29e78\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/07cb2000-4eba-4692-b548-094e9e1753c7\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/29379177-fa05-4753-8d3b-2b11f8c8a61d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c354bc38-ae1b-4a68-84ff-a52818e506cb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"6f7fe701-07ce-49fa-a84f-e04fdf4bb077\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1542,\"refSeqNumber\":21}},\"3e1ebf4a-9352-4c6e-ba89-d249aba219aa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":523,\"refSeqNumber\":161}},\"3a601698-0866-4f69-9170-94526b6a2658\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"8ef7b582-4203-4f9c-9f4b-c5e3d80c4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"aaaaff65-11b8-4048-bca4-bc2f7a60d38d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1239,\"refSeqNumber\":351}},\"8190d444-21f7-4b2c-bc4b-0e902415edca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":105,\"refSeqNumber\":311}},\"a3a91eb3-79dd-4e3d-8292-f7da6f976cdf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":311}},\"b3d0984c-38c4-45b9-a0af-af2473a0a24a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1206,\"pos\":638,\"refSeqNumber\":351}},\"298bcec9-c321-486d-b10e-886c7345edbf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":414}},\"f8c3c32b-d0cc-4342-a18f-2ec122223202\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":59,\"refSeqNumber\":422}},\"1aa64e2e-8086-47ba-8847-bb729506beda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":750,\"refSeqNumber\":773}},\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":808}},\"9549c9e8-9afa-430d-acf2-e4713d13e0af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":939}},\"da508758-647c-4d00-87d4-4881fadd8646\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":969}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f6a34084-d2ed-4f9d-915a-1d431cf43349",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f49543e5-85ab-41c3-a098-d62c43623d20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "07cb2000-4eba-4692-b548-094e9e1753c7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/575bf4db-6719-4b69-999d-f854c38611ec\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/048dd808-9fae-44a4-b6e3-f3d59e0dd65a\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e87dd691-f7e3-4397-ac30-01ef3187b00f\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/db6e7e53-0cff-470d-a24e-18345ad33689\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/56afc408-b221-41b6-ad42-ff3c1eb2bf6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1956ecb0-0186-433b-bb79-740c7e46d060\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6077cbc4-ea6c-4ade-83a0-7317c976f2de\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "575bf4db-6719-4b69-999d-f854c38611ec",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "048dd808-9fae-44a4-b6e3-f3d59e0dd65a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e87dd691-f7e3-4397-ac30-01ef3187b00f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "db6e7e53-0cff-470d-a24e-18345ad33689",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56afc408-b221-41b6-ad42-ff3c1eb2bf6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1956ecb0-0186-433b-bb79-740c7e46d060",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6077cbc4-ea6c-4ade-83a0-7317c976f2de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "29379177-fa05-4753-8d3b-2b11f8c8a61d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList21\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ee814639-d114-4ad6-8e0d-f5bba3f8304d\"}},\"listRegistryList-118\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/72a72863-eff7-43f5-a4d3-4a32518d4a50\"}},\"listRegistryList89\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c11561bf-c1c7-4e58-9411-ac6e414e7989\"}},\"listRegistryList91\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/561c29d4-c219-4fcb-a66f-1339cdae01e8\"}},\"listRegistryList102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/403979ed-3135-4261-bf84-e3d31e4a6696\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ee814639-d114-4ad6-8e0d-f5bba3f8304d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList21\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "72a72863-eff7-43f5-a4d3-4a32518d4a50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-118\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c11561bf-c1c7-4e58-9411-ac6e414e7989",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList89\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "561c29d4-c219-4fcb-a66f-1339cdae01e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList91\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "403979ed-3135-4261-bf84-e3d31e4a6696",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4985a5a9-e709-44a1-887a-0d2e4da29e78",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f49543e5-85ab-41c3-a098-d62c43623d20\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":26,\"chunkLengthChars\":1530,\"totalLengthChars\":1530,\"totalSegmentCount\":26,\"chunkSequenceNumber\":987,\"segmentTexts\":[{\"text\":\"xrvkbyw4qd8a91ad9cuqqnhzyqyno2cr46cjrb1cqxjb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3666f69e-f0c7-4842-9cf5-315c4e2b4c6f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"xvpj1auf4gkb952ccebnrhdsgladadenucv8pu5kh5i5tfnz12yh146e6680wi1tfaom88x2xcubek9ldkrwey4hdyu9msktawxgbh8adviccss3qyfn03hm3sl5egmhqaffvo5ohjkpsk4ng2raysdavybrkxrtlrby8xxssk71w0hf0uy6kfzaipw6f2y1ubed15qo5udb8xtv0jldydbps9gt33gsukkp2csmbc2ezew\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"077ddf84-7093-41da-9259-454d6897bcf4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"5a0tt94bp9j5v0o92imghin2kreker9jcqt1mgh5pwrzg5106ztafk4g4mixsx8c6xe82ip4l7cto1n87jgpsp1bswibdmjjeki76b0tciuoso086ahyf264kjdthnuglafkchmerjgtn7a3jdfqq704r2cur835uny2y206lir4c2d8nqib93ur0pp4sg7hg2l5kwr4cfo17fidb7qea9n2xv7riph6liobrj4hkfsf9m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4b858020-d41d-4de3-a2e5-ff6df955a8f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList21\"}}},{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"5377cbz6wj7mlscjytvrigubrk0snibg2je43fbwjiirrcnmg7uwbg3flblpfh9buswscpfybo4q7n1sy5u5nlce1wqqqe1cxl8cn5huv7mf9z34c8fo050xaxurhk9eklxcxrc35xrnf65n6hmljl67wghkmrzajua87n3eanshizw1xzu20s91919bkdzotu2eoqdnoh29wss73fa67b5ijiendgntkl11aygob52eip25ha9q1w6uixcwn\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd49eb82-6519-449e-b14a-762765b3a545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3vhab988628l0wzydcuy59en4c3sgyvevmuzs672uu36s5jxkujxgvgcbyhk7hkcsjypdnj00lyw1mrylwdgezvrjha1u05hbxvdw4gy1z4tzs68ye169qfbvxx7unooio5smteviyzj3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"a34c7f1d-0067-4043-bb07-7e1776f63a13\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\",\"display\":\"inline-block\"}}},{\"text\":\"rz9o3qwh9r8uwp8fle5dq8zqtzq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"125cce6f-ba64-4ef4-b3be-2faabd773abd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-118\"}}},{\"text\":\"v5p4xve2tckbputwulgquvaipo514z93j3p72vdy5m2kz93ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b307a75f-210d-49b2-87a4-2a58f0708335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"r255jwjumcpjjfdyijrjmdcbo2u7q214hjqol453325k1o3gyxe6g9yotg2a2laemzxcspex971utzn2ohj2nc47tyejjcakgrokhmp3nv53oos7v6zjy0i1c32l2ckqi27nap51vubvmkafxfpv3jcpftnyxo1mzpuk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"221814fa-d3e3-43e2-a55d-b7952fd6849b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3km3pznthwa81on7zhidx75dk4ih0i8a6bsg2nig2pqfhs0tf8ch1oc3ep87g8uvh6txft8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1bb718dd-2f4f-450f-b46a-4552f54de26b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"2679qwvgyzjjrjolhtymwsdzs0jzqhmfr8m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"950358dd-305e-4d4a-a82a-e160d20390e5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"slrko0dk5wv70amunkc8ykjyrx5d9logjdf04vmkx80l7s403094v7fwvosipogkv6g796h1mi8b329lffn9jlp1zj6i1wvcczjhlv2a718pdqkmpsnn6xrxtke938emok0tjdlu6evz9adu4tzkfs96n5di5rhgb7kfeco1390w97xip7b6ghd5pp7szxinrqlzu7jm43g8b72thm3b6mjjwkb53l9gxqkhpz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c3d7a93d-4320-4947-91b9-2681ca4919f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList91\"}}},{\"text\":\"jxrzx10m7js0v80w6jr9biclf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1c5a79f-5162-4ee3-b896-497500279251\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList102\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"213e8528-cd3d-434b-9e02-0656c194ebb7\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":987,\"totalLength\":1530,\"totalSegmentCount\":26}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"da508758-647c-4d00-87d4-4881fadd8646\",\"clientSequenceNumber\":13,\"minimumSequenceNumber\":987,\"referenceSequenceNumber\":987,\"sequenceNumber\":1000,\"timestamp\":1564157175957,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1996,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"f56a3f29-9dbe-4e13-bad3-c86d3a382d1c\",{\"client\":{\"user\":{\"id\":\"i5qf2oe1s@example.com}\",\"name\":\"ha1zc90n5s4is05\",\"email\":\"lr5nmaklk@example.com}\"}},\"sequenceNumber\":799}],[\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\",{\"client\":{\"user\":{\"id\":\"qtsm3ex40@example.com}\",\"name\":\"k9v3ttlk9xmemnr\",\"email\":\"37viuid7m@example.com}\"}},\"sequenceNumber\":812}],[\"b0ae2681-9d90-4187-97cd-b04a0e538a17\",{\"client\":{\"user\":{\"id\":\"ak17athdd@example.com}\",\"name\":\"e8f1ihq403j95nc\",\"email\":\"dx4ic3v8i@example.com}\"}},\"sequenceNumber\":950}],[\"da508758-647c-4d00-87d4-4881fadd8646\",{\"client\":{\"user\":{\"id\":\"5p96o3s2x@example.com}\",\"name\":\"le3fhshoi1lx6h9\",\"email\":\"mrn14oye0@example.com}\"}},\"sequenceNumber\":974}],[\"4a9b3309-740e-46a8-8510-8e920b958844\",{\"client\":{\"user\":{\"id\":\"hwhhyrkc3@example.com}\",\"name\":\"dtx9ju4vs8nlqih\",\"email\":\"jf67khpqd@example.com}\"}},\"sequenceNumber\":1118}],[\"6b9e7cd6-de65-4f03-8bc9-ac8735eaad4e\",{\"client\":{\"user\":{\"id\":\"ldqebeq2e@example.com}\",\"name\":\"biqjqoisuerciwd\",\"email\":\"bte7s15si@example.com}\"}},\"sequenceNumber\":1136}],[\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\",{\"client\":{\"user\":{\"id\":\"gehkhnn4u@example.com}\",\"name\":\"0grcark2zibpfgg\",\"email\":\"gwxoscej2@example.com}\"}},\"sequenceNumber\":1359}],[\"793851ab-91e3-4f11-9349-97ec25a88335\",{\"client\":{\"user\":{\"id\":\"nwlwbsdsz@example.com}\",\"name\":\"3rfe6k83t6r7qxi\",\"email\":\"mq6ytytdb@example.com}\"}},\"sequenceNumber\":1366}],[\"aee5f6c8-5124-49ec-ab31-f9205762584f\",{\"client\":{\"user\":{\"id\":\"tso13d4yk@example.com}\",\"name\":\"w2qlcj1cjkt2ivu\",\"email\":\"jgav1zk1k@example.com}\"}},\"sequenceNumber\":1367}],[\"851b68ad-6a89-4609-b169-3e6f1ce9d2ed\",{\"client\":{\"user\":{\"id\":\"fcexseulk@example.com}\",\"name\":\"x29u3v4bb5gra1q\",\"email\":\"lpo6t6x6e@example.com}\"}},\"sequenceNumber\":1657}],[\"0894a87b-36c4-42af-9b58-210058cfa8f8\",{\"client\":{\"user\":{\"id\":\"apsrmpias@example.com}\",\"name\":\"egspi7aqtlf0sd5\",\"email\":\"xv5qlk6k2@example.com}\"}},\"sequenceNumber\":1663}],[\"8209106c-5d33-4a16-ac1b-07ce37089697\",{\"client\":{\"user\":{\"id\":\"5m7clos2w@example.com}\",\"name\":\"txfng5iyfxl8wly\",\"email\":\"o9t1ytz1d@example.com}\"}},\"sequenceNumber\":1684}],[\"02791be6-0f5d-4edd-b74b-13aba9b82b47\",{\"client\":{\"user\":{\"id\":\"v6gt4so1a@example.com}\",\"name\":\"kjvzi5310lmhool\",\"email\":\"n9s5oiswk@example.com}\"}},\"sequenceNumber\":1715}],[\"8849479c-1211-4aa8-8ea1-c6e56d9b07ce\",{\"client\":{\"user\":{\"id\":\"3ztg3b69y@example.com}\",\"name\":\"apla7szb9bkqprn\",\"email\":\"8cu43npwr@example.com}\"}},\"sequenceNumber\":1916}],[\"c9d47ea7-6824-40c0-ba71-192a5e708add\",{\"client\":{\"user\":{\"id\":\"knxgbn9os@example.com}\",\"name\":\"nme2scvmnviq6oa\",\"email\":\"zm1bccpep@example.com}\"}},\"sequenceNumber\":1926}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/e33e78fc-17c1-4929-8dc3-7898d5ae9b9f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e33e78fc-17c1-4929-8dc3-7898d5ae9b9f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}},\"versions\":[{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1akwwopbt@example.com}\",\"displayName\":\"n2rmzgs34uq85a3\",\"originalName\":\"4p8w6o1yz15cnw7\",\"dateCreated\":\"2019-07-26T15:43:13.62Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c354bc38-ae1b-4a68-84ff-a52818e506cb\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f6a34084-d2ed-4f9d-915a-1d431cf43349\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4985a5a9-e709-44a1-887a-0d2e4da29e78\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/07cb2000-4eba-4692-b548-094e9e1753c7\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/29379177-fa05-4753-8d3b-2b11f8c8a61d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c354bc38-ae1b-4a68-84ff-a52818e506cb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"6f7fe701-07ce-49fa-a84f-e04fdf4bb077\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1542,\"refSeqNumber\":21}},\"3e1ebf4a-9352-4c6e-ba89-d249aba219aa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":523,\"refSeqNumber\":161}},\"3a601698-0866-4f69-9170-94526b6a2658\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"8ef7b582-4203-4f9c-9f4b-c5e3d80c4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"aaaaff65-11b8-4048-bca4-bc2f7a60d38d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1239,\"refSeqNumber\":351}},\"8190d444-21f7-4b2c-bc4b-0e902415edca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":105,\"refSeqNumber\":311}},\"a3a91eb3-79dd-4e3d-8292-f7da6f976cdf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":311}},\"b3d0984c-38c4-45b9-a0af-af2473a0a24a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1206,\"pos\":638,\"refSeqNumber\":351}},\"298bcec9-c321-486d-b10e-886c7345edbf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":414}},\"f8c3c32b-d0cc-4342-a18f-2ec122223202\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":59,\"refSeqNumber\":422}},\"1aa64e2e-8086-47ba-8847-bb729506beda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":750,\"refSeqNumber\":773}},\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":808}},\"9549c9e8-9afa-430d-acf2-e4713d13e0af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":939}},\"da508758-647c-4d00-87d4-4881fadd8646\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":969}},\"9dc1dba8-a16d-4345-9717-24fa8bda74a7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"2165785e-45ec-41ef-b7f9-31524daa6bae\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"4e0e2fc8-901e-4b6b-b6af-4ef6c9654c43\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"117e684d-2a43-462c-a171-fe6f30e93600\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1019}},\"9b387c62-d2a1-4da6-8e04-9712967a4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1045}},\"fe291788-db90-4378-bfa7-d9511e003dd9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"3abcbab5-803b-46be-9f6d-d89225b88319\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"c07a6e4e-b956-4d31-96a8-94b56632b250\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1089}},\"2c7c8714-9718-4517-a7f0-4a7f3164eeea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1098}},\"4a9b3309-740e-46a8-8510-8e920b958844\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1404,\"refSeqNumber\":1098}},\"54ac5638-e6e4-480c-89c7-e1b7ec264036\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"0e09ff6d-7978-4f70-852b-d3dab0ca8feb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"6b36fbad-24a3-4f1b-8006-a0d6de0b0e50\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"a621388f-315f-40fd-a357-32a288133bab\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"c75b5e91-5b08-413c-a628-edb469164f92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1350}},\"2c1122ab-96e1-4f62-a38b-5d3405f9de64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1319}},\"d5834525-608a-4539-8245-5afaf1a5473c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"289e0bf9-4c26-448f-a1f6-dc1018ac0b4b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"a4e16b3a-f769-4e83-a31e-8d7e69239fd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"d3858790-2944-46ab-b1c8-35424299a7fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1439}},\"96d01fc6-5bf0-4a5f-b921-f77db4f8b29d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1445}},\"1cad14a3-da07-4b2a-ab4a-04fb52e487c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1457}},\"26b1bb92-7496-4e85-a551-914d3b4b94e8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1465}},\"c00b82e2-7de2-4f28-8fa8-2209ba76fd24\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1524}},\"04ffb8b9-a032-4c5f-9b52-68ae3259d013\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1528}},\"11101188-d8fe-4f01-a2dc-7a8e1b4e6bfb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1553}},\"9c563510-e46c-476f-97c5-1f6ce9c70789\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1528,\"refSeqNumber\":1620}},\"ace042dc-afde-443b-9907-6fdb54f88267\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1747}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f6a34084-d2ed-4f9d-915a-1d431cf43349",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f49543e5-85ab-41c3-a098-d62c43623d20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4985a5a9-e709-44a1-887a-0d2e4da29e78",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f49543e5-85ab-41c3-a098-d62c43623d20\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":25,\"chunkLengthChars\":1529,\"totalLengthChars\":1529,\"totalSegmentCount\":25,\"chunkSequenceNumber\":1996,\"segmentTexts\":[{\"text\":\"xrvkbyw4qd8a91ad9cuqqnhzyqyno2cr46cjrb1cqxjb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3666f69e-f0c7-4842-9cf5-315c4e2b4c6f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"xvpj1auf4gkb952ccebnrhdsgladadenucv8pu5kh5i5tfnz12yh146e6680wi1tfaom88x2xcubek9ldkrwey4hdyu9msktawxgbh8adviccss3qyfn03hm3sl5egmhqaffvo5ohjkpsk4ng2raysdavybrkxrtlrby8xxssk71w0hf0uy6kfzaipw6f2y1ubed15qo5udb8xtv0jldydbps9gt33gsukkp2csmbc2ezew\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"077ddf84-7093-41da-9259-454d6897bcf4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"5a0tt94bp9j5v0o92imghin2kreker9jcqt1mgh5pwrzg5106ztafk4g4mixsx8c6xe82ip4l7cto1n87jgpsp1bswibdmjjeki76b0tciuoso086ahyf264kjdthnuglafkchmerjgtn7a3jdfqq704r2cur835uny2y206lir4c2d8nqib93ur0pp4sg7hg2l5kwr4cfo17fidb7qea9n2xv7riph6liobrj4hkfsf9m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4b858020-d41d-4de3-a2e5-ff6df955a8f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList21\"}}},{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"5377cbz6wj7mlscjytvrigubrk0snibg2je43fbwjiirrcnmg7uwbg3flblpfh9buswscpfybo4q7n1sy5u5nlce1wqqqe1cxl8cn5huv7mf9z34c8fo050xaxurhk9eklxcxrc35xrnf65n6hmljl67wghkmrzajua87n3eanshizw1xzu20s91919bkdzotu2eoqdnoh29wss73fa67b5ijiendgntkl11aygob52eip25ha9q1w6uixcwn\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd49eb82-6519-449e-b14a-762765b3a545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3vhab988628l0wzydcuy59en4c3sgyvevmuzs672uu36s5jxkujxgvgcbyhk7hkcsjypdnj00lyw1mrylwdgezvrjha1u05hbxvdw4gy1z4tzs68ye169qfbvxx7unooio5smteviyzj3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"a34c7f1d-0067-4043-bb07-7e1776f63a13\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\",\"display\":\"inline-block\"}}},{\"text\":\"rz9o3qwh9r8uwp8fle5dq8zqtzq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"125cce6f-ba64-4ef4-b3be-2faabd773abd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-118\"}}},{\"text\":\"v5p4xve2tckbputwulgquvaipo514z93j3p72vdy5m2kz93ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b307a75f-210d-49b2-87a4-2a58f0708335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"r255jwjumcpjjfdyijrjmdcbo2u7q214hjqol453325k1o3gyxe6g9yotg2a2laemzxcspex971utzn2ohj2nc47tyejjcakgrokhmp3nv53oos7v6zjy0i1c32l2ckqi27nap51vubvmkafxfpv3jcpftnyxo1mzpuk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"221814fa-d3e3-43e2-a55d-b7952fd6849b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3km3pznthwa81on7zhidx75dk4ih0i8a6bsg2nig2pqfhs0tf8ch1oc3ep87g8uvh6txft8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1bb718dd-2f4f-450f-b46a-4552f54de26b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"2679qwvgyzjjrjolhtymwsdzs0jzqhmfr8m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"950358dd-305e-4d4a-a82a-e160d20390e5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"slrko0dk5wv70amunkc8ykjyrx5d9logjdf04vmkx80l7s403094v7fwvosipogkv6g796h1mi8b329lffn9jlp1zj6i1wvcczjhlv2a718pdqkmpsnn6xrxtke938emok0tjdlu6evz9adu4tzkfs96n5di5rhgb7kfeco1390w97xip7b6ghd5pp7szxinrqlzu7jm43g8b72thm3b6mjjwkb53l9gxqkhpz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c3d7a93d-4320-4947-91b9-2681ca4919f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList91\"}}},{\"text\":\"jxrzx10m7js0v80w6jr9biclf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"213e8528-cd3d-434b-9e02-0656c194ebb7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList102\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1996,\"totalLength\":1529,\"totalSegmentCount\":25}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "07cb2000-4eba-4692-b548-094e9e1753c7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/575bf4db-6719-4b69-999d-f854c38611ec\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/048dd808-9fae-44a4-b6e3-f3d59e0dd65a\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e87dd691-f7e3-4397-ac30-01ef3187b00f\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/db6e7e53-0cff-470d-a24e-18345ad33689\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/56afc408-b221-41b6-ad42-ff3c1eb2bf6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1956ecb0-0186-433b-bb79-740c7e46d060\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6077cbc4-ea6c-4ade-83a0-7317c976f2de\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "575bf4db-6719-4b69-999d-f854c38611ec",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "048dd808-9fae-44a4-b6e3-f3d59e0dd65a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e87dd691-f7e3-4397-ac30-01ef3187b00f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "db6e7e53-0cff-470d-a24e-18345ad33689",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56afc408-b221-41b6-ad42-ff3c1eb2bf6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1956ecb0-0186-433b-bb79-740c7e46d060",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6077cbc4-ea6c-4ade-83a0-7317c976f2de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "29379177-fa05-4753-8d3b-2b11f8c8a61d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList21\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ee814639-d114-4ad6-8e0d-f5bba3f8304d\"}},\"listRegistryList-118\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/72a72863-eff7-43f5-a4d3-4a32518d4a50\"}},\"listRegistryList89\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c11561bf-c1c7-4e58-9411-ac6e414e7989\"}},\"listRegistryList91\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/561c29d4-c219-4fcb-a66f-1339cdae01e8\"}},\"listRegistryList102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/403979ed-3135-4261-bf84-e3d31e4a6696\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ee814639-d114-4ad6-8e0d-f5bba3f8304d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList21\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "72a72863-eff7-43f5-a4d3-4a32518d4a50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-118\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c11561bf-c1c7-4e58-9411-ac6e414e7989",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList89\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "561c29d4-c219-4fcb-a66f-1339cdae01e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList91\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "403979ed-3135-4261-bf84-e3d31e4a6696",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":1996,\"referenceSequenceNumber\":-1,\"sequenceNumber\":2000,\"timestamp\":1564521490337,\"type\":\"leave\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2995,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"f56a3f29-9dbe-4e13-bad3-c86d3a382d1c\",{\"client\":{\"user\":{\"id\":\"i5qf2oe1s@example.com}\",\"name\":\"ha1zc90n5s4is05\",\"email\":\"lr5nmaklk@example.com}\"}},\"sequenceNumber\":799}],[\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\",{\"client\":{\"user\":{\"id\":\"qtsm3ex40@example.com}\",\"name\":\"k9v3ttlk9xmemnr\",\"email\":\"37viuid7m@example.com}\"}},\"sequenceNumber\":812}],[\"b0ae2681-9d90-4187-97cd-b04a0e538a17\",{\"client\":{\"user\":{\"id\":\"ak17athdd@example.com}\",\"name\":\"e8f1ihq403j95nc\",\"email\":\"dx4ic3v8i@example.com}\"}},\"sequenceNumber\":950}],[\"da508758-647c-4d00-87d4-4881fadd8646\",{\"client\":{\"user\":{\"id\":\"5p96o3s2x@example.com}\",\"name\":\"le3fhshoi1lx6h9\",\"email\":\"mrn14oye0@example.com}\"}},\"sequenceNumber\":974}],[\"4a9b3309-740e-46a8-8510-8e920b958844\",{\"client\":{\"user\":{\"id\":\"hwhhyrkc3@example.com}\",\"name\":\"dtx9ju4vs8nlqih\",\"email\":\"jf67khpqd@example.com}\"}},\"sequenceNumber\":1118}],[\"6b9e7cd6-de65-4f03-8bc9-ac8735eaad4e\",{\"client\":{\"user\":{\"id\":\"ldqebeq2e@example.com}\",\"name\":\"biqjqoisuerciwd\",\"email\":\"bte7s15si@example.com}\"}},\"sequenceNumber\":1136}],[\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\",{\"client\":{\"user\":{\"id\":\"gehkhnn4u@example.com}\",\"name\":\"0grcark2zibpfgg\",\"email\":\"gwxoscej2@example.com}\"}},\"sequenceNumber\":1359}],[\"793851ab-91e3-4f11-9349-97ec25a88335\",{\"client\":{\"user\":{\"id\":\"nwlwbsdsz@example.com}\",\"name\":\"3rfe6k83t6r7qxi\",\"email\":\"mq6ytytdb@example.com}\"}},\"sequenceNumber\":1366}],[\"aee5f6c8-5124-49ec-ab31-f9205762584f\",{\"client\":{\"user\":{\"id\":\"tso13d4yk@example.com}\",\"name\":\"w2qlcj1cjkt2ivu\",\"email\":\"jgav1zk1k@example.com}\"}},\"sequenceNumber\":1367}],[\"851b68ad-6a89-4609-b169-3e6f1ce9d2ed\",{\"client\":{\"user\":{\"id\":\"fcexseulk@example.com}\",\"name\":\"x29u3v4bb5gra1q\",\"email\":\"lpo6t6x6e@example.com}\"}},\"sequenceNumber\":1657}],[\"0894a87b-36c4-42af-9b58-210058cfa8f8\",{\"client\":{\"user\":{\"id\":\"apsrmpias@example.com}\",\"name\":\"egspi7aqtlf0sd5\",\"email\":\"xv5qlk6k2@example.com}\"}},\"sequenceNumber\":1663}],[\"8209106c-5d33-4a16-ac1b-07ce37089697\",{\"client\":{\"user\":{\"id\":\"5m7clos2w@example.com}\",\"name\":\"txfng5iyfxl8wly\",\"email\":\"o9t1ytz1d@example.com}\"}},\"sequenceNumber\":1684}],[\"02791be6-0f5d-4edd-b74b-13aba9b82b47\",{\"client\":{\"user\":{\"id\":\"v6gt4so1a@example.com}\",\"name\":\"kjvzi5310lmhool\",\"email\":\"n9s5oiswk@example.com}\"}},\"sequenceNumber\":1715}],[\"32a17145-04d0-4567-ad8f-5c3df3c2e314\",{\"client\":{\"user\":{\"id\":\"uxrthb7hn@example.com}\",\"name\":\"zsz9jzzwk6cx9yg\",\"email\":\"tp1mdgy1a@example.com}\"}},\"sequenceNumber\":2211}],[\"568e11bf-7189-4b3f-b283-534b178cc023\",{\"client\":{\"user\":{\"id\":\"h2va3xnc6@example.com}\",\"name\":\"eoba0qcq7kidrkr\",\"email\":\"a008uyzxn@example.com}\"}},\"sequenceNumber\":2256}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/e33e78fc-17c1-4929-8dc3-7898d5ae9b9f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e33e78fc-17c1-4929-8dc3-7898d5ae9b9f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}},\"versions\":[{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1akwwopbt@example.com}\",\"displayName\":\"n2rmzgs34uq85a3\",\"originalName\":\"4p8w6o1yz15cnw7\",\"dateCreated\":\"2019-07-26T15:43:13.62Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c354bc38-ae1b-4a68-84ff-a52818e506cb\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f6a34084-d2ed-4f9d-915a-1d431cf43349\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4985a5a9-e709-44a1-887a-0d2e4da29e78\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/07cb2000-4eba-4692-b548-094e9e1753c7\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/29379177-fa05-4753-8d3b-2b11f8c8a61d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c354bc38-ae1b-4a68-84ff-a52818e506cb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"6f7fe701-07ce-49fa-a84f-e04fdf4bb077\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1542,\"refSeqNumber\":21}},\"3e1ebf4a-9352-4c6e-ba89-d249aba219aa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":523,\"refSeqNumber\":161}},\"3a601698-0866-4f69-9170-94526b6a2658\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"8ef7b582-4203-4f9c-9f4b-c5e3d80c4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"aaaaff65-11b8-4048-bca4-bc2f7a60d38d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1239,\"refSeqNumber\":351}},\"8190d444-21f7-4b2c-bc4b-0e902415edca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":105,\"refSeqNumber\":311}},\"a3a91eb3-79dd-4e3d-8292-f7da6f976cdf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":311}},\"b3d0984c-38c4-45b9-a0af-af2473a0a24a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1206,\"pos\":638,\"refSeqNumber\":351}},\"298bcec9-c321-486d-b10e-886c7345edbf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":414}},\"f8c3c32b-d0cc-4342-a18f-2ec122223202\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":59,\"refSeqNumber\":422}},\"1aa64e2e-8086-47ba-8847-bb729506beda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":750,\"refSeqNumber\":773}},\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":808}},\"9549c9e8-9afa-430d-acf2-e4713d13e0af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":939}},\"da508758-647c-4d00-87d4-4881fadd8646\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":969}},\"9dc1dba8-a16d-4345-9717-24fa8bda74a7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"2165785e-45ec-41ef-b7f9-31524daa6bae\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"4e0e2fc8-901e-4b6b-b6af-4ef6c9654c43\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"117e684d-2a43-462c-a171-fe6f30e93600\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1019}},\"9b387c62-d2a1-4da6-8e04-9712967a4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1045}},\"fe291788-db90-4378-bfa7-d9511e003dd9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"3abcbab5-803b-46be-9f6d-d89225b88319\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"c07a6e4e-b956-4d31-96a8-94b56632b250\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1089}},\"2c7c8714-9718-4517-a7f0-4a7f3164eeea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1098}},\"4a9b3309-740e-46a8-8510-8e920b958844\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1404,\"refSeqNumber\":1098}},\"54ac5638-e6e4-480c-89c7-e1b7ec264036\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"0e09ff6d-7978-4f70-852b-d3dab0ca8feb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"6b36fbad-24a3-4f1b-8006-a0d6de0b0e50\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"a621388f-315f-40fd-a357-32a288133bab\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"c75b5e91-5b08-413c-a628-edb469164f92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1350}},\"2c1122ab-96e1-4f62-a38b-5d3405f9de64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1319}},\"d5834525-608a-4539-8245-5afaf1a5473c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"289e0bf9-4c26-448f-a1f6-dc1018ac0b4b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"a4e16b3a-f769-4e83-a31e-8d7e69239fd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"d3858790-2944-46ab-b1c8-35424299a7fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1439}},\"96d01fc6-5bf0-4a5f-b921-f77db4f8b29d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1445}},\"1cad14a3-da07-4b2a-ab4a-04fb52e487c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1457}},\"26b1bb92-7496-4e85-a551-914d3b4b94e8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1465}},\"c00b82e2-7de2-4f28-8fa8-2209ba76fd24\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1524}},\"04ffb8b9-a032-4c5f-9b52-68ae3259d013\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1528}},\"11101188-d8fe-4f01-a2dc-7a8e1b4e6bfb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1553}},\"9c563510-e46c-476f-97c5-1f6ce9c70789\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1528,\"refSeqNumber\":1620}},\"ace042dc-afde-443b-9907-6fdb54f88267\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1747}},\"19e39f66-ec50-43aa-b8f6-089b334ebc1c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2088}},\"e9ef7716-0f41-4f18-93fa-990564a05a2e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2137}},\"32a17145-04d0-4567-ad8f-5c3df3c2e314\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2210}},\"7efacc11-813c-4480-90f5-bef878f19207\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2240}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f6a34084-d2ed-4f9d-915a-1d431cf43349",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f49543e5-85ab-41c3-a098-d62c43623d20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4985a5a9-e709-44a1-887a-0d2e4da29e78",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f49543e5-85ab-41c3-a098-d62c43623d20\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":25,\"chunkLengthChars\":1529,\"totalLengthChars\":1529,\"totalSegmentCount\":25,\"chunkSequenceNumber\":2995,\"segmentTexts\":[{\"text\":\"xrvkbyw4qd8a91ad9cuqqnhzyqyno2cr46cjrb1cqxjb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3666f69e-f0c7-4842-9cf5-315c4e2b4c6f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"xvpj1auf4gkb952ccebnrhdsgladadenucv8pu5kh5i5tfnz12yh146e6680wi1tfaom88x2xcubek9ldkrwey4hdyu9msktawxgbh8adviccss3qyfn03hm3sl5egmhqaffvo5ohjkpsk4ng2raysdavybrkxrtlrby8xxssk71w0hf0uy6kfzaipw6f2y1ubed15qo5udb8xtv0jldydbps9gt33gsukkp2csmbc2ezew\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"077ddf84-7093-41da-9259-454d6897bcf4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"5a0tt94bp9j5v0o92imghin2kreker9jcqt1mgh5pwrzg5106ztafk4g4mixsx8c6xe82ip4l7cto1n87jgpsp1bswibdmjjeki76b0tciuoso086ahyf264kjdthnuglafkchmerjgtn7a3jdfqq704r2cur835uny2y206lir4c2d8nqib93ur0pp4sg7hg2l5kwr4cfo17fidb7qea9n2xv7riph6liobrj4hkfsf9m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4b858020-d41d-4de3-a2e5-ff6df955a8f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList21\"}}},{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"5377cbz6wj7mlscjytvrigubrk0snibg2je43fbwjiirrcnmg7uwbg3flblpfh9buswscpfybo4q7n1sy5u5nlce1wqqqe1cxl8cn5huv7mf9z34c8fo050xaxurhk9eklxcxrc35xrnf65n6hmljl67wghkmrzajua87n3eanshizw1xzu20s91919bkdzotu2eoqdnoh29wss73fa67b5ijiendgntkl11aygob52eip25ha9q1w6uixcwn\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd49eb82-6519-449e-b14a-762765b3a545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3vhab988628l0wzydcuy59en4c3sgyvevmuzs672uu36s5jxkujxgvgcbyhk7hkcsjypdnj00lyw1mrylwdgezvrjha1u05hbxvdw4gy1z4tzs68ye169qfbvxx7unooio5smteviyzj3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"a34c7f1d-0067-4043-bb07-7e1776f63a13\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\",\"display\":\"inline-block\"}}},{\"text\":\"rz9o3qwh9r8uwp8fle5dq8zqtzq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"125cce6f-ba64-4ef4-b3be-2faabd773abd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-118\"}}},{\"text\":\"v5p4xve2tckbputwulgquvaipo514z93j3p72vdy5m2kz93ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b307a75f-210d-49b2-87a4-2a58f0708335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"r255jwjumcpjjfdyijrjmdcbo2u7q214hjqol453325k1o3gyxe6g9yotg2a2laemzxcspex971utzn2ohj2nc47tyejjcakgrokhmp3nv53oos7v6zjy0i1c32l2ckqi27nap51vubvmkafxfpv3jcpftnyxo1mzpuk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"221814fa-d3e3-43e2-a55d-b7952fd6849b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3km3pznthwa81on7zhidx75dk4ih0i8a6bsg2nig2pqfhs0tf8ch1oc3ep87g8uvh6txft8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1bb718dd-2f4f-450f-b46a-4552f54de26b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"2679qwvgyzjjrjolhtymwsdzs0jzqhmfr8m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"950358dd-305e-4d4a-a82a-e160d20390e5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"slrko0dk5wv70amunkc8ykjyrx5d9logjdf04vmkx80l7s403094v7fwvosipogkv6g796h1mi8b329lffn9jlp1zj6i1wvcczjhlv2a718pdqkmpsnn6xrxtke938emok0tjdlu6evz9adu4tzkfs96n5di5rhgb7kfeco1390w97xip7b6ghd5pp7szxinrqlzu7jm43g8b72thm3b6mjjwkb53l9gxqkhpz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c3d7a93d-4320-4947-91b9-2681ca4919f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList91\"}}},{\"text\":\"jxrzx10m7js0v80w6jr9biclf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"213e8528-cd3d-434b-9e02-0656c194ebb7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList102\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2995,\"totalLength\":1529,\"totalSegmentCount\":25}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "07cb2000-4eba-4692-b548-094e9e1753c7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/575bf4db-6719-4b69-999d-f854c38611ec\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/048dd808-9fae-44a4-b6e3-f3d59e0dd65a\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e87dd691-f7e3-4397-ac30-01ef3187b00f\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/db6e7e53-0cff-470d-a24e-18345ad33689\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/56afc408-b221-41b6-ad42-ff3c1eb2bf6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1956ecb0-0186-433b-bb79-740c7e46d060\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6077cbc4-ea6c-4ade-83a0-7317c976f2de\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "575bf4db-6719-4b69-999d-f854c38611ec",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "048dd808-9fae-44a4-b6e3-f3d59e0dd65a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e87dd691-f7e3-4397-ac30-01ef3187b00f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "db6e7e53-0cff-470d-a24e-18345ad33689",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56afc408-b221-41b6-ad42-ff3c1eb2bf6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1956ecb0-0186-433b-bb79-740c7e46d060",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6077cbc4-ea6c-4ade-83a0-7317c976f2de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "29379177-fa05-4753-8d3b-2b11f8c8a61d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList21\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ee814639-d114-4ad6-8e0d-f5bba3f8304d\"}},\"listRegistryList-118\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/72a72863-eff7-43f5-a4d3-4a32518d4a50\"}},\"listRegistryList89\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c11561bf-c1c7-4e58-9411-ac6e414e7989\"}},\"listRegistryList91\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/561c29d4-c219-4fcb-a66f-1339cdae01e8\"}},\"listRegistryList102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/403979ed-3135-4261-bf84-e3d31e4a6696\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ee814639-d114-4ad6-8e0d-f5bba3f8304d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList21\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "72a72863-eff7-43f5-a4d3-4a32518d4a50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-118\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c11561bf-c1c7-4e58-9411-ac6e414e7989",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList89\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "561c29d4-c219-4fcb-a66f-1339cdae01e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList91\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "403979ed-3135-4261-bf84-e3d31e4a6696",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"32a17145-04d0-4567-ad8f-5c3df3c2e314\",\"clientSequenceNumber\":393,\"minimumSequenceNumber\":2995,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1564604930496,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_3461_0.json
+++ b/snapshotTestContent/HotBugs2/src_snapshots/0.59.3000/snapshot_3461_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3460,\"sequenceNumber\":3461,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"f56a3f29-9dbe-4e13-bad3-c86d3a382d1c\",{\"client\":{\"user\":{\"id\":\"i5qf2oe1s@example.com}\",\"name\":\"ha1zc90n5s4is05\",\"email\":\"lr5nmaklk@example.com}\"}},\"sequenceNumber\":799}],[\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\",{\"client\":{\"user\":{\"id\":\"qtsm3ex40@example.com}\",\"name\":\"k9v3ttlk9xmemnr\",\"email\":\"37viuid7m@example.com}\"}},\"sequenceNumber\":812}],[\"b0ae2681-9d90-4187-97cd-b04a0e538a17\",{\"client\":{\"user\":{\"id\":\"ak17athdd@example.com}\",\"name\":\"e8f1ihq403j95nc\",\"email\":\"dx4ic3v8i@example.com}\"}},\"sequenceNumber\":950}],[\"da508758-647c-4d00-87d4-4881fadd8646\",{\"client\":{\"user\":{\"id\":\"5p96o3s2x@example.com}\",\"name\":\"le3fhshoi1lx6h9\",\"email\":\"mrn14oye0@example.com}\"}},\"sequenceNumber\":974}],[\"4a9b3309-740e-46a8-8510-8e920b958844\",{\"client\":{\"user\":{\"id\":\"hwhhyrkc3@example.com}\",\"name\":\"dtx9ju4vs8nlqih\",\"email\":\"jf67khpqd@example.com}\"}},\"sequenceNumber\":1118}],[\"6b9e7cd6-de65-4f03-8bc9-ac8735eaad4e\",{\"client\":{\"user\":{\"id\":\"ldqebeq2e@example.com}\",\"name\":\"biqjqoisuerciwd\",\"email\":\"bte7s15si@example.com}\"}},\"sequenceNumber\":1136}],[\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\",{\"client\":{\"user\":{\"id\":\"gehkhnn4u@example.com}\",\"name\":\"0grcark2zibpfgg\",\"email\":\"gwxoscej2@example.com}\"}},\"sequenceNumber\":1359}],[\"793851ab-91e3-4f11-9349-97ec25a88335\",{\"client\":{\"user\":{\"id\":\"nwlwbsdsz@example.com}\",\"name\":\"3rfe6k83t6r7qxi\",\"email\":\"mq6ytytdb@example.com}\"}},\"sequenceNumber\":1366}],[\"aee5f6c8-5124-49ec-ab31-f9205762584f\",{\"client\":{\"user\":{\"id\":\"tso13d4yk@example.com}\",\"name\":\"w2qlcj1cjkt2ivu\",\"email\":\"jgav1zk1k@example.com}\"}},\"sequenceNumber\":1367}],[\"851b68ad-6a89-4609-b169-3e6f1ce9d2ed\",{\"client\":{\"user\":{\"id\":\"fcexseulk@example.com}\",\"name\":\"x29u3v4bb5gra1q\",\"email\":\"lpo6t6x6e@example.com}\"}},\"sequenceNumber\":1657}],[\"0894a87b-36c4-42af-9b58-210058cfa8f8\",{\"client\":{\"user\":{\"id\":\"apsrmpias@example.com}\",\"name\":\"egspi7aqtlf0sd5\",\"email\":\"xv5qlk6k2@example.com}\"}},\"sequenceNumber\":1663}],[\"8209106c-5d33-4a16-ac1b-07ce37089697\",{\"client\":{\"user\":{\"id\":\"5m7clos2w@example.com}\",\"name\":\"txfng5iyfxl8wly\",\"email\":\"o9t1ytz1d@example.com}\"}},\"sequenceNumber\":1684}],[\"02791be6-0f5d-4edd-b74b-13aba9b82b47\",{\"client\":{\"user\":{\"id\":\"v6gt4so1a@example.com}\",\"name\":\"kjvzi5310lmhool\",\"email\":\"n9s5oiswk@example.com}\"}},\"sequenceNumber\":1715}],[\"2ee81962-8b5e-47fe-a512-69828d18f748\",{\"client\":{\"user\":{\"id\":\"817umc2rr@example.com}\",\"name\":\"hu29pn0u8cmtrdw\",\"email\":\"rzm2qn2u0@example.com}\"}},\"sequenceNumber\":3429}],[\"ab305342-2ece-42f8-abcb-c6e33eb36470\",{\"client\":{\"user\":{\"id\":\"4cin1jbf0@example.com}\",\"name\":\"eemk1rh9rut6o4s\",\"email\":\"p2xtixvt4@example.com}\"}},\"sequenceNumber\":3435}],[\"8d1f587c-6f46-43dd-81cb-223e361ebc48\",{\"client\":{\"user\":{\"id\":\"ks8wwbmp2@example.com}\",\"name\":\"dm3u6rxfzjp6zdm\",\"email\":\"5oa1pznn5@example.com}\"}},\"sequenceNumber\":3441}],[\"16847e78-c436-4e77-9e8a-75512bc71e14\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"txo8aeq1u@example.com}\",\"name\":\"bovp1pum1iezedm\",\"email\":\"gptrxopoi@example.com}\"}},\"sequenceNumber\":3461}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/e33e78fc-17c1-4929-8dc3-7898d5ae9b9f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e33e78fc-17c1-4929-8dc3-7898d5ae9b9f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}},\"versions\":[{\"sequenceNumber\":817,\"value\":{\"type\":\"Plain\",\"value\":\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1akwwopbt@example.com}\",\"displayName\":\"n2rmzgs34uq85a3\",\"originalName\":\"4p8w6o1yz15cnw7\",\"dateCreated\":\"2019-07-26T15:43:13.62Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c354bc38-ae1b-4a68-84ff-a52818e506cb\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f6a34084-d2ed-4f9d-915a-1d431cf43349\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4985a5a9-e709-44a1-887a-0d2e4da29e78\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/07cb2000-4eba-4692-b548-094e9e1753c7\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/29379177-fa05-4753-8d3b-2b11f8c8a61d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c354bc38-ae1b-4a68-84ff-a52818e506cb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"6f7fe701-07ce-49fa-a84f-e04fdf4bb077\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1542,\"refSeqNumber\":21}},\"3e1ebf4a-9352-4c6e-ba89-d249aba219aa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":523,\"refSeqNumber\":161}},\"3a601698-0866-4f69-9170-94526b6a2658\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"8ef7b582-4203-4f9c-9f4b-c5e3d80c4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":186}},\"aaaaff65-11b8-4048-bca4-bc2f7a60d38d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1239,\"refSeqNumber\":351}},\"8190d444-21f7-4b2c-bc4b-0e902415edca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":105,\"refSeqNumber\":311}},\"a3a91eb3-79dd-4e3d-8292-f7da6f976cdf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":311}},\"b3d0984c-38c4-45b9-a0af-af2473a0a24a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1206,\"pos\":638,\"refSeqNumber\":351}},\"298bcec9-c321-486d-b10e-886c7345edbf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":414}},\"f8c3c32b-d0cc-4342-a18f-2ec122223202\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":59,\"refSeqNumber\":422}},\"1aa64e2e-8086-47ba-8847-bb729506beda\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":750,\"refSeqNumber\":773}},\"73bb6a1f-36d6-4e10-bd40-6318e992b42e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":808}},\"9549c9e8-9afa-430d-acf2-e4713d13e0af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":939}},\"da508758-647c-4d00-87d4-4881fadd8646\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":969}},\"9dc1dba8-a16d-4345-9717-24fa8bda74a7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"2165785e-45ec-41ef-b7f9-31524daa6bae\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"4e0e2fc8-901e-4b6b-b6af-4ef6c9654c43\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":994}},\"117e684d-2a43-462c-a171-fe6f30e93600\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1019}},\"9b387c62-d2a1-4da6-8e04-9712967a4493\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1045}},\"fe291788-db90-4378-bfa7-d9511e003dd9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"3abcbab5-803b-46be-9f6d-d89225b88319\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1059}},\"c07a6e4e-b956-4d31-96a8-94b56632b250\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1089}},\"2c7c8714-9718-4517-a7f0-4a7f3164eeea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1098}},\"4a9b3309-740e-46a8-8510-8e920b958844\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1404,\"refSeqNumber\":1098}},\"54ac5638-e6e4-480c-89c7-e1b7ec264036\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"0e09ff6d-7978-4f70-852b-d3dab0ca8feb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"6b36fbad-24a3-4f1b-8006-a0d6de0b0e50\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1160}},\"a621388f-315f-40fd-a357-32a288133bab\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"c75b5e91-5b08-413c-a628-edb469164f92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1285}},\"aada59da-aa07-43cd-a4c0-675ef18f2d1b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1350}},\"2c1122ab-96e1-4f62-a38b-5d3405f9de64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1319}},\"d5834525-608a-4539-8245-5afaf1a5473c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"289e0bf9-4c26-448f-a1f6-dc1018ac0b4b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"a4e16b3a-f769-4e83-a31e-8d7e69239fd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1378}},\"d3858790-2944-46ab-b1c8-35424299a7fa\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1439}},\"96d01fc6-5bf0-4a5f-b921-f77db4f8b29d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1445}},\"1cad14a3-da07-4b2a-ab4a-04fb52e487c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1457}},\"26b1bb92-7496-4e85-a551-914d3b4b94e8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1465}},\"c00b82e2-7de2-4f28-8fa8-2209ba76fd24\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1524}},\"04ffb8b9-a032-4c5f-9b52-68ae3259d013\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1528}},\"11101188-d8fe-4f01-a2dc-7a8e1b4e6bfb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1553}},\"9c563510-e46c-476f-97c5-1f6ce9c70789\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1528,\"refSeqNumber\":1620}},\"ace042dc-afde-443b-9907-6fdb54f88267\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1747}},\"19e39f66-ec50-43aa-b8f6-089b334ebc1c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2088}},\"e9ef7716-0f41-4f18-93fa-990564a05a2e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2137}},\"32a17145-04d0-4567-ad8f-5c3df3c2e314\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2210}},\"7efacc11-813c-4480-90f5-bef878f19207\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2240}},\"cf0600d2-c40d-42f5-a818-65027117d702\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3340}},\"9b561845-e960-4d02-8cfd-9e67ab69ba6b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":294,\"pos\":285,\"refSeqNumber\":3351}},\"caa1fce2-6f6b-44db-be3e-cd7705d34e01\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3385}},\"5ce6fe75-cbbf-4517-8616-476da7cf2075\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3412}},\"2ee81962-8b5e-47fe-a512-69828d18f748\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3426}},\"ab305342-2ece-42f8-abcb-c6e33eb36470\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3433}},\"0a053cb7-0dd4-4c1d-85c4-e199f4736749\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3441}},\"e88209c2-8b04-4213-bf52-5d3ad8fbcd27\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3441}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f6a34084-d2ed-4f9d-915a-1d431cf43349",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f49543e5-85ab-41c3-a098-d62c43623d20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4985a5a9-e709-44a1-887a-0d2e4da29e78",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f49543e5-85ab-41c3-a098-d62c43623d20\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":25,\"chunkLengthChars\":1529,\"totalLengthChars\":1529,\"totalSegmentCount\":25,\"chunkSequenceNumber\":3460,\"segmentTexts\":[{\"text\":\"xrvkbyw4qd8a91ad9cuqqnhzyqyno2cr46cjrb1cqxjb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3666f69e-f0c7-4842-9cf5-315c4e2b4c6f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"xvpj1auf4gkb952ccebnrhdsgladadenucv8pu5kh5i5tfnz12yh146e6680wi1tfaom88x2xcubek9ldkrwey4hdyu9msktawxgbh8adviccss3qyfn03hm3sl5egmhqaffvo5ohjkpsk4ng2raysdavybrkxrtlrby8xxssk71w0hf0uy6kfzaipw6f2y1ubed15qo5udb8xtv0jldydbps9gt33gsukkp2csmbc2ezew\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"077ddf84-7093-41da-9259-454d6897bcf4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"5a0tt94bp9j5v0o92imghin2kreker9jcqt1mgh5pwrzg5106ztafk4g4mixsx8c6xe82ip4l7cto1n87jgpsp1bswibdmjjeki76b0tciuoso086ahyf264kjdthnuglafkchmerjgtn7a3jdfqq704r2cur835uny2y206lir4c2d8nqib93ur0pp4sg7hg2l5kwr4cfo17fidb7qea9n2xv7riph6liobrj4hkfsf9m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4b858020-d41d-4de3-a2e5-ff6df955a8f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList21\"}}},{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"text\":\"5377cbz6wj7mlscjytvrigubrk0snibg2je43fbwjiirrcnmg7uwbg3flblpfh9buswscpfybo4q7n1sy5u5nlce1wqqqe1cxl8cn5huv7mf9z34c8fo050xaxurhk9eklxcxrc35xrnf65n6hmljl67wghkmrzajua87n3eanshizw1xzu20s91919bkdzotu2eoqdnoh29wss73fa67b5ijiendgntkl11aygob52eip25ha9q1w6uixcwn\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd49eb82-6519-449e-b14a-762765b3a545\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3vhab988628l0wzydcuy59en4c3sgyvevmuzs672uu36s5jxkujxgvgcbyhk7hkcsjypdnj00lyw1mrylwdgezvrjha1u05hbxvdw4gy1z4tzs68ye169qfbvxx7unooio5smteviyzj3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"a34c7f1d-0067-4043-bb07-7e1776f63a13\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/3c5bcb6f-fff1-48ab-927a-a5d9d7ec9cbe\",\"display\":\"inline-block\"}}},{\"text\":\"rz9o3qwh9r8uwp8fle5dq8zqtzq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"125cce6f-ba64-4ef4-b3be-2faabd773abd\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-118\"}}},{\"text\":\"v5p4xve2tckbputwulgquvaipo514z93j3p72vdy5m2kz93ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b307a75f-210d-49b2-87a4-2a58f0708335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"r255jwjumcpjjfdyijrjmdcbo2u7q214hjqol453325k1o3gyxe6g9yotg2a2laemzxcspex971utzn2ohj2nc47tyejjcakgrokhmp3nv53oos7v6zjy0i1c32l2ckqi27nap51vubvmkafxfpv3jcpftnyxo1mzpuk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"221814fa-d3e3-43e2-a55d-b7952fd6849b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"3km3pznthwa81on7zhidx75dk4ih0i8a6bsg2nig2pqfhs0tf8ch1oc3ep87g8uvh6txft8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1bb718dd-2f4f-450f-b46a-4552f54de26b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList89\"}}},{\"text\":\"2679qwvgyzjjrjolhtymwsdzs0jzqhmfr8m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"950358dd-305e-4d4a-a82a-e160d20390e5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"slrko0dk5wv70amunkc8ykjyrx5d9logjdf04vmkx80l7s403094v7fwvosipogkv6g796h1mi8b329lffn9jlp1zj6i1wvcczjhlv2a718pdqkmpsnn6xrxtke938emok0tjdlu6evz9adu4tzkfs96n5di5rhgb7kfeco1390w97xip7b6ghd5pp7szxinrqlzu7jm43g8b72thm3b6mjjwkb53l9gxqkhpz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c3d7a93d-4320-4947-91b9-2681ca4919f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList91\"}}},{\"text\":\"jxrzx10m7js0v80w6jr9biclf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"213e8528-cd3d-434b-9e02-0656c194ebb7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList102\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3460,\"totalLength\":1529,\"totalSegmentCount\":25}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "07cb2000-4eba-4692-b548-094e9e1753c7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/575bf4db-6719-4b69-999d-f854c38611ec\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/048dd808-9fae-44a4-b6e3-f3d59e0dd65a\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e87dd691-f7e3-4397-ac30-01ef3187b00f\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/db6e7e53-0cff-470d-a24e-18345ad33689\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/56afc408-b221-41b6-ad42-ff3c1eb2bf6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1956ecb0-0186-433b-bb79-740c7e46d060\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6077cbc4-ea6c-4ade-83a0-7317c976f2de\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "575bf4db-6719-4b69-999d-f854c38611ec",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "048dd808-9fae-44a4-b6e3-f3d59e0dd65a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e87dd691-f7e3-4397-ac30-01ef3187b00f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "db6e7e53-0cff-470d-a24e-18345ad33689",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56afc408-b221-41b6-ad42-ff3c1eb2bf6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1956ecb0-0186-433b-bb79-740c7e46d060",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6077cbc4-ea6c-4ade-83a0-7317c976f2de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "29379177-fa05-4753-8d3b-2b11f8c8a61d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList21\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ee814639-d114-4ad6-8e0d-f5bba3f8304d\"}},\"listRegistryList-118\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/72a72863-eff7-43f5-a4d3-4a32518d4a50\"}},\"listRegistryList89\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c11561bf-c1c7-4e58-9411-ac6e414e7989\"}},\"listRegistryList91\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/561c29d4-c219-4fcb-a66f-1339cdae01e8\"}},\"listRegistryList102\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/403979ed-3135-4261-bf84-e3d31e4a6696\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ee814639-d114-4ad6-8e0d-f5bba3f8304d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList21\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "72a72863-eff7-43f5-a4d3-4a32518d4a50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-118\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c11561bf-c1c7-4e58-9411-ac6e414e7989",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList89\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "561c29d4-c219-4fcb-a66f-1339cdae01e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList91\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "403979ed-3135-4261-bf84-e3d31e4a6696",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList102\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":3460,\"referenceSequenceNumber\":-1,\"sequenceNumber\":3461,\"timestamp\":1564767326960,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_10000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_10000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":9987,\"sequenceNumber\":10000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"a7e21367-d487-4482-a95d-c853d436860d\",{\"client\":{\"user\":{\"id\":\"08h56wlvs@example.com}\",\"name\":\"r1twh59xnfqo1vd\",\"email\":\"qjx5fz4pv@example.com}\"}},\"sequenceNumber\":7011}],[\"8e257b0a-3abf-47b5-893e-71a3554fcaa3\",{\"client\":{\"user\":{\"id\":\"4xxopwc3h@example.com}\",\"name\":\"tz7eti1tr1ia881\",\"email\":\"iwd1ioy3v@example.com}\"}},\"sequenceNumber\":7203}],[\"969a5cee-3efd-49db-879c-2ded9169042f\",{\"client\":{\"user\":{\"id\":\"d0xk8ay2p@example.com}\",\"name\":\"zl45bcqo99t1w8l\",\"email\":\"8pkfttpsh@example.com}\"}},\"sequenceNumber\":7330}],[\"c7713b00-fc44-4250-afda-63c7e531cb72\",{\"client\":{\"user\":{\"id\":\"ck80vpsvl@example.com}\",\"name\":\"12d48z207c1knqn\",\"email\":\"qvvnyxpt2@example.com}\"}},\"sequenceNumber\":8788}],[\"ce9d65a3-ac1f-4967-b83e-58eaeb88ab3f\",{\"client\":{\"user\":{\"id\":\"zliihwzp7@example.com}\",\"name\":\"xj2tkgcjl1kg4ve\",\"email\":\"6zdrvrir9@example.com}\"}},\"sequenceNumber\":8801}],[\"ea104d23-eb26-4969-9880-4e09f59dcc16\",{\"client\":{\"user\":{\"id\":\"ihhl1l2t9@example.com}\",\"name\":\"0nlju6ktl02r4mx\",\"email\":\"th4x111w9@example.com}\"}},\"sequenceNumber\":8828}],[\"b1e2d238-1377-4391-9bdb-7a846645059f\",{\"client\":{\"user\":{\"id\":\"3o85w7cnb@example.com}\",\"name\":\"1k4hnmonh1calsy\",\"email\":\"2r7aq66za@example.com}\"}},\"sequenceNumber\":8858}],[\"4a31718c-d9ad-40e5-aac3-552ec7389c1f\",{\"client\":{\"user\":{\"id\":\"55pxiqujp@example.com}\",\"name\":\"fapv9bf4aj5h5s1\",\"email\":\"m5v3w21kf@example.com}\"}},\"sequenceNumber\":8865}],[\"6cfec889-d47d-47f9-83d6-40b415c0cd64\",{\"client\":{\"user\":{\"id\":\"iwv0gz6pf@example.com}\",\"name\":\"l4rd51smixnl03i\",\"email\":\"kiap9mqvb@example.com}\"}},\"sequenceNumber\":8894}],[\"072c8040-4557-4190-a9d9-9e78b889e5fd\",{\"client\":{\"user\":{\"id\":\"k17wvfzx6@example.com}\",\"name\":\"prgdd0gbici58jr\",\"email\":\"vfp0fh25z@example.com}\"}},\"sequenceNumber\":8982}],[\"5c0be35b-b784-4bc8-b0d1-b784ca6108d1\",{\"client\":{\"user\":{\"id\":\"k6pkuntff@example.com}\",\"name\":\"ctpr0y08ewloi1a\",\"email\":\"k443qiuje@example.com}\"}},\"sequenceNumber\":9515}],[\"a054e44e-12dc-4e2f-b2e2-a90104616014\",{\"client\":{\"user\":{\"id\":\"h9m5b2bv1@example.com}\",\"name\":\"jjda9d9y5xrxeui\",\"email\":\"e3qzgmop6@example.com}\"}},\"sequenceNumber\":9528}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"a7e21367-d487-4482-a95d-c853d436860d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":171,\"refSeqNumber\":6971}},\"54e3fecd-9302-4e4a-bc53-6d0eb82d6730\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"41a81f73-67eb-4d48-96a8-fc3bc76be549\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7116}},\"0488f86a-f090-4901-8ec7-89c27e36ec94\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":350,\"pos\":485,\"refSeqNumber\":6971}},\"969a5cee-3efd-49db-879c-2ded9169042f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"7941fba5-9070-4705-8660-368225ef88a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7344}},\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6971}},\"34e1e2ca-7379-46f0-9a7f-c36cba9d5fbd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7208}},\"a79ae9cf-39d3-4661-baf5-1367e40983e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7332}},\"83f15f07-06cd-46f4-b366-98a6cc274650\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7401}},\"befebc61-f145-4a59-ac21-a6e5334db265\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7440}},\"b41bc100-6f95-4555-8a1b-3856148e0433\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7467}},\"80cb6e9b-0da6-4964-95e8-bb7bd13146da\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"671b9ea2-fe72-4ea5-9442-d5d55845f60f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"e2975b73-7939-4891-9bf5-27a1953863e6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":498,\"refSeqNumber\":7680}},\"b6391cf9-6a84-47da-96eb-368d088044af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":187,\"refSeqNumber\":8269}},\"1f1d1ab3-dcda-4ed4-8a19-42cda05b767e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8286}},\"e4b951bb-3c6d-4196-88eb-c8928628bbcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"ea104d23-eb26-4969-9880-4e09f59dcc16\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8821}},\"d04b2493-c128-4251-9351-1fad62aef7d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":62,\"refSeqNumber\":7680}},\"072c8040-4557-4190-a9d9-9e78b889e5fd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":816,\"refSeqNumber\":7680}},\"4016ee46-098d-4156-9e5a-c7ff29ef5bdd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2212,\"refSeqNumber\":9163}},\"0fb8e28d-b064-4cad-9bb0-df91a75bd966\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":133,\"pos\":137,\"refSeqNumber\":9265}},\"a054e44e-12dc-4e2f-b2e2-a90104616014\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":714,\"refSeqNumber\":9529}},\"a08ea056-16b2-4c44-bfff-8eef11e686ec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2013,\"refSeqNumber\":9529}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":98,\"chunkLengthChars\":2214,\"totalLengthChars\":2214,\"totalSegmentCount\":98,\"chunkSequenceNumber\":9987,\"segmentTexts\":[{\"text\":\"46ynxt67\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"dyh7ixcw48que8c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"text\":\"asv39xkbj5c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p\",{\"text\":\"8u47bcc\",\"props\":{\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0835-0000-000000000000}\":false}},\"a6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"text\":\"uqdq585fu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5e7654de-0c09-4a99-b138-9872f90272ad\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d7d08548-e6d0-4580-9eb6-1c794d7cb74c\",\"display\":\"inline-block\"}}},{\"text\":\"krm6cdy34finy6ms9d3c94ry8e7s0zt79i0gi8azwccntrybrt\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5724d074-3621-4463-979b-d7aeb09c35a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-48\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3438f1ed-eb23-46a6-b951-f27a732bf9d4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"hjvknzrah32snoa9thfruaha9xnqg4cj1y3m7t67g1jb9vye3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dddcd389-441b-4069-802a-5d2c4b9dae26\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":9987,\"totalLength\":2214,\"totalSegmentCount\":98}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}},\"listRegistryList-48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0d902dc3-9d2e-4747-9b3e-dd81d790db5e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0d902dc3-9d2e-4747-9b3e-dd81d790db5e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vngywf2yc@example.com}\",\"displayName\":\"zx7an48p27a5f8w\",\"originalName\":\"8nxcqofmkri4r23\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}},\"d7d08548-e6d0-4580-9eb6-1c794d7cb74c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"516rxxem9@example.com}\",\"displayName\":\"qqrnvyuioandjah\",\"originalName\":\"l313qaekoy3jcly\",\"dateCreated\":\"2019-07-29T22:36:10.079Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c7713b00-fc44-4250-afda-63c7e531cb72\",\"clientSequenceNumber\":550,\"minimumSequenceNumber\":9987,\"referenceSequenceNumber\":9998,\"sequenceNumber\":10000,\"timestamp\":1564510394247,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,737 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":998,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\",{\"client\":{\"user\":{\"id\":\"u5ebdf4in@example.com}\",\"name\":\"aybj1d5rkpwhezk\",\"email\":\"emziry5d0@example.com}\"}},\"sequenceNumber\":68}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":73,\"value\":{\"type\":\"Plain\",\"value\":\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\"}},\"versions\":[{\"sequenceNumber\":73,\"value\":{\"type\":\"Plain\",\"value\":\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":469,\"refSeqNumber\":997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":22,\"chunkLengthChars\":619,\"totalLengthChars\":619,\"totalSegmentCount\":22,\"chunkSequenceNumber\":998,\"segmentTexts\":[\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\"}},\"ft21fcb5s8m46fix23hpxx625a6410ie5q7y3tu8o4p4zcyut\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"04b3c662-c165-4a90-995f-e37ab2c53ceb\",\"ItemType\":\"Paragraph\"}},\"rdjth4p0ika3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\"}},\"mziv9ocugbru8vi6p5wtciyrnupo8iaq2ohp6ru99yxcrd0br5ghgwbcpa0aif2jd2jkhtr\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98e9add4-1e21-4c96-9686-415444ecf4be\",\"ItemType\":\"Paragraph\"}},\"k5nadlw7529wgli723es6iwvsk67aw5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"45827d2c-b307-4561-81fd-1252f3a62c24\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":998,\"totalLength\":619,\"totalSegmentCount\":22}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\",\"clientSequenceNumber\":1025,\"contents\":{\"pos1\":468,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1564183749419,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\",\"clientSequenceNumber\":1026,\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1564183749419,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_11000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_11000_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":10996,\"sequenceNumber\":11000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"a7e21367-d487-4482-a95d-c853d436860d\",{\"client\":{\"user\":{\"id\":\"08h56wlvs@example.com}\",\"name\":\"r1twh59xnfqo1vd\",\"email\":\"qjx5fz4pv@example.com}\"}},\"sequenceNumber\":7011}],[\"8e257b0a-3abf-47b5-893e-71a3554fcaa3\",{\"client\":{\"user\":{\"id\":\"4xxopwc3h@example.com}\",\"name\":\"tz7eti1tr1ia881\",\"email\":\"iwd1ioy3v@example.com}\"}},\"sequenceNumber\":7203}],[\"969a5cee-3efd-49db-879c-2ded9169042f\",{\"client\":{\"user\":{\"id\":\"d0xk8ay2p@example.com}\",\"name\":\"zl45bcqo99t1w8l\",\"email\":\"8pkfttpsh@example.com}\"}},\"sequenceNumber\":7330}],[\"aac6ca27-89d5-425e-b56c-562a8caa8684\",{\"client\":{\"user\":{\"id\":\"q9t36jqmn@example.com}\",\"name\":\"ggrg7c1pnp81tp0\",\"email\":\"wd2yhexx1@example.com}\"}},\"sequenceNumber\":10267}],[\"fcd8fecd-ea46-4220-ae91-b4b6c26301de\",{\"client\":{\"user\":{\"id\":\"yjoyqti6c@example.com}\",\"name\":\"6cyob5pqayuax62\",\"email\":\"qfngopfsu@example.com}\"}},\"sequenceNumber\":10395}],[\"9417e6f1-7cc0-4ce8-879e-d9d0e540f52e\",{\"client\":{\"user\":{\"id\":\"q2m20r7vr@example.com}\",\"name\":\"k3kuj5tfbw6e0gr\",\"email\":\"ol5rufkvj@example.com}\"}},\"sequenceNumber\":10419}],[\"e6f0b3bb-2fb3-4799-8eb3-05d458939724\",{\"client\":{\"user\":{\"id\":\"79bye5ozl@example.com}\",\"name\":\"d3uyr5lzphqjf7a\",\"email\":\"6tc7dats3@example.com}\"}},\"sequenceNumber\":10441}],[\"7ea5fb6a-5128-4d06-ba00-e2f8942bfbe7\",{\"client\":{\"user\":{\"id\":\"2yft3at8f@example.com}\",\"name\":\"9xjynyc3lvdnkou\",\"email\":\"gbj3trdd2@example.com}\"}},\"sequenceNumber\":10512}],[\"7f6ad315-6e5f-41bb-b078-1eb1e919b911\",{\"client\":{\"user\":{\"id\":\"xdmnzk8jr@example.com}\",\"name\":\"rxqa7whf13az52p\",\"email\":\"egrdzkgh1@example.com}\"}},\"sequenceNumber\":10513}],[\"99d963ce-dc5b-42c5-b500-67bebd55e17b\",{\"client\":{\"user\":{\"id\":\"ntfjtqq1b@example.com}\",\"name\":\"w0hyczs6k4fjxgd\",\"email\":\"x4qz7qykv@example.com}\"}},\"sequenceNumber\":10514}],[\"c0d25595-9c07-4eab-8051-9b89c949e485\",{\"client\":{\"user\":{\"id\":\"ggt2zeb6o@example.com}\",\"name\":\"vmpi9a3katfastx\",\"email\":\"7z9smhqp0@example.com}\"}},\"sequenceNumber\":10515}],[\"3f6cfe22-1e4f-4863-b792-52c798dc0585\",{\"client\":{\"user\":{\"id\":\"1trfbyn4i@example.com}\",\"name\":\"938npq36dp62jnb\",\"email\":\"fjh9wckpp@example.com}\"}},\"sequenceNumber\":10802}],[\"873321fe-f23d-4501-93e8-a696cac3884d\",{\"client\":{\"user\":{\"id\":\"0te4so6to@example.com}\",\"name\":\"3rb7iz8t0vkwhb6\",\"email\":\"c8gkqbho6@example.com}\"}},\"sequenceNumber\":10839}],[\"15ca99e8-9f58-45a9-ac8d-cc6e7fa77cde\",{\"client\":{\"user\":{\"id\":\"7mqkitfmc@example.com}\",\"name\":\"ql9dw16a4andb0s\",\"email\":\"w4gxzg722@example.com}\"}},\"sequenceNumber\":10899}],[\"3f5dfac0-9fcc-476b-95c3-4fb8c0a83976\",{\"client\":{\"user\":{\"id\":\"ao48k1zpp@example.com}\",\"name\":\"w2ks6runrzdwn1q\",\"email\":\"r6tw14w6x@example.com}\"}},\"sequenceNumber\":10925}],[\"6cf205a7-cc9e-483d-8e75-241fd49bd8ef\",{\"client\":{\"user\":{\"id\":\"9hhd3km6r@example.com}\",\"name\":\"ev24oa5fydpey7j\",\"email\":\"igfm8vbl2@example.com}\"}},\"sequenceNumber\":10933}],[\"afbafeb4-6b64-421e-991a-467b9cec4cd0\",{\"client\":{\"user\":{\"id\":\"q0pxe3lof@example.com}\",\"name\":\"o9sp84tsfzpopiv\",\"email\":\"r5jq9rs5m@example.com}\"}},\"sequenceNumber\":10984}],[\"908c336d-427b-4af1-811f-8d57ad5710c7\",{\"client\":{\"user\":{\"id\":\"ohtqyk9wk@example.com}\",\"name\":\"o96uzdb85dmcjvi\",\"email\":\"f5tvz4hky@example.com}\"}},\"sequenceNumber\":10995}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vngywf2yc@example.com}\",\"displayName\":\"zx7an48p27a5f8w\",\"originalName\":\"8nxcqofmkri4r23\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}},\"d7d08548-e6d0-4580-9eb6-1c794d7cb74c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"516rxxem9@example.com}\",\"displayName\":\"qqrnvyuioandjah\",\"originalName\":\"l313qaekoy3jcly\",\"dateCreated\":\"2019-07-29T22:36:10.079Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2a3f2675-6a07-44ff-8d61-100a06168141\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"a7e21367-d487-4482-a95d-c853d436860d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":171,\"refSeqNumber\":6971}},\"54e3fecd-9302-4e4a-bc53-6d0eb82d6730\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"41a81f73-67eb-4d48-96a8-fc3bc76be549\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7116}},\"0488f86a-f090-4901-8ec7-89c27e36ec94\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":350,\"pos\":485,\"refSeqNumber\":6971}},\"969a5cee-3efd-49db-879c-2ded9169042f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"7941fba5-9070-4705-8660-368225ef88a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7344}},\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6971}},\"34e1e2ca-7379-46f0-9a7f-c36cba9d5fbd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7208}},\"a79ae9cf-39d3-4661-baf5-1367e40983e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7332}},\"83f15f07-06cd-46f4-b366-98a6cc274650\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7401}},\"befebc61-f145-4a59-ac21-a6e5334db265\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7440}},\"b41bc100-6f95-4555-8a1b-3856148e0433\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7467}},\"80cb6e9b-0da6-4964-95e8-bb7bd13146da\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"671b9ea2-fe72-4ea5-9442-d5d55845f60f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"e2975b73-7939-4891-9bf5-27a1953863e6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":498,\"refSeqNumber\":7680}},\"b6391cf9-6a84-47da-96eb-368d088044af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":187,\"refSeqNumber\":8269}},\"1f1d1ab3-dcda-4ed4-8a19-42cda05b767e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8286}},\"e4b951bb-3c6d-4196-88eb-c8928628bbcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"ea104d23-eb26-4969-9880-4e09f59dcc16\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8821}},\"d04b2493-c128-4251-9351-1fad62aef7d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":62,\"refSeqNumber\":7680}},\"072c8040-4557-4190-a9d9-9e78b889e5fd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":212,\"refSeqNumber\":9529}},\"4016ee46-098d-4156-9e5a-c7ff29ef5bdd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2212,\"refSeqNumber\":9163}},\"0fb8e28d-b064-4cad-9bb0-df91a75bd966\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":133,\"pos\":137,\"refSeqNumber\":9265}},\"a054e44e-12dc-4e2f-b2e2-a90104616014\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":714,\"refSeqNumber\":9529}},\"a08ea056-16b2-4c44-bfff-8eef11e686ec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2013,\"refSeqNumber\":9529}},\"e576fca3-4055-407f-9635-1107488a9356\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":117,\"refSeqNumber\":9529}},\"ca8295bf-2340-4477-a017-a34a16e76e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10462}},\"884f4003-8780-43a6-b74d-8aa55ee2da5b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10477}},\"420f7766-0c38-49b0-a9df-1f56c8518814\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10492}},\"1ce80cdc-3f8e-479f-a8c9-64ea7ecb36a8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10521}},\"99ebf72a-950f-4f32-9989-e966b0009f1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10547}},\"ba9b1ca1-8670-4cd0-b0ad-7246bc3334d1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1056,\"refSeqNumber\":10571}},\"98a82db8-9171-452c-9fe0-eb98b871accd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":9529}},\"52d65767-a368-4f1e-a184-0b6e79459d42\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10712}},\"d6ab6f8f-60db-41a0-a9d1-ded97371bdd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10725}},\"eacf184f-842b-4454-8e35-5042844a272a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":9529}},\"4ae394da-f20e-4149-a9b4-a21f1d20c091\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10768}},\"8321cea6-e4bb-44c2-9aca-c07e164c100f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10931}},\"c5719064-b8de-4926-8c01-5c0207a1d76d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":31,\"refSeqNumber\":9529}},\"d681c8f0-0610-4fc4-8657-c727b6459d3a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10970}},\"afbafeb4-6b64-421e-991a-467b9cec4cd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10981}},\"908c336d-427b-4af1-811f-8d57ad5710c7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10992}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":98,\"chunkLengthChars\":2214,\"totalLengthChars\":2214,\"totalSegmentCount\":98,\"chunkSequenceNumber\":10996,\"segmentTexts\":[{\"text\":\"46ynxt67\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"dyh7ixcw48que8c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"text\":\"asv39xkbj5c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p\",{\"text\":\"8u47bcc\",\"props\":{\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0835-0000-000000000000}\":false}},\"a6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"text\":\"uqdq585fu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5e7654de-0c09-4a99-b138-9872f90272ad\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d7d08548-e6d0-4580-9eb6-1c794d7cb74c\",\"display\":\"inline-block\"}}},{\"text\":\"krm6cdy34finy6ms9d3c94ry8e7s0zt79i0gi8azwccntrybrt\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5724d074-3621-4463-979b-d7aeb09c35a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-48\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3438f1ed-eb23-46a6-b951-f27a732bf9d4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"hjvknzrah32snoa9thfruaha9xnqg4cj1y3m7t67g1jb9vye3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dddcd389-441b-4069-802a-5d2c4b9dae26\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":10996,\"totalLength\":2214,\"totalSegmentCount\":98}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}},\"listRegistryList-48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0d902dc3-9d2e-4747-9b3e-dd81d790db5e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0d902dc3-9d2e-4747-9b3e-dd81d790db5e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2a3f2675-6a07-44ff-8d61-100a06168141",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30363778-5310-4550-ac2a-22dc75604d50\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4fd559d5-0c43-4988-b87d-6741a031b363\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d1287b28-24ea-4f65-969e-359a1816223a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/afe6a5d8-247a-4513-8a26-15e03c206359\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d5595dc-62f3-45c4-81c4-c6a1c462a855\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ea0da9fd-6dfb-4487-8bf3-b3b1b800af9c\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ed6e980-1b60-4a6b-bc16-c65ce21f0672\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30363778-5310-4550-ac2a-22dc75604d50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4fd559d5-0c43-4988-b87d-6741a031b363",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d1287b28-24ea-4f65-969e-359a1816223a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "afe6a5d8-247a-4513-8a26-15e03c206359",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d5595dc-62f3-45c4-81c4-c6a1c462a855",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ea0da9fd-6dfb-4487-8bf3-b3b1b800af9c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ed6e980-1b60-4a6b-bc16-c65ce21f0672",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"908c336d-427b-4af1-811f-8d57ad5710c7\",\"clientSequenceNumber\":4,\"minimumSequenceNumber\":10996,\"referenceSequenceNumber\":10996,\"sequenceNumber\":11000,\"timestamp\":1564613126239,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_11380_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_11380_0.json
@@ -1,0 +1,1106 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":11379,\"sequenceNumber\":11380,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"a7e21367-d487-4482-a95d-c853d436860d\",{\"client\":{\"user\":{\"id\":\"08h56wlvs@example.com}\",\"name\":\"r1twh59xnfqo1vd\",\"email\":\"qjx5fz4pv@example.com}\"}},\"sequenceNumber\":7011}],[\"8e257b0a-3abf-47b5-893e-71a3554fcaa3\",{\"client\":{\"user\":{\"id\":\"4xxopwc3h@example.com}\",\"name\":\"tz7eti1tr1ia881\",\"email\":\"iwd1ioy3v@example.com}\"}},\"sequenceNumber\":7203}],[\"969a5cee-3efd-49db-879c-2ded9169042f\",{\"client\":{\"user\":{\"id\":\"d0xk8ay2p@example.com}\",\"name\":\"zl45bcqo99t1w8l\",\"email\":\"8pkfttpsh@example.com}\"}},\"sequenceNumber\":7330}],[\"aac6ca27-89d5-425e-b56c-562a8caa8684\",{\"client\":{\"user\":{\"id\":\"q9t36jqmn@example.com}\",\"name\":\"ggrg7c1pnp81tp0\",\"email\":\"wd2yhexx1@example.com}\"}},\"sequenceNumber\":10267}],[\"fcd8fecd-ea46-4220-ae91-b4b6c26301de\",{\"client\":{\"user\":{\"id\":\"yjoyqti6c@example.com}\",\"name\":\"6cyob5pqayuax62\",\"email\":\"qfngopfsu@example.com}\"}},\"sequenceNumber\":10395}],[\"9417e6f1-7cc0-4ce8-879e-d9d0e540f52e\",{\"client\":{\"user\":{\"id\":\"q2m20r7vr@example.com}\",\"name\":\"k3kuj5tfbw6e0gr\",\"email\":\"ol5rufkvj@example.com}\"}},\"sequenceNumber\":10419}],[\"e6f0b3bb-2fb3-4799-8eb3-05d458939724\",{\"client\":{\"user\":{\"id\":\"79bye5ozl@example.com}\",\"name\":\"d3uyr5lzphqjf7a\",\"email\":\"6tc7dats3@example.com}\"}},\"sequenceNumber\":10441}],[\"7ea5fb6a-5128-4d06-ba00-e2f8942bfbe7\",{\"client\":{\"user\":{\"id\":\"2yft3at8f@example.com}\",\"name\":\"9xjynyc3lvdnkou\",\"email\":\"gbj3trdd2@example.com}\"}},\"sequenceNumber\":10512}],[\"7f6ad315-6e5f-41bb-b078-1eb1e919b911\",{\"client\":{\"user\":{\"id\":\"xdmnzk8jr@example.com}\",\"name\":\"rxqa7whf13az52p\",\"email\":\"egrdzkgh1@example.com}\"}},\"sequenceNumber\":10513}],[\"99d963ce-dc5b-42c5-b500-67bebd55e17b\",{\"client\":{\"user\":{\"id\":\"ntfjtqq1b@example.com}\",\"name\":\"w0hyczs6k4fjxgd\",\"email\":\"x4qz7qykv@example.com}\"}},\"sequenceNumber\":10514}],[\"c0d25595-9c07-4eab-8051-9b89c949e485\",{\"client\":{\"user\":{\"id\":\"ggt2zeb6o@example.com}\",\"name\":\"vmpi9a3katfastx\",\"email\":\"7z9smhqp0@example.com}\"}},\"sequenceNumber\":10515}],[\"3f6cfe22-1e4f-4863-b792-52c798dc0585\",{\"client\":{\"user\":{\"id\":\"1trfbyn4i@example.com}\",\"name\":\"938npq36dp62jnb\",\"email\":\"fjh9wckpp@example.com}\"}},\"sequenceNumber\":10802}],[\"873321fe-f23d-4501-93e8-a696cac3884d\",{\"client\":{\"user\":{\"id\":\"0te4so6to@example.com}\",\"name\":\"3rb7iz8t0vkwhb6\",\"email\":\"c8gkqbho6@example.com}\"}},\"sequenceNumber\":10839}],[\"15ca99e8-9f58-45a9-ac8d-cc6e7fa77cde\",{\"client\":{\"user\":{\"id\":\"7mqkitfmc@example.com}\",\"name\":\"ql9dw16a4andb0s\",\"email\":\"w4gxzg722@example.com}\"}},\"sequenceNumber\":10899}],[\"3f5dfac0-9fcc-476b-95c3-4fb8c0a83976\",{\"client\":{\"user\":{\"id\":\"ao48k1zpp@example.com}\",\"name\":\"w2ks6runrzdwn1q\",\"email\":\"r6tw14w6x@example.com}\"}},\"sequenceNumber\":10925}],[\"6cf205a7-cc9e-483d-8e75-241fd49bd8ef\",{\"client\":{\"user\":{\"id\":\"9hhd3km6r@example.com}\",\"name\":\"ev24oa5fydpey7j\",\"email\":\"igfm8vbl2@example.com}\"}},\"sequenceNumber\":10933}],[\"533f1e8a-d0a6-4f61-be3c-399352bab420\",{\"client\":{\"user\":{\"id\":\"ytigjy9w5@example.com}\",\"name\":\"sg8zrw00hf8quxn\",\"email\":\"qqejgee3l@example.com}\"}},\"sequenceNumber\":11010}],[\"6b596ab3-61bd-4c1f-8722-23a93b92da92\",{\"client\":{\"user\":{\"id\":\"trnhhm4vd@example.com}\",\"name\":\"k3y20hrrv8ss8m7\",\"email\":\"eoyudble2@example.com}\"}},\"sequenceNumber\":11014}],[\"4caa0990-7824-487e-b8d4-a709cb1c453c\",{\"client\":{\"user\":{\"id\":\"633hp5lrr@example.com}\",\"name\":\"5705pgu4txevaeu\",\"email\":\"cw970kngk@example.com}\"}},\"sequenceNumber\":11015}],[\"48bbc8aa-3405-473d-9195-892d945a08d2\",{\"client\":{\"user\":{\"id\":\"xdv0ydkah@example.com}\",\"name\":\"1ncujwvenuzzrc2\",\"email\":\"26z5uc7u7@example.com}\"}},\"sequenceNumber\":11016}],[\"3855eaab-3877-4de6-a497-4da4b9b0e453\",{\"client\":{\"user\":{\"id\":\"2fddhetuu@example.com}\",\"name\":\"yu2c95umcp9vg05\",\"email\":\"9o2fioeoz@example.com}\"}},\"sequenceNumber\":11017}],[\"a5294d29-1d91-4d53-9542-76ce42938e0e\",{\"client\":{\"user\":{\"id\":\"pgvj7hpxg@example.com}\",\"name\":\"miu4g7ur88kmki2\",\"email\":\"g5fh5z6li@example.com}\"}},\"sequenceNumber\":11018}],[\"afad1e3c-b659-4326-9d5e-ab31b1999f2d\",{\"client\":{\"user\":{\"id\":\"j8sxs2mle@example.com}\",\"name\":\"lg7merdx9mnk7z5\",\"email\":\"dcamy5pbg@example.com}\"}},\"sequenceNumber\":11025}],[\"fc8efa81-eff5-4b7f-9740-1d0c4587d17b\",{\"client\":{\"user\":{\"id\":\"xih9s9hny@example.com}\",\"name\":\"jhklk4bg94qa9zc\",\"email\":\"7cntlwvc1@example.com}\"}},\"sequenceNumber\":11027}],[\"0ea90ecb-6f22-482e-8728-4587127bcd27\",{\"client\":{\"user\":{\"id\":\"366kf5vu4@example.com}\",\"name\":\"v2najhu2dl3nyfr\",\"email\":\"1gqfbni9u@example.com}\"}},\"sequenceNumber\":11028}],[\"9d9a318c-bf5f-4aff-86fa-924c47c02579\",{\"client\":{\"user\":{\"id\":\"6ixmtq7as@example.com}\",\"name\":\"7jp2uli3qrh4dux\",\"email\":\"ug5zg3i64@example.com}\"}},\"sequenceNumber\":11029}],[\"1a8c2f95-7da0-47a9-9106-4f8d6b708382\",{\"client\":{\"user\":{\"id\":\"ub4kawb86@example.com}\",\"name\":\"9jbxc036gxqgbon\",\"email\":\"idpl1vezw@example.com}\"}},\"sequenceNumber\":11031}],[\"c49738e9-0f82-49f3-93ab-18e84596cb5e\",{\"client\":{\"user\":{\"id\":\"htysbi6az@example.com}\",\"name\":\"1r7qlns8hvprn62\",\"email\":\"jvbhw95de@example.com}\"}},\"sequenceNumber\":11042}],[\"d2e6e161-e573-4a71-a866-9ca5d699a34a\",{\"client\":{\"user\":{\"id\":\"3rptopjex@example.com}\",\"name\":\"weaexht7zsnrc93\",\"email\":\"cavbcsdfc@example.com}\"}},\"sequenceNumber\":11043}],[\"9d4996f8-e9bd-4446-9412-ca0d13976c01\",{\"client\":{\"user\":{\"id\":\"ze9ezyvg5@example.com}\",\"name\":\"e9i95bz47t6u51w\",\"email\":\"yfwu2nxsa@example.com}\"}},\"sequenceNumber\":11044}],[\"c1dcfac8-954a-4758-bf6c-c35a6cb5fe86\",{\"client\":{\"user\":{\"id\":\"q72xs3bho@example.com}\",\"name\":\"fqt2dj114rh4d9n\",\"email\":\"bhbtgg99d@example.com}\"}},\"sequenceNumber\":11045}],[\"139416aa-00f8-4eee-9e08-dcecf76cbf92\",{\"client\":{\"user\":{\"id\":\"0glw3w0qx@example.com}\",\"name\":\"2v8c7057cm7s2p7\",\"email\":\"lrvbngh27@example.com}\"}},\"sequenceNumber\":11046}],[\"fbcc8ba1-c5ab-4819-aa1d-2d701950a288\",{\"client\":{\"user\":{\"id\":\"x2jwwn7b2@example.com}\",\"name\":\"tg026gcn610ayq4\",\"email\":\"bvxld22gv@example.com}\"}},\"sequenceNumber\":11047}],[\"5ab7753c-fcb4-439b-a1f0-f14d2b21aca9\",{\"client\":{\"user\":{\"id\":\"s0kfxmv1q@example.com}\",\"name\":\"bunmr6xthknf9s1\",\"email\":\"l0w6wui1n@example.com}\"}},\"sequenceNumber\":11048}],[\"baf60140-90a5-4e42-be87-5596b3c79d22\",{\"client\":{\"user\":{\"id\":\"todwl7su0@example.com}\",\"name\":\"13b45kj1r4zdfzy\",\"email\":\"aqfr6yr1j@example.com}\"}},\"sequenceNumber\":11049}],[\"0cb70e11-6c56-4188-baa2-53f64721f991\",{\"client\":{\"user\":{\"id\":\"92iunby24@example.com}\",\"name\":\"zvojo6ijwbjluhc\",\"email\":\"tvrevaixk@example.com}\"}},\"sequenceNumber\":11050}],[\"8fcb7afc-b219-4ceb-a48f-85845e94c0fe\",{\"client\":{\"user\":{\"id\":\"7ad34si31@example.com}\",\"name\":\"mz84bwtweykzyzf\",\"email\":\"33jx5vbhw@example.com}\"}},\"sequenceNumber\":11051}],[\"0af9f7e2-7e50-447c-8673-9e8e4739b2ea\",{\"client\":{\"user\":{\"id\":\"755d8dtpx@example.com}\",\"name\":\"tefftip29rjzs86\",\"email\":\"bzn168fsl@example.com}\"}},\"sequenceNumber\":11052}],[\"e4c7224a-a9ac-48d1-a6cf-9906a652ed13\",{\"client\":{\"user\":{\"id\":\"hiaqghotr@example.com}\",\"name\":\"e8d1dkwmbuh9o90\",\"email\":\"5gcq9yluz@example.com}\"}},\"sequenceNumber\":11053}],[\"6b2d9969-7da1-45eb-a37b-242f41ad7fb6\",{\"client\":{\"user\":{\"id\":\"m2xcikh1w@example.com}\",\"name\":\"qzxjdmkstim5fn5\",\"email\":\"7ltv1epm8@example.com}\"}},\"sequenceNumber\":11054}],[\"e98d85ca-f1dc-4999-add7-55cf8cc33ab9\",{\"client\":{\"user\":{\"id\":\"a0ohe4mn1@example.com}\",\"name\":\"6pdi094gxwrwus0\",\"email\":\"n7d7z8rwm@example.com}\"}},\"sequenceNumber\":11055}],[\"106c8461-839c-4786-8514-49a9b902dd01\",{\"client\":{\"user\":{\"id\":\"78rqvearx@example.com}\",\"name\":\"5tzx0fwf2g7t12y\",\"email\":\"34x59uo86@example.com}\"}},\"sequenceNumber\":11056}],[\"f8ccac4d-6ccd-4b86-9f0a-62d350a3d806\",{\"client\":{\"user\":{\"id\":\"6xnlbfkn8@example.com}\",\"name\":\"q3cojloyc9hs739\",\"email\":\"q5dtwo4nf@example.com}\"}},\"sequenceNumber\":11057}],[\"bc2848e7-213f-4a24-a7c0-38a37896383f\",{\"client\":{\"user\":{\"id\":\"205tvqyiy@example.com}\",\"name\":\"d7rpwbv8a7jbteb\",\"email\":\"5su0fv60p@example.com}\"}},\"sequenceNumber\":11058}],[\"22556dd0-ac78-4739-888d-5d0ef17e9067\",{\"client\":{\"user\":{\"id\":\"1ob5bkaqc@example.com}\",\"name\":\"9z85l07ga7wooif\",\"email\":\"sv73110yx@example.com}\"}},\"sequenceNumber\":11059}],[\"f504d398-b34d-4200-8efb-1a51db521862\",{\"client\":{\"user\":{\"id\":\"3okhcsq37@example.com}\",\"name\":\"md8zxce1qqqvfpf\",\"email\":\"ef7hjnv22@example.com}\"}},\"sequenceNumber\":11060}],[\"0ac51805-bdee-4806-a8b0-2df24b53e95e\",{\"client\":{\"user\":{\"id\":\"9d7q4ijpa@example.com}\",\"name\":\"jzkg9b9zibr8eof\",\"email\":\"ywjfur5li@example.com}\"}},\"sequenceNumber\":11061}],[\"e31bf1dc-f4c6-4669-92eb-891ebf59d9d2\",{\"client\":{\"user\":{\"id\":\"1752lc00c@example.com}\",\"name\":\"mv5a5bctkt8gbn0\",\"email\":\"15ugtimgj@example.com}\"}},\"sequenceNumber\":11062}],[\"871ae6ec-3458-4e9b-ba3a-b949b4724c7d\",{\"client\":{\"user\":{\"id\":\"ou5ip1kap@example.com}\",\"name\":\"7yrdmp2lz0lcj2h\",\"email\":\"qm72aciwl@example.com}\"}},\"sequenceNumber\":11063}],[\"1cc865b3-3fc3-4849-9be9-3633592128e4\",{\"client\":{\"user\":{\"id\":\"virwzgmz8@example.com}\",\"name\":\"46mw1e8v7e8qzvf\",\"email\":\"rf43fvzw3@example.com}\"}},\"sequenceNumber\":11064}],[\"485bbff7-cc00-4e6f-a5fb-ef35bbed1b78\",{\"client\":{\"user\":{\"id\":\"1d4znemox@example.com}\",\"name\":\"1uln5xywk85ycm3\",\"email\":\"4reeyjcya@example.com}\"}},\"sequenceNumber\":11065}],[\"bf4c2fa5-74f2-4767-83d6-636ae3fb3672\",{\"client\":{\"user\":{\"id\":\"nd3giaivt@example.com}\",\"name\":\"8az5z5nweo5zzzp\",\"email\":\"40ac0nsny@example.com}\"}},\"sequenceNumber\":11066}],[\"5abf4a1a-f5fe-4e0b-ad21-0ed58cc21fab\",{\"client\":{\"user\":{\"id\":\"8x1wsvdwk@example.com}\",\"name\":\"xy05rbu3vj8yfzo\",\"email\":\"q66w4tb5d@example.com}\"}},\"sequenceNumber\":11067}],[\"8730e90b-8119-44fa-b9da-c6a2c89366a4\",{\"client\":{\"user\":{\"id\":\"jmwyl62mu@example.com}\",\"name\":\"0k90lb003dqfcpz\",\"email\":\"ih4ct3ho2@example.com}\"}},\"sequenceNumber\":11068}],[\"ebef4508-3bc8-412e-893e-240102b682f3\",{\"client\":{\"user\":{\"id\":\"esi7rns05@example.com}\",\"name\":\"jen5mtdxt4fg009\",\"email\":\"wyonz5yo8@example.com}\"}},\"sequenceNumber\":11069}],[\"f34fa2bc-7d92-4c84-aee6-de3c839f75e0\",{\"client\":{\"user\":{\"id\":\"3su1gbg9n@example.com}\",\"name\":\"a65gxvqh6yuj9x0\",\"email\":\"0gnm2fo0h@example.com}\"}},\"sequenceNumber\":11070}],[\"d79c6294-b26b-4b1c-84bb-ecbd001854df\",{\"client\":{\"user\":{\"id\":\"lxzd6lkob@example.com}\",\"name\":\"tkvedtnzwmb7chs\",\"email\":\"j5auwisqa@example.com}\"}},\"sequenceNumber\":11078}],[\"a1c8fc3e-1c24-461f-a6dc-53948bc1d586\",{\"client\":{\"user\":{\"id\":\"0su1mzmlx@example.com}\",\"name\":\"21dtmeceqr7fxt1\",\"email\":\"cmq8d7bbb@example.com}\"}},\"sequenceNumber\":11084}],[\"3d0849df-6146-4041-bb38-860e8990eae5\",{\"client\":{\"user\":{\"id\":\"crdj9ig77@example.com}\",\"name\":\"tn36lhgfj7gbzfa\",\"email\":\"5bl7ss4mr@example.com}\"}},\"sequenceNumber\":11085}],[\"340bd03c-d09e-41da-901c-46181769ceb4\",{\"client\":{\"user\":{\"id\":\"i2ph5sptf@example.com}\",\"name\":\"guvxy8atqhvdax6\",\"email\":\"ph6djsb3k@example.com}\"}},\"sequenceNumber\":11086}],[\"59f152cf-a99d-453f-918a-1354d5dd8a62\",{\"client\":{\"user\":{\"id\":\"77g1ofm1t@example.com}\",\"name\":\"haj26ylxw3jvhfp\",\"email\":\"c0swji9b2@example.com}\"}},\"sequenceNumber\":11087}],[\"48d26437-d71a-4143-958a-7e99679bd96c\",{\"client\":{\"user\":{\"id\":\"gat4d2m0d@example.com}\",\"name\":\"nbjhoo1yi8yzbum\",\"email\":\"lg6ar779x@example.com}\"}},\"sequenceNumber\":11107}],[\"e90e283a-4660-4b20-a7a6-cf07ffb08ec0\",{\"client\":{\"user\":{\"id\":\"2mmqy1ha8@example.com}\",\"name\":\"ohhc19y2npnc5ma\",\"email\":\"37300ded0@example.com}\"}},\"sequenceNumber\":11192}],[\"564fd1ba-63de-4f1a-8236-f96f314fff20\",{\"client\":{\"user\":{\"id\":\"mp9aobv2w@example.com}\",\"name\":\"xiwp1hputge1i9b\",\"email\":\"lbtuopf5z@example.com}\"}},\"sequenceNumber\":11193}],[\"64940448-fdda-4e2a-bc81-de62253fc48c\",{\"client\":{\"user\":{\"id\":\"skuqruavk@example.com}\",\"name\":\"0bdtvfj6n62tmv6\",\"email\":\"mn8eaq201@example.com}\"}},\"sequenceNumber\":11194}],[\"bdca0e27-9df0-4572-b15e-11870d1b08f8\",{\"client\":{\"user\":{\"id\":\"atr47q4er@example.com}\",\"name\":\"riy5kqh49pio5wv\",\"email\":\"jb9tcyvp9@example.com}\"}},\"sequenceNumber\":11195}],[\"a6d19c99-c079-4a2e-9dd3-43fca8e9dbee\",{\"client\":{\"user\":{\"id\":\"hrn708ctn@example.com}\",\"name\":\"emcg81rgtqk782l\",\"email\":\"n0n6aikyp@example.com}\"}},\"sequenceNumber\":11196}],[\"d7ff2c0e-b7d2-4955-9c9c-ca0d0f1acfb1\",{\"client\":{\"user\":{\"id\":\"waanb2qkz@example.com}\",\"name\":\"f63o96mrbw23tst\",\"email\":\"bm5n0xnc5@example.com}\"}},\"sequenceNumber\":11197}],[\"386bee34-43f9-4bd3-bd7c-9472602e3da0\",{\"client\":{\"user\":{\"id\":\"obh73q33u@example.com}\",\"name\":\"l8aauz35hjn5rwt\",\"email\":\"ln6fc0m4s@example.com}\"}},\"sequenceNumber\":11198}],[\"d80630e5-7aa4-4ddf-b3c5-e2df6268b953\",{\"client\":{\"user\":{\"id\":\"r57h4kriv@example.com}\",\"name\":\"0svbchfq1oup3bv\",\"email\":\"j31il5rn2@example.com}\"}},\"sequenceNumber\":11199}],[\"71be2924-a8c1-4d5b-9749-61f4dbb6a5d4\",{\"client\":{\"user\":{\"id\":\"jkwloaa07@example.com}\",\"name\":\"8mxylcu1dd3ramu\",\"email\":\"n9x7ynyd3@example.com}\"}},\"sequenceNumber\":11200}],[\"6beb33d6-b298-47a2-a7ac-5fdc3e54239d\",{\"client\":{\"user\":{\"id\":\"td9dgtiyi@example.com}\",\"name\":\"shna35kn8j6ovod\",\"email\":\"0f2ptk4l6@example.com}\"}},\"sequenceNumber\":11201}],[\"8baf1965-f758-41d4-9a4a-36c658cee46c\",{\"client\":{\"user\":{\"id\":\"tt2gmjhvo@example.com}\",\"name\":\"yitk6dvgy4cl4qk\",\"email\":\"ct09bpgrw@example.com}\"}},\"sequenceNumber\":11202}],[\"3a00bae7-7cff-4e8c-9d6c-4db1ab12d2be\",{\"client\":{\"user\":{\"id\":\"n49yk8uv8@example.com}\",\"name\":\"9at8h16blhiowux\",\"email\":\"akjjsxo1f@example.com}\"}},\"sequenceNumber\":11203}],[\"6a651a8f-a2a1-4302-844d-2a19b5657e2f\",{\"client\":{\"user\":{\"id\":\"640u6w48m@example.com}\",\"name\":\"e8wwtmwjrzkpsoo\",\"email\":\"5rminkxwc@example.com}\"}},\"sequenceNumber\":11204}],[\"91547baa-7283-4194-a012-5b309f36119a\",{\"client\":{\"user\":{\"id\":\"d1bt5wizd@example.com}\",\"name\":\"1qopfiavqyf4jq8\",\"email\":\"hjzqplcto@example.com}\"}},\"sequenceNumber\":11205}],[\"54be2dec-9f9b-4ed8-bf59-de5f10fa4e48\",{\"client\":{\"user\":{\"id\":\"zjqblc8ur@example.com}\",\"name\":\"624iexpesd2m127\",\"email\":\"0u24wrd41@example.com}\"}},\"sequenceNumber\":11206}],[\"9cd384ad-737a-4349-b810-9b38c39a2a0d\",{\"client\":{\"user\":{\"id\":\"cg1hkibxu@example.com}\",\"name\":\"ns3zvoqsw9mcglr\",\"email\":\"4lmnzcx3p@example.com}\"}},\"sequenceNumber\":11207}],[\"aeedcdec-c02d-4901-a7aa-bffe52361b08\",{\"client\":{\"user\":{\"id\":\"zxt0lt681@example.com}\",\"name\":\"tarsevfjfhrsssh\",\"email\":\"xekkdig9u@example.com}\"}},\"sequenceNumber\":11208}],[\"1c16a2aa-8e7b-4378-aeb4-264a870fbf57\",{\"client\":{\"user\":{\"id\":\"s1b5wh53m@example.com}\",\"name\":\"fp0ngptes6lq2k1\",\"email\":\"oayvedwp0@example.com}\"}},\"sequenceNumber\":11209}],[\"2da80edf-2784-4d13-9657-e7be28a97c85\",{\"client\":{\"user\":{\"id\":\"4ag0htlr3@example.com}\",\"name\":\"uglin4rqmrr2uv9\",\"email\":\"iyzro4n8r@example.com}\"}},\"sequenceNumber\":11210}],[\"6eb835c8-d6f0-453e-8a9c-d17e017da51a\",{\"client\":{\"user\":{\"id\":\"522953sh5@example.com}\",\"name\":\"ei7b7dckshkgwyf\",\"email\":\"xu4m5d458@example.com}\"}},\"sequenceNumber\":11211}],[\"e4b9a058-32cb-4912-8fc8-8e4573ac7f6b\",{\"client\":{\"user\":{\"id\":\"fgl4wid03@example.com}\",\"name\":\"29dj8vsk68fujpz\",\"email\":\"0lqjzhziw@example.com}\"}},\"sequenceNumber\":11212}],[\"e2edc564-eecb-41e7-a4e0-b9f6d4b6b502\",{\"client\":{\"user\":{\"id\":\"o468vgmtt@example.com}\",\"name\":\"j6bmthqh2t9yn59\",\"email\":\"g3j1t71tj@example.com}\"}},\"sequenceNumber\":11273}],[\"a8a2bcce-e785-4453-a9bb-c53da6abece3\",{\"client\":{\"user\":{\"id\":\"zvks819z9@example.com}\",\"name\":\"w4dn57ocbtrmvfx\",\"email\":\"q0gdi5ppt@example.com}\"}},\"sequenceNumber\":11276}],[\"17a1ac1e-836e-43b7-b306-318ddcdba089\",{\"client\":{\"user\":{\"id\":\"3imys1k0s@example.com}\",\"name\":\"4c1fzi4h6x3zduq\",\"email\":\"q2oru7s2g@example.com}\"}},\"sequenceNumber\":11277}],[\"d39a16bd-3e9f-44bb-87b7-aebac73c1bee\",{\"client\":{\"user\":{\"id\":\"4njaepv4q@example.com}\",\"name\":\"2lq21dua9n594pv\",\"email\":\"4jeofykcx@example.com}\"}},\"sequenceNumber\":11289}],[\"f884f59d-e40c-49b5-a7d4-52e43f09e6a8\",{\"client\":{\"user\":{\"id\":\"ua50nmg0t@example.com}\",\"name\":\"hjc96xorgibyupp\",\"email\":\"xgod04czi@example.com}\"}},\"sequenceNumber\":11297}],[\"edd4acaf-57da-4e30-996f-5494bbdce046\",{\"client\":{\"user\":{\"id\":\"xen6gd4y1@example.com}\",\"name\":\"v6n6w1zh0xnlyqx\",\"email\":\"q5wsvko2b@example.com}\"}},\"sequenceNumber\":11298}],[\"a0a09e22-b97c-495e-a643-33b3a0d1a49d\",{\"client\":{\"user\":{\"id\":\"zy6uelfe7@example.com}\",\"name\":\"eooxkukzms66k76\",\"email\":\"sceshae8n@example.com}\"}},\"sequenceNumber\":11299}],[\"074a8bc5-aec2-4a26-972b-6b0663eb2140\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"8zuf1woo4@example.com}\",\"name\":\"07hnkdlz1towr7c\",\"email\":\"54xazwmwq@example.com}\"}},\"sequenceNumber\":11380}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2a3f2675-6a07-44ff-8d61-100a06168141\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"a7e21367-d487-4482-a95d-c853d436860d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":171,\"refSeqNumber\":6971}},\"54e3fecd-9302-4e4a-bc53-6d0eb82d6730\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"41a81f73-67eb-4d48-96a8-fc3bc76be549\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7116}},\"0488f86a-f090-4901-8ec7-89c27e36ec94\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":350,\"pos\":485,\"refSeqNumber\":6971}},\"969a5cee-3efd-49db-879c-2ded9169042f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"7941fba5-9070-4705-8660-368225ef88a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7344}},\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6971}},\"34e1e2ca-7379-46f0-9a7f-c36cba9d5fbd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7208}},\"a79ae9cf-39d3-4661-baf5-1367e40983e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7332}},\"83f15f07-06cd-46f4-b366-98a6cc274650\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7401}},\"befebc61-f145-4a59-ac21-a6e5334db265\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7440}},\"b41bc100-6f95-4555-8a1b-3856148e0433\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7467}},\"80cb6e9b-0da6-4964-95e8-bb7bd13146da\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"671b9ea2-fe72-4ea5-9442-d5d55845f60f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"e2975b73-7939-4891-9bf5-27a1953863e6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":498,\"refSeqNumber\":7680}},\"b6391cf9-6a84-47da-96eb-368d088044af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":187,\"refSeqNumber\":8269}},\"1f1d1ab3-dcda-4ed4-8a19-42cda05b767e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8286}},\"e4b951bb-3c6d-4196-88eb-c8928628bbcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"ea104d23-eb26-4969-9880-4e09f59dcc16\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8821}},\"d04b2493-c128-4251-9351-1fad62aef7d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":62,\"refSeqNumber\":7680}},\"072c8040-4557-4190-a9d9-9e78b889e5fd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":212,\"refSeqNumber\":9529}},\"4016ee46-098d-4156-9e5a-c7ff29ef5bdd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2212,\"refSeqNumber\":9163}},\"0fb8e28d-b064-4cad-9bb0-df91a75bd966\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":133,\"pos\":137,\"refSeqNumber\":9265}},\"a054e44e-12dc-4e2f-b2e2-a90104616014\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":714,\"refSeqNumber\":9529}},\"a08ea056-16b2-4c44-bfff-8eef11e686ec\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2013,\"refSeqNumber\":9529}},\"e576fca3-4055-407f-9635-1107488a9356\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":117,\"refSeqNumber\":9529}},\"ca8295bf-2340-4477-a017-a34a16e76e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10462}},\"884f4003-8780-43a6-b74d-8aa55ee2da5b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10477}},\"420f7766-0c38-49b0-a9df-1f56c8518814\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10492}},\"1ce80cdc-3f8e-479f-a8c9-64ea7ecb36a8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10521}},\"99ebf72a-950f-4f32-9989-e966b0009f1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10547}},\"ba9b1ca1-8670-4cd0-b0ad-7246bc3334d1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1056,\"refSeqNumber\":10571}},\"98a82db8-9171-452c-9fe0-eb98b871accd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":9529}},\"52d65767-a368-4f1e-a184-0b6e79459d42\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10712}},\"d6ab6f8f-60db-41a0-a9d1-ded97371bdd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10725}},\"eacf184f-842b-4454-8e35-5042844a272a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":9529}},\"4ae394da-f20e-4149-a9b4-a21f1d20c091\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10768}},\"8321cea6-e4bb-44c2-9aca-c07e164c100f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10931}},\"c5719064-b8de-4926-8c01-5c0207a1d76d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":31,\"refSeqNumber\":9529}},\"d681c8f0-0610-4fc4-8657-c727b6459d3a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10970}},\"afbafeb4-6b64-421e-991a-467b9cec4cd0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10981}},\"908c336d-427b-4af1-811f-8d57ad5710c7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10992}},\"6b596ab3-61bd-4c1f-8722-23a93b92da92\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10981}},\"48bbc8aa-3405-473d-9195-892d945a08d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":10981}},\"c2ecc0be-56d5-4684-9ec4-bad2e6e9aa00\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11066}},\"d79c6294-b26b-4b1c-84bb-ecbd001854df\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11075}},\"2abbae56-7177-4ac2-85a6-02e955fa5601\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11086}},\"3e4b5324-22aa-4ebb-bf2b-0941355d587a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11097}},\"cb952d25-bd5d-4a54-87c7-d2b3e9f2f410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":71,\"refSeqNumber\":11106}},\"099518c8-55f1-42b4-9bf1-01bda9943b45\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"9b704654-6ddd-4421-80da-0dd41595264b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"7f83c8d3-0d95-466a-a07c-72bcd2d8ff71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"7d2dadf5-2a1f-46ac-a6e1-eb302441f103\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"b939c7d2-f34e-472d-bddc-ad790294f68b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"36a1d87c-8982-4302-8273-047057da4ab2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":11,\"refSeqNumber\":11106}},\"04b8fac5-0aa6-4318-88b0-3894fadb8dc2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"79efaa1c-6c73-4cd4-8cad-3af71e06c647\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"dd21b74c-7ca7-4ed0-a1d9-32b62f45c0b8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":344,\"refSeqNumber\":11106}},\"ec499667-dfb6-4687-af17-462e1a171665\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"fed056fd-b368-42d4-afc1-2b237b9a5618\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"52182b50-0f4a-4108-9f80-560d95a35769\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"03ba1daa-8d16-4d2b-bbff-71c1f4371e46\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"7bb86bad-8bff-4ae2-ae7a-dfce208db2c0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11106}},\"b2dbb875-4113-4855-80c4-455299f8cce9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2227,\"refSeqNumber\":11314}},\"5e149188-dc09-4eb6-82bb-bd87d9c6eac7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11318}},\"61294eb4-bad0-4890-b340-f56d803d1031\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":670,\"refSeqNumber\":11324}},\"1dc353e0-a20f-46f6-90c9-6e40293592d0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":730,\"refSeqNumber\":11334}},\"a21bc029-88fe-4825-9f91-894538149937\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11357}},\"d39bdc8d-f804-4654-9257-063b5dd75101\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11357}},\"5b11585a-d50c-40a4-ba91-672d319a7dc2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":11372}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":99,\"chunkLengthChars\":2229,\"totalLengthChars\":2229,\"totalSegmentCount\":99,\"chunkSequenceNumber\":11379,\"segmentTexts\":[{\"text\":\"46ynxt67\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"dyh7ixcw48que8c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"text\":\"asv39xkbj5c\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-0835-0000-000000000000}\":false}},{\"text\":\"504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"text\":\"q0enj0l5707og1u\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p\",{\"text\":\"8u47bcc\",\"props\":{\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0835-0000-000000000000}\":false}},\"a6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"text\":\"uqdq585fu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5e7654de-0c09-4a99-b138-9872f90272ad\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d7d08548-e6d0-4580-9eb6-1c794d7cb74c\",\"display\":\"inline-block\"}}},{\"text\":\"krm6cdy34finy6ms9d3c94ry8e7s0zt79i0gi8azwccntrybrt\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5724d074-3621-4463-979b-d7aeb09c35a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-48\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3438f1ed-eb23-46a6-b951-f27a732bf9d4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"hjvknzrah32snoa9thfruaha9xnqg4cj1y3m7t67g1jb9vye3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dddcd389-441b-4069-802a-5d2c4b9dae26\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":11379,\"totalLength\":2229,\"totalSegmentCount\":99}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}},\"listRegistryList-48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0d902dc3-9d2e-4747-9b3e-dd81d790db5e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0d902dc3-9d2e-4747-9b3e-dd81d790db5e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2a3f2675-6a07-44ff-8d61-100a06168141",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30363778-5310-4550-ac2a-22dc75604d50\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4fd559d5-0c43-4988-b87d-6741a031b363\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d1287b28-24ea-4f65-969e-359a1816223a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/afe6a5d8-247a-4513-8a26-15e03c206359\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d5595dc-62f3-45c4-81c4-c6a1c462a855\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ea0da9fd-6dfb-4487-8bf3-b3b1b800af9c\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ed6e980-1b60-4a6b-bc16-c65ce21f0672\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30363778-5310-4550-ac2a-22dc75604d50",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4fd559d5-0c43-4988-b87d-6741a031b363",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d1287b28-24ea-4f65-969e-359a1816223a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "afe6a5d8-247a-4513-8a26-15e03c206359",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d5595dc-62f3-45c4-81c4-c6a1c462a855",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ea0da9fd-6dfb-4487-8bf3-b3b1b800af9c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ed6e980-1b60-4a6b-bc16-c65ce21f0672",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vngywf2yc@example.com}\",\"displayName\":\"zx7an48p27a5f8w\",\"originalName\":\"8nxcqofmkri4r23\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}},\"d7d08548-e6d0-4580-9eb6-1c794d7cb74c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"516rxxem9@example.com}\",\"displayName\":\"qqrnvyuioandjah\",\"originalName\":\"l313qaekoy3jcly\",\"dateCreated\":\"2019-07-29T22:36:10.079Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":11379,\"referenceSequenceNumber\":-1,\"sequenceNumber\":11380,\"timestamp\":1564766898577,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,755 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1996,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"374da229-e520-4f65-b86b-7cadf9f3af7e\",{\"client\":{\"user\":{\"id\":\"m2j79z88n@example.com}\",\"name\":\"eezqjhryrwqllkt\",\"email\":\"xjszyzduj@example.com}\"}},\"sequenceNumber\":1985}],[\"0d28398e-0b64-4898-be91-d21ae0fc0096\",{\"client\":{\"user\":{\"id\":\"6kopde281@example.com}\",\"name\":\"401yzqhzryf00tb\",\"email\":\"bz0n6j8co@example.com}\"}},\"sequenceNumber\":1990}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":26,\"chunkLengthChars\":783,\"totalLengthChars\":783,\"totalSegmentCount\":26,\"chunkSequenceNumber\":1996,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7eqoqitb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\"}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"rdjth4p0ik\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"76a240b5-e458-4153-b46c-09b1b7c2e68c\",\"ItemType\":\"Paragraph\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfqlx9dc3r0960opt8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"45827d2c-b307-4561-81fd-1252f3a62c24\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1996,\"totalLength\":783,\"totalSegmentCount\":26}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"05093113-6021-4762-8e35-da8448bbca97\",\"clientSequenceNumber\":62,\"minimumSequenceNumber\":1996,\"referenceSequenceNumber\":1996,\"sequenceNumber\":2000,\"timestamp\":1564422439560,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,764 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2929,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"05c0e3f7-41e7-404f-a556-e950977fccf8\",{\"client\":{\"user\":{\"id\":\"vywwq3w2n@example.com}\",\"name\":\"csz06a2fjdye5j0\",\"email\":\"0p0ps0t1l@example.com}\"}},\"sequenceNumber\":2480}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":628,\"refSeqNumber\":2998}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":27,\"chunkLengthChars\":1023,\"totalLengthChars\":1023,\"totalSegmentCount\":27,\"chunkSequenceNumber\":2929,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7evoqith\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg69d687l5712d78\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\"}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh7\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfqlx9dc3r0960opt8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj84\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysm\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2929,\"totalLength\":1023,\"totalSegmentCount\":27}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":525,\"contents\":{\"pos1\":577,\"pos2\":578,\"type\":1},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2934,\"sequenceNumber\":2935,\"timestamp\":1564422883637,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":527,\"contents\":{\"pos1\":577,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2935,\"sequenceNumber\":2936,\"timestamp\":1564422883934,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":529,\"contents\":{\"pos1\":578,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2937,\"sequenceNumber\":2938,\"timestamp\":1564422884168,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":532,\"contents\":{\"pos1\":579,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2939,\"sequenceNumber\":2940,\"timestamp\":1564422885326,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":534,\"contents\":{\"pos1\":580,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2941,\"sequenceNumber\":2942,\"timestamp\":1564422885529,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":536,\"contents\":{\"pos1\":581,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2943,\"sequenceNumber\":2944,\"timestamp\":1564422885638,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":538,\"contents\":{\"pos1\":582,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2945,\"sequenceNumber\":2946,\"timestamp\":1564422885872,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":540,\"contents\":{\"pos1\":583,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2947,\"sequenceNumber\":2948,\"timestamp\":1564422885982,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":543,\"contents\":{\"pos1\":584,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2949,\"sequenceNumber\":2950,\"timestamp\":1564422886294,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":587,\"contents\":{\"pos1\":632,\"pos2\":633,\"type\":1},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2974,\"sequenceNumber\":2975,\"timestamp\":1564422892595,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":589,\"contents\":{\"pos1\":631,\"pos2\":632,\"type\":1},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2976,\"sequenceNumber\":2977,\"timestamp\":1564422892766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":591,\"contents\":{\"pos1\":631,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2977,\"sequenceNumber\":2978,\"timestamp\":1564422893110,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":594,\"contents\":{\"pos1\":632,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2979,\"sequenceNumber\":2980,\"timestamp\":1564422893536,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":599,\"contents\":{\"pos1\":641,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2982,\"sequenceNumber\":2983,\"timestamp\":1564422894592,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":618,\"contents\":{\"pos1\":629,\"pos2\":630,\"type\":1},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2997,\"sequenceNumber\":2998,\"timestamp\":1564422896467,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":620,\"contents\":{\"pos1\":628,\"pos2\":629,\"type\":1},\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1564422896655,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"05c0e3f7-41e7-404f-a556-e950977fccf8\",\"clientSequenceNumber\":620,\"minimumSequenceNumber\":2929,\"referenceSequenceNumber\":2998,\"sequenceNumber\":3000,\"timestamp\":1564422896655,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,845 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3884,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\",{\"client\":{\"user\":{\"id\":\"z5z0rv02m@example.com}\",\"name\":\"1vt7ef2q7tj5z49\",\"email\":\"nydam7jif@example.com}\"}},\"sequenceNumber\":3115}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"2a20f645-debb-4a31-9afd-c49fa8debaf0\",{\"client\":{\"user\":{\"id\":\"n0z5caigc@example.com}\",\"name\":\"z2n2jqn4o3ogquc\",\"email\":\"63j0jeq8u@example.com}\"}},\"sequenceNumber\":3149}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\",{\"client\":{\"user\":{\"id\":\"6e6744sct@example.com}\",\"name\":\"4o5yjubggnihqqb\",\"email\":\"zybi5qdff@example.com}\"}},\"sequenceNumber\":3796}],[\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",{\"client\":{\"user\":{\"id\":\"lhsuv3w2v@example.com}\",\"name\":\"ohpdo5et825uxm3\",\"email\":\"hv1cprs0y@example.com}\"}},\"sequenceNumber\":3824}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"2a20f645-debb-4a31-9afd-c49fa8debaf0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1148,\"refSeqNumber\":3635}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":998,\"refSeqNumber\":3996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":43,\"chunkLengthChars\":1111,\"totalLengthChars\":1111,\"totalSegmentCount\":43,\"chunkSequenceNumber\":3884,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3884,\"totalLength\":1111,\"totalSegmentCount\":43}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":77,\"contents\":{\"pos1\":117,\"pos2\":118,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3895,\"sequenceNumber\":3896,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":78,\"contents\":{\"pos1\":117,\"pos2\":118,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3896,\"sequenceNumber\":3897,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":79,\"contents\":{\"pos1\":187,\"pos2\":188,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3897,\"sequenceNumber\":3898,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":80,\"contents\":{\"pos1\":187,\"pos2\":188,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3898,\"sequenceNumber\":3899,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":81,\"contents\":{\"pos1\":344,\"pos2\":345,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3899,\"sequenceNumber\":3900,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":344,\"pos2\":345,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3900,\"sequenceNumber\":3901,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":570,\"pos2\":571,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3901,\"sequenceNumber\":3902,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":570,\"pos2\":571,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3902,\"sequenceNumber\":3903,\"timestamp\":1564428448746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":714,\"pos2\":715,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3903,\"sequenceNumber\":3904,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":714,\"pos2\":715,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3904,\"sequenceNumber\":3905,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":845,\"pos2\":846,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3905,\"sequenceNumber\":3906,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":845,\"pos2\":846,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3906,\"sequenceNumber\":3907,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":959,\"pos2\":960,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3907,\"sequenceNumber\":3908,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":959,\"pos2\":960,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3908,\"sequenceNumber\":3909,\"timestamp\":1564428448762,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":960,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3911,\"sequenceNumber\":3912,\"timestamp\":1564428450778,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":97,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}},\"relativePos1\":{\"id\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"before\":true},\"relativePos2\":{\"id\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\"},\"type\":2},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3913,\"sequenceNumber\":3914,\"timestamp\":1564428451841,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":99,\"contents\":{\"pos1\":960,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3914,\"sequenceNumber\":3915,\"timestamp\":1564428453419,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":961,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3916,\"sequenceNumber\":3917,\"timestamp\":1564428453575,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":962,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3918,\"sequenceNumber\":3919,\"timestamp\":1564428453737,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":105,\"contents\":{\"pos1\":963,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3920,\"sequenceNumber\":3921,\"timestamp\":1564428453831,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":107,\"contents\":{\"pos1\":964,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3922,\"sequenceNumber\":3923,\"timestamp\":1564428453956,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":109,\"contents\":{\"pos1\":965,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3924,\"sequenceNumber\":3925,\"timestamp\":1564428454112,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":966,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3926,\"sequenceNumber\":3927,\"timestamp\":1564428454206,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":967,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3928,\"sequenceNumber\":3929,\"timestamp\":1564428454471,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":968,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3930,\"sequenceNumber\":3931,\"timestamp\":1564428454627,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":969,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3932,\"sequenceNumber\":3933,\"timestamp\":1564428454815,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":119,\"contents\":{\"pos1\":970,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3934,\"sequenceNumber\":3935,\"timestamp\":1564428454971,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":971,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3936,\"sequenceNumber\":3937,\"timestamp\":1564428455377,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":972,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3938,\"sequenceNumber\":3939,\"timestamp\":1564428455518,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":973,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3940,\"sequenceNumber\":3941,\"timestamp\":1564428455737,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":129,\"contents\":{\"pos1\":974,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3942,\"sequenceNumber\":3943,\"timestamp\":1564428456096,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":975,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3944,\"sequenceNumber\":3945,\"timestamp\":1564428456331,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":976,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3946,\"sequenceNumber\":3947,\"timestamp\":1564428457049,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":976,\"pos2\":977,\"type\":1},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3949,\"sequenceNumber\":3950,\"timestamp\":1564428457049,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":976,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3951,\"sequenceNumber\":3952,\"timestamp\":1564428457049,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":977,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3953,\"sequenceNumber\":3954,\"timestamp\":1564428458928,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":978,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3955,\"sequenceNumber\":3956,\"timestamp\":1564428459069,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":979,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3957,\"sequenceNumber\":3958,\"timestamp\":1564428459194,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":980,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3959,\"sequenceNumber\":3960,\"timestamp\":1564428459444,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":981,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3961,\"sequenceNumber\":3962,\"timestamp\":1564428459616,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":982,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3963,\"sequenceNumber\":3964,\"timestamp\":1564428459694,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":983,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3965,\"sequenceNumber\":3966,\"timestamp\":1564428459819,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":983,\"pos2\":984,\"type\":1},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3968,\"sequenceNumber\":3969,\"timestamp\":1564428460367,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":160,\"contents\":{\"pos1\":983,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3969,\"sequenceNumber\":3970,\"timestamp\":1564428460633,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":162,\"contents\":{\"pos1\":984,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3971,\"sequenceNumber\":3972,\"timestamp\":1564428460805,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":164,\"contents\":{\"pos1\":985,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3973,\"sequenceNumber\":3974,\"timestamp\":1564428460867,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":166,\"contents\":{\"pos1\":986,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3975,\"sequenceNumber\":3976,\"timestamp\":1564428461086,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":168,\"contents\":{\"pos1\":987,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3977,\"sequenceNumber\":3978,\"timestamp\":1564428461243,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":170,\"contents\":{\"pos1\":988,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3979,\"sequenceNumber\":3980,\"timestamp\":1564428461383,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":989,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3981,\"sequenceNumber\":3982,\"timestamp\":1564428461508,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":990,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3983,\"sequenceNumber\":3984,\"timestamp\":1564428461664,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":176,\"contents\":{\"pos1\":991,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3985,\"sequenceNumber\":3986,\"timestamp\":1564428461828,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":992,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3987,\"sequenceNumber\":3988,\"timestamp\":1564428461917,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":993,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3989,\"sequenceNumber\":3990,\"timestamp\":1564428461979,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":994,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3991,\"sequenceNumber\":3992,\"timestamp\":1564428462137,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":995,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3993,\"sequenceNumber\":3994,\"timestamp\":1564428462215,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":996,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3995,\"sequenceNumber\":3996,\"timestamp\":1564428462293,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":997,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3997,\"sequenceNumber\":3998,\"timestamp\":1564428462387,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":998,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1564428462496,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\",\"clientSequenceNumber\":190,\"minimumSequenceNumber\":3884,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1564428462496,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,872 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4997,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\",{\"client\":{\"user\":{\"id\":\"z5z0rv02m@example.com}\",\"name\":\"1vt7ef2q7tj5z49\",\"email\":\"nydam7jif@example.com}\"}},\"sequenceNumber\":3115}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"2a20f645-debb-4a31-9afd-c49fa8debaf0\",{\"client\":{\"user\":{\"id\":\"n0z5caigc@example.com}\",\"name\":\"z2n2jqn4o3ogquc\",\"email\":\"63j0jeq8u@example.com}\"}},\"sequenceNumber\":3149}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"7e3e6b94-af77-42d9-88af-2866ae3822d7\",{\"client\":{\"user\":{\"id\":\"scl1q05xc@example.com}\",\"name\":\"u7ceoi0o6g0trzr\",\"email\":\"00zqricu1@example.com}\"}},\"sequenceNumber\":4880}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xph0klr4b@example.com}\",\"displayName\":\"7568trcbg968pzw\",\"originalName\":\"a7qrzo80dctilbs\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"bee023ef-c4d3-4752-8b2e-18489b1cf2c7\":{\"type\":\"Plain\",\"value\":{\"dateCreated\":\"2019-07-29T19:38:13.81Z\",\"backReference\":\"\",\"initialized\":false}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"2a20f645-debb-4a31-9afd-c49fa8debaf0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1148,\"refSeqNumber\":3635}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":860,\"refSeqNumber\":4989}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":63,\"chunkLengthChars\":1541,\"totalLengthChars\":1541,\"totalSegmentCount\":63,\"chunkSequenceNumber\":4997,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"7m3s157jx4rln\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"cf35834b-13e6-47ca-b029-8d5750b54cdd\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/bee023ef-c4d3-4752-8b2e-18489b1cf2c7\",\"display\":\"inline-block\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4997,\"totalLength\":1541,\"totalSegmentCount\":63}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"7e3e6b94-af77-42d9-88af-2866ae3822d7\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":860,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4997,\"referenceSequenceNumber\":4998,\"sequenceNumber\":4999,\"timestamp\":1564429097349,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"7e3e6b94-af77-42d9-88af-2866ae3822d7\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":861,\"pos2\":862,\"type\":1},\"minimumSequenceNumber\":4997,\"referenceSequenceNumber\":4999,\"sequenceNumber\":5000,\"timestamp\":1564429097349,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"7e3e6b94-af77-42d9-88af-2866ae3822d7\",\"clientSequenceNumber\":134,\"minimumSequenceNumber\":4997,\"referenceSequenceNumber\":4998,\"sequenceNumber\":5000,\"timestamp\":1564429097349,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,872 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5906,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"2a20f645-debb-4a31-9afd-c49fa8debaf0\",{\"client\":{\"user\":{\"id\":\"n0z5caigc@example.com}\",\"name\":\"z2n2jqn4o3ogquc\",\"email\":\"63j0jeq8u@example.com}\"}},\"sequenceNumber\":3149}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"7e3e6b94-af77-42d9-88af-2866ae3822d7\",{\"client\":{\"user\":{\"id\":\"scl1q05xc@example.com}\",\"name\":\"u7ceoi0o6g0trzr\",\"email\":\"00zqricu1@example.com}\"}},\"sequenceNumber\":4880}],[\"0a59478e-0e39-4110-88f8-17d8d6d46090\",{\"client\":{\"user\":{\"id\":\"ubkpxuw9q@example.com}\",\"name\":\"s8ort3qyiaj0tyg\",\"email\":\"7nggyj63i@example.com}\"}},\"sequenceNumber\":5698}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"a112f09a-6f8e-4979-92ad-1d93a0313328\",{\"client\":{\"user\":{\"id\":\"5fbimkpiu@example.com}\",\"name\":\"tzgwzcvmk4p0uvk\",\"email\":\"kltgaqxml@example.com}\"}},\"sequenceNumber\":5766}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"2a20f645-debb-4a31-9afd-c49fa8debaf0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1148,\"refSeqNumber\":3635}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1002,\"refSeqNumber\":5903}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1702,\"refSeqNumber\":5996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":75,\"chunkLengthChars\":1830,\"totalLengthChars\":1830,\"totalSegmentCount\":75,\"chunkSequenceNumber\":5906,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"ia8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"1hu7jjuoz1gxjs2t67tu1d4b1a9fsmc6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"uqdq585fumz9bexg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5906,\"totalLength\":1830,\"totalSegmentCount\":75}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":67,\"contents\":{\"pos1\":1677,\"pos2\":1678,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5908,\"sequenceNumber\":5909,\"timestamp\":1564430072561,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":69,\"contents\":{\"pos1\":1676,\"pos2\":1677,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5910,\"sequenceNumber\":5911,\"timestamp\":1564430072733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":71,\"contents\":{\"pos1\":1675,\"pos2\":1676,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5912,\"sequenceNumber\":5913,\"timestamp\":1564430072873,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":73,\"contents\":{\"pos1\":1674,\"pos2\":1675,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5914,\"sequenceNumber\":5915,\"timestamp\":1564430073030,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":75,\"contents\":{\"pos1\":1673,\"pos2\":1674,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5916,\"sequenceNumber\":5917,\"timestamp\":1564430073186,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":77,\"contents\":{\"pos1\":1672,\"pos2\":1673,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5918,\"sequenceNumber\":5919,\"timestamp\":1564430073342,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":79,\"contents\":{\"pos1\":1671,\"pos2\":1672,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5920,\"sequenceNumber\":5921,\"timestamp\":1564430073483,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":81,\"contents\":{\"pos1\":1671,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5921,\"sequenceNumber\":5922,\"timestamp\":1564430073826,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":1672,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5923,\"sequenceNumber\":5924,\"timestamp\":1564430073951,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":1673,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5925,\"sequenceNumber\":5926,\"timestamp\":1564430074139,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":1674,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5927,\"sequenceNumber\":5928,\"timestamp\":1564430074233,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":91,\"contents\":{\"pos1\":1674,\"pos2\":1675,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5930,\"sequenceNumber\":5931,\"timestamp\":1564430074733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":1673,\"pos2\":1674,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5932,\"sequenceNumber\":5933,\"timestamp\":1564430075547,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":1672,\"pos2\":1673,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5934,\"sequenceNumber\":5935,\"timestamp\":1564430075750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":1671,\"pos2\":1672,\"type\":1},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5936,\"sequenceNumber\":5937,\"timestamp\":1564430075868,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":1671,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5937,\"sequenceNumber\":5938,\"timestamp\":1564430076144,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":1672,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5939,\"sequenceNumber\":5940,\"timestamp\":1564430076394,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":1673,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5941,\"sequenceNumber\":5942,\"timestamp\":1564430076613,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":1674,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5943,\"sequenceNumber\":5944,\"timestamp\":1564430076784,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":1675,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5945,\"sequenceNumber\":5946,\"timestamp\":1564430076894,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":1676,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5947,\"sequenceNumber\":5948,\"timestamp\":1564430077597,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":1677,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5949,\"sequenceNumber\":5950,\"timestamp\":1564430077722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":1678,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5951,\"sequenceNumber\":5952,\"timestamp\":1564430077832,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":1679,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5953,\"sequenceNumber\":5954,\"timestamp\":1564430078613,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":1680,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5955,\"sequenceNumber\":5956,\"timestamp\":1564430078738,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":1681,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5957,\"sequenceNumber\":5958,\"timestamp\":1564430078847,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":1682,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5959,\"sequenceNumber\":5960,\"timestamp\":1564430078957,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":1683,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5961,\"sequenceNumber\":5962,\"timestamp\":1564430079144,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":1684,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5963,\"sequenceNumber\":5964,\"timestamp\":1564430079191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":1685,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5965,\"sequenceNumber\":5966,\"timestamp\":1564430079301,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":1686,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5967,\"sequenceNumber\":5968,\"timestamp\":1564430079787,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":1687,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5969,\"sequenceNumber\":5970,\"timestamp\":1564430079849,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":1688,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5971,\"sequenceNumber\":5972,\"timestamp\":1564430080006,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":1689,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5973,\"sequenceNumber\":5974,\"timestamp\":1564430080068,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":1690,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5975,\"sequenceNumber\":5976,\"timestamp\":1564430080256,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":1691,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5977,\"sequenceNumber\":5978,\"timestamp\":1564430080303,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":1692,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5979,\"sequenceNumber\":5980,\"timestamp\":1564430080412,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":1693,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5981,\"sequenceNumber\":5982,\"timestamp\":1564430080584,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":1694,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5983,\"sequenceNumber\":5984,\"timestamp\":1564430080693,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":1695,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5985,\"sequenceNumber\":5986,\"timestamp\":1564430080896,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":1696,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5987,\"sequenceNumber\":5988,\"timestamp\":1564430081099,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":1697,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5989,\"sequenceNumber\":5990,\"timestamp\":1564430081209,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":1698,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5991,\"sequenceNumber\":5992,\"timestamp\":1564430081318,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":1699,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5993,\"sequenceNumber\":5994,\"timestamp\":1564430081506,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":1700,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5995,\"sequenceNumber\":5996,\"timestamp\":1564430081521,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":163,\"contents\":{\"pos1\":1701,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5997,\"sequenceNumber\":5998,\"timestamp\":1564430081615,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":166,\"contents\":{\"pos1\":1702,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1564430082068,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xph0klr4b@example.com}\",\"displayName\":\"7568trcbg968pzw\",\"originalName\":\"a7qrzo80dctilbs\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"a112f09a-6f8e-4979-92ad-1d93a0313328\",\"clientSequenceNumber\":166,\"minimumSequenceNumber\":5906,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1564430082068,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_7000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_7000_0.json
@@ -1,0 +1,863 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6998,\"sequenceNumber\":7000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"2a20f645-debb-4a31-9afd-c49fa8debaf0\",{\"client\":{\"user\":{\"id\":\"n0z5caigc@example.com}\",\"name\":\"z2n2jqn4o3ogquc\",\"email\":\"63j0jeq8u@example.com}\"}},\"sequenceNumber\":3149}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"0a59478e-0e39-4110-88f8-17d8d6d46090\",{\"client\":{\"user\":{\"id\":\"ubkpxuw9q@example.com}\",\"name\":\"s8ort3qyiaj0tyg\",\"email\":\"7nggyj63i@example.com}\"}},\"sequenceNumber\":5698}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"86de50f2-a193-4388-9926-2b52deff5d87\",{\"client\":{\"user\":{\"id\":\"mt304etvo@example.com}\",\"name\":\"k2x6qucvjimk3dy\",\"email\":\"31qm2l7cd@example.com}\"}},\"sequenceNumber\":6996}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"2a20f645-debb-4a31-9afd-c49fa8debaf0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1148,\"refSeqNumber\":3635}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"86de50f2-a193-4388-9926-2b52deff5d87\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":86,\"chunkLengthChars\":2111,\"totalLengthChars\":2111,\"totalSegmentCount\":86,\"chunkSequenceNumber\":6998,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"uqdq585fuwjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6998,\"totalLength\":2111,\"totalSegmentCount\":86}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xph0klr4b@example.com}\",\"displayName\":\"7568trcbg968pzw\",\"originalName\":\"a7qrzo80dctilbs\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":6998,\"referenceSequenceNumber\":-1,\"sequenceNumber\":7000,\"timestamp\":1564431133015,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_8000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_8000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":7991,\"sequenceNumber\":8000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"a7e21367-d487-4482-a95d-c853d436860d\",{\"client\":{\"user\":{\"id\":\"08h56wlvs@example.com}\",\"name\":\"r1twh59xnfqo1vd\",\"email\":\"qjx5fz4pv@example.com}\"}},\"sequenceNumber\":7011}],[\"8e257b0a-3abf-47b5-893e-71a3554fcaa3\",{\"client\":{\"user\":{\"id\":\"4xxopwc3h@example.com}\",\"name\":\"tz7eti1tr1ia881\",\"email\":\"iwd1ioy3v@example.com}\"}},\"sequenceNumber\":7203}],[\"969a5cee-3efd-49db-879c-2ded9169042f\",{\"client\":{\"user\":{\"id\":\"d0xk8ay2p@example.com}\",\"name\":\"zl45bcqo99t1w8l\",\"email\":\"8pkfttpsh@example.com}\"}},\"sequenceNumber\":7330}],[\"b5841931-a995-490a-842f-beeb7b1d6144\",{\"client\":{\"user\":{\"id\":\"e74paacho@example.com}\",\"name\":\"knxc5sclq4m7do7\",\"email\":\"8l9ih3i0v@example.com}\"}},\"sequenceNumber\":7379}],[\"a79ae9cf-39d3-4661-baf5-1367e40983e9\",{\"client\":{\"user\":{\"id\":\"z5k5x55as@example.com}\",\"name\":\"yygna93z37knhj6\",\"email\":\"7lh6zh8os@example.com}\"}},\"sequenceNumber\":7380}],[\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\",{\"client\":{\"user\":{\"id\":\"su40m3pw1@example.com}\",\"name\":\"pwxuv23b3f0iczd\",\"email\":\"tbbqjrrmg@example.com}\"}},\"sequenceNumber\":7381}],[\"8bee5d95-4227-4ca2-af38-a56b05ddeb91\",{\"client\":{\"user\":{\"id\":\"k2yk947jx@example.com}\",\"name\":\"iyrxdeajj0q71is\",\"email\":\"b3emt5tus@example.com}\"}},\"sequenceNumber\":7382}],[\"83f15f07-06cd-46f4-b366-98a6cc274650\",{\"client\":{\"user\":{\"id\":\"p9lgc2ewi@example.com}\",\"name\":\"jceqv9659zhjv1n\",\"email\":\"pxajgam41@example.com}\"}},\"sequenceNumber\":7407}],[\"7d1657ad-a424-47bb-ac06-aea82953e9b1\",{\"client\":{\"user\":{\"id\":\"4n1rvsd66@example.com}\",\"name\":\"4u8jzih27n3nwb2\",\"email\":\"rm6c51wjo@example.com}\"}},\"sequenceNumber\":7473}],[\"bd365cf5-f4f4-4e86-b008-827ac92994dc\",{\"client\":{\"user\":{\"id\":\"h83t49tsh@example.com}\",\"name\":\"jzg5cmdnu4nxmvp\",\"email\":\"lopuma13n@example.com}\"}},\"sequenceNumber\":7698}],[\"43e96c19-0889-4a65-8af2-15b080937580\",{\"client\":{\"user\":{\"id\":\"ejxsgc2ej@example.com}\",\"name\":\"n5vtj22du9hxz9g\",\"email\":\"z5jjdkefg@example.com}\"}},\"sequenceNumber\":7706}],[\"e2975b73-7939-4891-9bf5-27a1953863e6\",{\"client\":{\"user\":{\"id\":\"x8qtak29u@example.com}\",\"name\":\"haz8x1mul7rp3j4\",\"email\":\"v2x6gwi8y@example.com}\"}},\"sequenceNumber\":7988}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vngywf2yc@example.com}\",\"displayName\":\"zx7an48p27a5f8w\",\"originalName\":\"8nxcqofmkri4r23\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}},\"d7d08548-e6d0-4580-9eb6-1c794d7cb74c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"516rxxem9@example.com}\",\"displayName\":\"qqrnvyuioandjah\",\"originalName\":\"l313qaekoy3jcly\",\"dateCreated\":\"2019-07-29T22:36:10.079Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"a7e21367-d487-4482-a95d-c853d436860d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":171,\"refSeqNumber\":6971}},\"54e3fecd-9302-4e4a-bc53-6d0eb82d6730\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"41a81f73-67eb-4d48-96a8-fc3bc76be549\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7116}},\"0488f86a-f090-4901-8ec7-89c27e36ec94\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":350,\"pos\":485,\"refSeqNumber\":6971}},\"969a5cee-3efd-49db-879c-2ded9169042f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"7941fba5-9070-4705-8660-368225ef88a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7344}},\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6971}},\"34e1e2ca-7379-46f0-9a7f-c36cba9d5fbd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7208}},\"a79ae9cf-39d3-4661-baf5-1367e40983e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7332}},\"83f15f07-06cd-46f4-b366-98a6cc274650\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7401}},\"befebc61-f145-4a59-ac21-a6e5334db265\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7440}},\"b41bc100-6f95-4555-8a1b-3856148e0433\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7467}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":90,\"chunkLengthChars\":2164,\"totalLengthChars\":2164,\"totalSegmentCount\":90,\"chunkSequenceNumber\":7991,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"uqdq585fuwjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5e7654de-0c09-4a99-b138-9872f90272ad\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d7d08548-e6d0-4580-9eb6-1c794d7cb74c\",\"display\":\"inline-block\"}}},{\"text\":\"krm6cdy34finy6ms9d3c94ry8e7s0zt79i0gi8azwccntrybrt\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5724d074-3621-4463-979b-d7aeb09c35a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-48\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3438f1ed-eb23-46a6-b951-f27a732bf9d4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":7991,\"totalLength\":2164,\"totalSegmentCount\":90}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}},\"listRegistryList-48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0d902dc3-9d2e-4747-9b3e-dd81d790db5e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0d902dc3-9d2e-4747-9b3e-dd81d790db5e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"7d1657ad-a424-47bb-ac06-aea82953e9b1\",\"clientSequenceNumber\":377,\"minimumSequenceNumber\":7991,\"referenceSequenceNumber\":7991,\"sequenceNumber\":8000,\"timestamp\":1564440195495,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_9000_0.json
+++ b/snapshotTestContent/HotBugs3/src_snapshots/0.59.3000/snapshot_9000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":8998,\"sequenceNumber\":9000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"05093113-6021-4762-8e35-da8448bbca97\",{\"client\":{\"user\":{\"id\":\"c74biulrx@example.com}\",\"name\":\"xjit6xlm0jvgx7j\",\"email\":\"myvkmj9p8@example.com}\"}},\"sequenceNumber\":1219}],[\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\",{\"client\":{\"user\":{\"id\":\"ic7fyrs10@example.com}\",\"name\":\"8fs27fyvzbj3qcg\",\"email\":\"xzn2jleq5@example.com}\"}},\"sequenceNumber\":2472}],[\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\",{\"client\":{\"user\":{\"id\":\"5i9kekw83@example.com}\",\"name\":\"nfflkw2piui8clh\",\"email\":\"8q1d6srhg@example.com}\"}},\"sequenceNumber\":3127}],[\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\",{\"client\":{\"user\":{\"id\":\"kzeqtn8t8@example.com}\",\"name\":\"dggqerv6hrl2n2a\",\"email\":\"5utf999x0@example.com}\"}},\"sequenceNumber\":3651}],[\"8f70a11a-ddb0-4709-a38b-e463df55f213\",{\"client\":{\"user\":{\"id\":\"oeh73z6u0@example.com}\",\"name\":\"s6zyfit4fcji1k9\",\"email\":\"dlarnkaza@example.com}\"}},\"sequenceNumber\":5703}],[\"16d8b730-8b68-48b5-ac18-20e70f06d112\",{\"client\":{\"user\":{\"id\":\"czjuese5r@example.com}\",\"name\":\"bqdeh91wgoferqa\",\"email\":\"bommw2p0p@example.com}\"}},\"sequenceNumber\":6102}],[\"a7e21367-d487-4482-a95d-c853d436860d\",{\"client\":{\"user\":{\"id\":\"08h56wlvs@example.com}\",\"name\":\"r1twh59xnfqo1vd\",\"email\":\"qjx5fz4pv@example.com}\"}},\"sequenceNumber\":7011}],[\"8e257b0a-3abf-47b5-893e-71a3554fcaa3\",{\"client\":{\"user\":{\"id\":\"4xxopwc3h@example.com}\",\"name\":\"tz7eti1tr1ia881\",\"email\":\"iwd1ioy3v@example.com}\"}},\"sequenceNumber\":7203}],[\"969a5cee-3efd-49db-879c-2ded9169042f\",{\"client\":{\"user\":{\"id\":\"d0xk8ay2p@example.com}\",\"name\":\"zl45bcqo99t1w8l\",\"email\":\"8pkfttpsh@example.com}\"}},\"sequenceNumber\":7330}],[\"c7713b00-fc44-4250-afda-63c7e531cb72\",{\"client\":{\"user\":{\"id\":\"ck80vpsvl@example.com}\",\"name\":\"12d48z207c1knqn\",\"email\":\"qvvnyxpt2@example.com}\"}},\"sequenceNumber\":8788}],[\"ce9d65a3-ac1f-4967-b83e-58eaeb88ab3f\",{\"client\":{\"user\":{\"id\":\"zliihwzp7@example.com}\",\"name\":\"xj2tkgcjl1kg4ve\",\"email\":\"6zdrvrir9@example.com}\"}},\"sequenceNumber\":8801}],[\"ea104d23-eb26-4969-9880-4e09f59dcc16\",{\"client\":{\"user\":{\"id\":\"ihhl1l2t9@example.com}\",\"name\":\"0nlju6ktl02r4mx\",\"email\":\"th4x111w9@example.com}\"}},\"sequenceNumber\":8828}],[\"b1e2d238-1377-4391-9bdb-7a846645059f\",{\"client\":{\"user\":{\"id\":\"3o85w7cnb@example.com}\",\"name\":\"1k4hnmonh1calsy\",\"email\":\"2r7aq66za@example.com}\"}},\"sequenceNumber\":8858}],[\"4a31718c-d9ad-40e5-aac3-552ec7389c1f\",{\"client\":{\"user\":{\"id\":\"55pxiqujp@example.com}\",\"name\":\"fapv9bf4aj5h5s1\",\"email\":\"m5v3w21kf@example.com}\"}},\"sequenceNumber\":8865}],[\"6cfec889-d47d-47f9-83d6-40b415c0cd64\",{\"client\":{\"user\":{\"id\":\"iwv0gz6pf@example.com}\",\"name\":\"l4rd51smixnl03i\",\"email\":\"kiap9mqvb@example.com}\"}},\"sequenceNumber\":8894}],[\"072c8040-4557-4190-a9d9-9e78b889e5fd\",{\"client\":{\"user\":{\"id\":\"k17wvfzx6@example.com}\",\"name\":\"prgdd0gbici58jr\",\"email\":\"vfp0fh25z@example.com}\"}},\"sequenceNumber\":8982}],[\"e9aa9e12-b763-4af1-9245-45b86e069466\",{\"client\":{\"user\":{\"id\":\"656vojkd2@example.com}\",\"name\":\"o1x3jjitg18d8cu\",\"email\":\"tkh5t4sh0@example.com}\"}},\"sequenceNumber\":8990}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0f9b589d-d7ae-4e53-8b9a-4b3ca9623daf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}},\"versions\":[{\"sequenceNumber\":1223,\"value\":{\"type\":\"Plain\",\"value\":\"05093113-6021-4762-8e35-da8448bbca97\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5a1bb1df-8649-4971-94dc-f050f8746a37\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/266db83a-a460-43ec-bde5-6e5249d2dc66\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/66667a89-1b9b-4911-a37b-e7eeafa1f633\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8cdd6e9a-ac59-4eb1-9179-485d87ba5260\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8b7e2935-638d-4774-b300-7fbbe8195314\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5a1bb1df-8649-4971-94dc-f050f8746a37",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c7409aca-099a-4bb5-882d-b874a6eb0483\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1270,\"refSeqNumber\":62}},\"8c1e85ac-9295-40e7-b47a-6c7abaadd455\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":47,\"refSeqNumber\":1071}},\"a9d252c0-161b-4edd-bf2c-eb874835d411\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":472,\"refSeqNumber\":1190}},\"0bfc82cf-896b-4bab-83bb-fc2a18847b66\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1193}},\"c845d050-5207-4fdf-b018-618815db619b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":413,\"refSeqNumber\":1250}},\"13e2cdc8-4bda-4982-8346-8724b8aaa1f2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":151,\"refSeqNumber\":1268}},\"bc970183-b042-4181-8612-c40a836212ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":215,\"refSeqNumber\":1449}},\"c97e6fbb-81ec-4b6c-ae99-e5541b07d0fc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":631,\"refSeqNumber\":1956}},\"a3f4e2f0-3e91-41e4-9f14-480c47d27a54\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":633,\"refSeqNumber\":1956}},\"374da229-e520-4f65-b86b-7cadf9f3af7e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":575,\"refSeqNumber\":1972}},\"0d28398e-0b64-4898-be91-d21ae0fc0096\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1972}},\"9a4b63d0-e7f6-4e38-90ac-67bdab457d0f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2003}},\"b6d01b49-0626-44ce-9cf6-e14e8b9707fb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":757,\"refSeqNumber\":2443}},\"8392d89a-d1cf-45ec-bb6d-1f5fba627328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2443}},\"05c0e3f7-41e7-404f-a556-e950977fccf8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":955,\"refSeqNumber\":3109}},\"73ef8daa-3ba8-44f6-9389-366c05afc5ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1067,\"pos\":0,\"refSeqNumber\":3109}},\"b7bba625-3862-4b4d-bbae-1274eeac8e3d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3109}},\"e3f69aa5-05f6-4d46-bd43-1e07152bb2a2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1110,\"refSeqNumber\":3790}},\"30c89f64-c1e6-4dfa-8dd1-0a182ce98ec8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1109,\"refSeqNumber\":3790}},\"089b4a3b-9d7e-49a2-bd78-689cdc24afc5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1372,\"refSeqNumber\":4820}},\"7e3e6b94-af77-42d9-88af-2866ae3822d7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1356,\"refSeqNumber\":6898}},\"680016fc-1246-47ee-97f6-f1884d7b4a71\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1780,\"refSeqNumber\":5690}},\"0a59478e-0e39-4110-88f8-17d8d6d46090\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5695}},\"8f70a11a-ddb0-4709-a38b-e463df55f213\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1629,\"refSeqNumber\":5690}},\"a112f09a-6f8e-4979-92ad-1d93a0313328\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1739,\"refSeqNumber\":6081}},\"16d8b730-8b68-48b5-ac18-20e70f06d112\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6084}},\"baeec0fb-807d-4385-b8bc-b0ab697ddea7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6900}},\"a7e21367-d487-4482-a95d-c853d436860d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":171,\"refSeqNumber\":6971}},\"54e3fecd-9302-4e4a-bc53-6d0eb82d6730\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"41a81f73-67eb-4d48-96a8-fc3bc76be549\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7116}},\"0488f86a-f090-4901-8ec7-89c27e36ec94\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":350,\"pos\":485,\"refSeqNumber\":6971}},\"969a5cee-3efd-49db-879c-2ded9169042f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2109,\"refSeqNumber\":6971}},\"7941fba5-9070-4705-8660-368225ef88a1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7344}},\"4a7b9550-ca5e-46ff-a15e-9387cd1a2ada\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6971}},\"34e1e2ca-7379-46f0-9a7f-c36cba9d5fbd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7208}},\"a79ae9cf-39d3-4661-baf5-1367e40983e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7332}},\"83f15f07-06cd-46f4-b366-98a6cc274650\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7401}},\"befebc61-f145-4a59-ac21-a6e5334db265\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7440}},\"b41bc100-6f95-4555-8a1b-3856148e0433\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7467}},\"80cb6e9b-0da6-4964-95e8-bb7bd13146da\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"671b9ea2-fe72-4ea5-9442-d5d55845f60f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"e2975b73-7939-4891-9bf5-27a1953863e6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":498,\"refSeqNumber\":7680}},\"b6391cf9-6a84-47da-96eb-368d088044af\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":187,\"refSeqNumber\":8269}},\"1f1d1ab3-dcda-4ed4-8a19-42cda05b767e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8286}},\"e4b951bb-3c6d-4196-88eb-c8928628bbcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2162,\"refSeqNumber\":7680}},\"ea104d23-eb26-4969-9880-4e09f59dcc16\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8821}},\"d04b2493-c128-4251-9351-1fad62aef7d2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":62,\"refSeqNumber\":7680}},\"072c8040-4557-4190-a9d9-9e78b889e5fd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":715,\"refSeqNumber\":7680}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "266db83a-a460-43ec-bde5-6e5249d2dc66",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2957890c-065a-4bf6-8b34-72f37085c54b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "66667a89-1b9b-4911-a37b-e7eeafa1f633",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2957890c-065a-4bf6-8b34-72f37085c54b\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":90,\"chunkLengthChars\":2164,\"totalLengthChars\":2164,\"totalSegmentCount\":90,\"chunkSequenceNumber\":8998,\"segmentTexts\":[{\"text\":\"46ynxt67dyh7ixcw48que8casv39xkbj5c504u42qqpec5m1hfx8mtywqzd4lkf5szllu8k\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2a56857-d5ed-45f0-a0a5-ef53d1e41a04\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Body\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5aff9802-d926-4455-85aa-2b4f9e8efcb3\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"2k3c8undnhb02vpxjatnconm7lb1q1tussv5m8g7lrqs\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"36c3ebf3-9bec-4636-a57a-8a5e3f6644c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"i\",{\"text\":\"q\",\"props\":{}},\"8p8u47bcca6lzkc1w53qauzb9c1i53hgvbf5cpwh9947e1obsynyj66ar0rt2r7ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8ef2457a-0e08-4de5-a1bc-fbee58a8b94f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a26fbee7-f88d-4ce8-8aea-9502186f2141\",\"display\":\"inline-block\"}}},\"h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1cf23eb6-d9a2-4e71-a484-43f31be1490c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"5jasqz5hk0h03tsewia4sq0s8dbhgjm0j0frq4er0d1t76pnbtmp1hsw96c9d6onwvrcmu2fonohpdi9vizl94cmfqbz3b0zjo4afcdlqpl1ibizdnhidi2aejyk7vi714x5lqrc7ldnwtdsaiurpg6\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"2282f4ac-d150-4600-a31e-dd9cc2e9ee98\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/777db84f-25ad-42bd-a4de-da478f674571\",\"display\":\"inline-block\"}}},\"6b\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"d24b0ca1-65b7-40bf-a222-fa1380a4e674\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/916b71c3-524b-4f02-91ba-120439e53d16\",\"display\":\"inline-block\"}}},\"8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9ce55d3b-d0d2-4ca7-bd46-26268bb5896b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"ydtsybhrtnbdn9tdidjbh3xwsvx21mtu62zyzuip7dxolahdnpf0yk2nd4j3jkgf6osa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"a3rhwcxwqv2jw2s129xviwm7k83x2r3mh7w9yxjhd3o5k8q99wyvhpvcq6um7unv22cd5k6dgo3rjccl9tgluha0q95s4an04i6mupjpkfynmd735i1n49sbhq6lksxygmak9tn32gsj29l1yhg7g2tuh27\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9064aa0f-e2f1-47cc-9d02-ae625647f475\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\",\"display\":\"inline-block\"}}},\"r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef32814e-6e11-4723-8fad-75232e1c4024\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"k5nadlw7529wgli723es6iwvsk67aw5im6qjclfq4h84cl821gtfrqbhkf2agdcqf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"594b2233-ff47-4d0f-b33b-ba7edb237c65\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\",\"display\":\"inline-block\"}}},\"4d\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4014edf9-8745-4ce1-8bb7-8a3449a771f1\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\",\"display\":\"inline-block\"}}},\"cwag4ixmjmbvm1enrobnkn1ayzq0uavb4rpgd1k4b02yhwwcv9qmxsoaemxcganfdv8rt700k3\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6e29785-e6fd-4c70-a3bc-a967c7542490\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7b18eb1a-9640-4ca7-a8f7-135c650df87e\",\"ItemType\":\"Paragraph\"}},\"bjqj8whjrqoi2yxpnnfh6vj58g96jxsy1lm3x9i8fjw8af7dkcanowjmm92labnlogkdxhjyb4kqpwwktfgjxwz7fq0q3ci67s8wfwobrqsodwc1z2e3rhqnsicj849y\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5ede276e-9e2f-43bf-b7e8-3cf1187fd145\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\",\"display\":\"inline-block\"}}},\"u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"24ae9be5-2c10-4e0c-a6fe-6f6f681b2ffa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},{\"text\":\"4wpa2kg2\",\"props\":{}},\"7m3sjx4r\",{\"text\":\"w9\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"63e0db04-d36f-4008-a6d0-50cd74c0708a\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42b2fe4b-38ce-4458-85e5-9cd029883021\",\"display\":\"inline-block\"}}},{\"text\":\"rxvp\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"29027283-9ede-4731-b7f1-50a99da94536\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9bdc0e2f-c515-447c-adf2-c5edab3f21d9\",\"display\":\"inline-block\"}}},\"11p44fnw4280tin2v8ww9md556v8lkq6tecew\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31f6c841-358d-4a1b-83d1-ab0f8d524d94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList65\"}}},\"vq9ddminrrorhvtdskh2n4aqrmdid4p1vyva8gk2hslrbkoh0qwr7nkagzk9v2aazyw3tgzr9jmsi420wbw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0f6c8e24-d37c-4476-8aea-3485b838f853\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},\"blvho5rxhl5are3nd1eiv7jjuixg6ejqeblf61lhfqngg5fsmc6zadlr9aapu5x1tf4hc3vo4q4vsz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"92020704-3d8f-4790-b069-2e04a5f36570\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/5330bf2f-38b9-4c3a-8c81-a20482611164\",\"display\":\"inline-block\"}}},\"hmn6bjx6ka6mhx0gbc6s6zsnv99xeahd1vdpui1rtmo4kdy9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fede41e5-e415-44a1-8d7a-2b0b77a8b88d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},\"ybi2rc7lbt587vcklw5qgh0v26hsyk43if79leknjnqtd0vlzadqfaxoaw68h35jquuz0pygl03irq2tkcaz1plevswam6sv8zfbh7bjnuk8\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e1299124-5d83-45be-952d-c7cbb849aee1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"03cba216-6d87-4579-a82c-d343bfb89cc2\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/608bd0bb-dcdb-48ff-9102-b3578915413d\",\"display\":\"inline-block\"}}},{\"text\":\"p9xkfhqhikqatnw011kzzgqnt9r0b76vplcfy31in99ggukaq51ghf93nzmv7rdrplg58ofh6bfpz4a26dw1yhzpy7wh6ecwpl2h32i16o16q7dhrlny53a\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"9f991525-7bec-41f2-8f70-ddd320ba14f8\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/e322598b-a96b-4c89-94d5-8b79dc846e3a\",\"display\":\"inline-block\"}}},\"6tf9q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f86c6aa-3967-4c30-8c78-45239d11b08f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":2,\"listId\":\"listRegistryList65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56dbe6da-6a61-4ac4-9135-bea18c9cb560\",\"ItemType\":\"Paragraph\"}},\"dxmw8rn5ks7xbn0zk2e97stedyveepvkiqe7h41o8mi38anbngk4iirfcjmuf9c277ryb98r12a77xcib8nyp8tdnzcq3buccgtmlp3dsgysmci\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0be6412e-63fc-469b-aaf8-6a79fe8f3775\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/451cdc23-b173-47c9-980f-538819c41692\",\"display\":\"inline-block\"}}},\"4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"146fa9da-756b-4530-8847-24a7641ed50e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList10\"}}},\"r0a0znyo4rc10g79\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b72f0158-46fd-42a2-ac71-5ac70cd4bcce\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/42553f8e-75c5-4794-b01d-3767118b197b\",\"display\":\"inline-block\"}}},\"0s5mnttdvlr1az2zon5udmae6k7il23bfpwhsbczbscsl055abeu8ium2ttxccu3nq4t1gvyd9qyi2d2u7teo4wycapi8wc9npypcnnqjevp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"963fe3d0-fbcc-4c67-a0f2-4c2f33a45e3b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ea9abd63-01c8-41ad-93e8-1e0fac9ecf4b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/da5b1a03-275f-48ef-bde2-e4723819d960\",\"display\":\"inline-block\"}}},{\"text\":\"6hog3xlmqhh6c905c1xwyyq4mzblq8xveqxou29sfr5gal3tc23hv11tkiltojnpgyuaibl483cnelonzmhxa54jv30kzbpq3cil\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c33c091d-5364-4344-8a58-9b1332c89a67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"x00yofdh0grwzg87z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"8484c460-8a71-4332-9f91-4170ccdc3a17\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/a196c5f5-116d-469d-98e3-909236dfddbd\",\"display\":\"inline-block\"}}},\"s4f9hflopoeeiy60q1oxyffhq5ps9h36kzl7eov2wxpz42qyp0nkjig26imzhkzhtr12e28roczxvrgnladr9h4n8y7is9yotn8s6du16kjztxgi\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc03bb44-b74f-49b8-b005-c6dc9ddd1719\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"e164f27e-b2e4-4123-bb62-c7c19da532f5\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/96682146-99c3-4fc9-889e-c629396efc2c\",\"display\":\"inline-block\"}}},{\"text\":\"ib30mm3b30jlghkskypbp0zfs91rimisavv5cy4kx12d34waxg6\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"80075c88-af9b-4b59-a18f-6f1f315d55e7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList10\"}}},\"uqdq585fuwjey966aobhyksu3suoft2wnmjs5lqkzhmtq30tjkg7hb8bsxe9jh2svekuocxff\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"608d3e7b-f4fe-4f9c-bcfa-564b91e8ad4e\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/cb39cbb1-6ebe-4126-aaf0-77242cf0190b\",\"display\":\"inline-block\"}}},\"5\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d52b17c7-a41b-4916-90b1-641e6cbdd289\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"5e7654de-0c09-4a99-b138-9872f90272ad\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d7d08548-e6d0-4580-9eb6-1c794d7cb74c\",\"display\":\"inline-block\"}}},{\"text\":\"krm6cdy34finy6ms9d3c94ry8e7s0zt79i0gi8azwccntrybrt\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5724d074-3621-4463-979b-d7aeb09c35a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-48\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3438f1ed-eb23-46a6-b951-f27a732bf9d4\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"834cc147-9d18-4905-8675-942eed13714b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9fd47aa-a3e4-47f0-92bd-227a09831910\",\"ItemType\":\"Paragraph\"}},{\"text\":\"3y9r37m6il83alay0xyj1dwhwmvn816utgk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"326d72ba-89cb-42a2-b95b-d8ec8ea5f4a6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"qxdwvehl19qdabpkej17l7w4e40zpdqdy7jhjzxhkj6kq9812yb\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cd467d23-0876-4e81-b97f-928585bd7407\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},\"5hwj8tqh00akykb1yq7un3735etkw3286f2hv2jdobpa29wct26qafob2ug\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42e45ec7-9e59-4db7-92e2-b181315b5bdc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList94\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d3511af7-c175-449f-92b1-dec06c6c6634\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":8998,\"totalLength\":2164,\"totalSegmentCount\":90}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8cdd6e9a-ac59-4eb1-9179-485d87ba5260",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1f814ccf-9e5e-43d8-85ab-839774eda4ea\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3f6d3131-3299-43d4-abc7-e3228a3394d5\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/805d9b58-488d-4668-b4dc-d9cd3edd80b1\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b5a7d8ad-8245-44f0-9aa1-d70c56029ef2\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec9ffbd1-3652-4bce-becc-be229768d4eb\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/259b13a9-108e-43c3-b48a-87fc50fce236\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/240a8756-2b89-4947-861d-1f56cb58f438\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f814ccf-9e5e-43d8-85ab-839774eda4ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3f6d3131-3299-43d4-abc7-e3228a3394d5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "805d9b58-488d-4668-b4dc-d9cd3edd80b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b5a7d8ad-8245-44f0-9aa1-d70c56029ef2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec9ffbd1-3652-4bce-becc-be229768d4eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "259b13a9-108e-43c3-b48a-87fc50fce236",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "240a8756-2b89-4947-861d-1f56cb58f438",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8b7e2935-638d-4774-b300-7fbbe8195314",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList94\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1e56f446-696c-4b33-8528-dba7c5c5b4de\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f8ee89b-2945-4423-a35a-73ce195363cc\"}},\"listRegistryList10\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3e5dbf00-0084-4999-ba8f-3aff224f1d19\"}},\"listRegistryList65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7254cbaa-f90b-48da-b007-3cf1a6a96a77\"}},\"listRegistryList-48\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0d902dc3-9d2e-4747-9b3e-dd81d790db5e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1e56f446-696c-4b33-8528-dba7c5c5b4de",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList94\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f8ee89b-2945-4423-a35a-73ce195363cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3e5dbf00-0084-4999-ba8f-3aff224f1d19",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList10\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7254cbaa-f90b-48da-b007-3cf1a6a96a77",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0d902dc3-9d2e-4747-9b3e-dd81d790db5e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-48\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"a26fbee7-f88d-4ce8-8aea-9502186f2141\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"afbqsi5gz@example.com}\",\"displayName\":\"wv6j7ns93a3nl18\",\"originalName\":\"p1p7qcehpydm5tf\",\"dateCreated\":\"2019-07-29T19:05:32.433Z\",\"backReference\":\"\",\"initialized\":true}},\"777db84f-25ad-42bd-a4de-da478f674571\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cml7m67j2@example.com}\",\"displayName\":\"pg4zn8e1hhumb2d\",\"originalName\":\"0tssu5ujf1xahog\",\"dateCreated\":\"2019-07-29T19:05:42.755Z\",\"backReference\":\"\",\"initialized\":true}},\"916b71c3-524b-4f02-91ba-120439e53d16\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dczzmx8jq@example.com}\",\"displayName\":\"lmrz8txmaplbs3e\",\"originalName\":\"beew7xueci6cjnz\",\"dateCreated\":\"2019-07-29T19:05:48.602Z\",\"backReference\":\"\",\"initialized\":true}},\"89d2a5b2-9abf-47a3-a54d-636b0bad9d7d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cruj0lph6@example.com}\",\"displayName\":\"49ffiwcsor1fxrw\",\"originalName\":\"qewetr7ocqs14wk\",\"dateCreated\":\"2019-07-29T19:05:57.495Z\",\"backReference\":\"\",\"initialized\":true}},\"0fb27a55-d652-45a0-b5f2-b15dadfbb7c5\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"33ta9itgj@example.com}\",\"displayName\":\"q29pyf4ltvvj48o\",\"originalName\":\"qltwkkgdaun9z51\",\"dateCreated\":\"2019-07-29T19:06:05.34Z\",\"backReference\":\"\",\"initialized\":true}},\"17e2031f-f4d4-44bb-8b6c-c6a43b115cbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"m5jp727dt@example.com}\",\"displayName\":\"2lq0ye6hryyl3lc\",\"originalName\":\"wv3tvgt8dxhlklj\",\"dateCreated\":\"2019-07-29T19:06:12.156Z\",\"backReference\":\"\",\"initialized\":true}},\"6941a7a3-bf5c-4e20-8a79-6bd2ee43a940\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"5hdwr49tr@example.com}\",\"displayName\":\"kzaxh7yytgez1ed\",\"originalName\":\"zwkhgm1rrqkji44\",\"dateCreated\":\"2019-07-29T19:06:29.015Z\",\"backReference\":\"\",\"initialized\":true}},\"451cdc23-b173-47c9-980f-538819c41692\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"4u5khpmfa@example.com}\",\"displayName\":\"nqptnf8zbycjojx\",\"originalName\":\"9bgi0zzmspdcggz\",\"dateCreated\":\"2019-07-29T19:06:35.287Z\",\"backReference\":\"\",\"initialized\":true}},\"42553f8e-75c5-4794-b01d-3767118b197b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"6r0ckwmmy@example.com}\",\"displayName\":\"qtmdxyay3c8h3k2\",\"originalName\":\"6rh0lvnoixkxq58\",\"dateCreated\":\"2019-07-29T19:27:36.939Z\",\"backReference\":\"\",\"initialized\":true}},\"da5b1a03-275f-48ef-bde2-e4723819d960\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vngywf2yc@example.com}\",\"displayName\":\"zx7an48p27a5f8w\",\"originalName\":\"8nxcqofmkri4r23\",\"dateCreated\":\"2019-07-29T19:28:05.967Z\",\"backReference\":\"\",\"initialized\":true}},\"a196c5f5-116d-469d-98e3-909236dfddbd\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"umefdrxph@example.com}\",\"displayName\":\"bk1js2ptczth5zv\",\"originalName\":\"ahife2vfqpvs912\",\"dateCreated\":\"2019-07-29T19:28:38.936Z\",\"backReference\":\"\",\"initialized\":true}},\"96682146-99c3-4fc9-889e-c629396efc2c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"z3u7yw3nf@example.com}\",\"displayName\":\"t8em0ubewkt6568\",\"originalName\":\"2lvmcseq0ktqm5f\",\"dateCreated\":\"2019-07-29T19:29:09.888Z\",\"backReference\":\"\",\"initialized\":true}},\"9bdc0e2f-c515-447c-adf2-c5edab3f21d9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"e5eod0w38@example.com}\",\"displayName\":\"p59s94n4u98gpts\",\"originalName\":\"x0lmqgii1diczzu\",\"dateCreated\":\"2019-07-29T19:38:37.322Z\",\"backReference\":\"\",\"initialized\":true}},\"42b2fe4b-38ce-4458-85e5-9cd029883021\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"q50oldsc8@example.com}\",\"displayName\":\"i9igqfnlntjheyq\",\"originalName\":\"e9fsmgjpwz55mb8\",\"dateCreated\":\"2019-07-29T19:39:12.586Z\",\"backReference\":\"\",\"initialized\":true}},\"cb39cbb1-6ebe-4126-aaf0-77242cf0190b\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"zkm4y516t@example.com}\",\"displayName\":\"2tifw24fohfm48b\",\"originalName\":\"lbjzazcmbf86296\",\"dateCreated\":\"2019-07-29T19:54:53.525Z\",\"backReference\":\"\",\"initialized\":true}},\"5330bf2f-38b9-4c3a-8c81-a20482611164\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"0wp0i5rn7@example.com}\",\"displayName\":\"weaqlbb30pm3lli\",\"originalName\":\"blcxsgtgbhtiki1\",\"dateCreated\":\"2019-07-29T19:57:46.103Z\",\"backReference\":\"\",\"initialized\":true}},\"608bd0bb-dcdb-48ff-9102-b3578915413d\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"xbnh97q0y@example.com}\",\"displayName\":\"c3tjnlhr1xti1ed\",\"originalName\":\"m6ycka7jjannjkn\",\"dateCreated\":\"2019-07-29T19:58:16.618Z\",\"backReference\":\"\",\"initialized\":true}},\"e322598b-a96b-4c89-94d5-8b79dc846e3a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1qo8v28yq@example.com}\",\"displayName\":\"7s9hck7nsan2b1a\",\"originalName\":\"wjjf700yywmjdvy\",\"dateCreated\":\"2019-07-29T19:59:36.266Z\",\"backReference\":\"\",\"initialized\":true}},\"d7d08548-e6d0-4580-9eb6-1c794d7cb74c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"516rxxem9@example.com}\",\"displayName\":\"qqrnvyuioandjah\",\"originalName\":\"l313qaekoy3jcly\",\"dateCreated\":\"2019-07-29T22:36:10.079Z\",\"backReference\":\"\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "80da598f-8c45-4297-be79-6480eb3d1d48",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":8998,\"referenceSequenceNumber\":-1,\"sequenceNumber\":9000,\"timestamp\":1564504146734,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":998,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"3e1d4dec-e660-4522-ba47-b3640d08629d\",{\"client\":{\"user\":{\"id\":\"stviqaznx@example.com}\",\"name\":\"nz7p6g638247qcz\",\"email\":\"idr3wqzwt@example.com}\"}},\"sequenceNumber\":383}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":329,\"refSeqNumber\":998}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":9,\"chunkLengthChars\":333,\"totalLengthChars\":333,\"totalSegmentCount\":9,\"chunkSequenceNumber\":998,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},\"0xmmnaovec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlufpyo\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":998,\"totalLength\":333,\"totalSegmentCount\":9}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":616,\"contents\":{\"pos1\":329,\"pos2\":330,\"type\":1},\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1564948322676,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":616,\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1564948322676,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1998,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"3e1d4dec-e660-4522-ba47-b3640d08629d\",{\"client\":{\"user\":{\"id\":\"stviqaznx@example.com}\",\"name\":\"nz7p6g638247qcz\",\"email\":\"idr3wqzwt@example.com}\"}},\"sequenceNumber\":383}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":553,\"refSeqNumber\":1997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":9,\"chunkLengthChars\":555,\"totalLengthChars\":555,\"totalSegmentCount\":9,\"chunkSequenceNumber\":1998,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},\"0xmmnaovec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1998,\"totalLength\":555,\"totalSegmentCount\":9}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":1615,\"contents\":{\"pos1\":552,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1998,\"referenceSequenceNumber\":1998,\"sequenceNumber\":1999,\"timestamp\":1564948441986,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":1616,\"minimumSequenceNumber\":1998,\"referenceSequenceNumber\":1998,\"sequenceNumber\":2000,\"timestamp\":1564948441986,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2999,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"3e1d4dec-e660-4522-ba47-b3640d08629d\",{\"client\":{\"user\":{\"id\":\"stviqaznx@example.com}\",\"name\":\"nz7p6g638247qcz\",\"email\":\"idr3wqzwt@example.com}\"}},\"sequenceNumber\":383}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":897,\"refSeqNumber\":2996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":18,\"chunkLengthChars\":901,\"totalLengthChars\":901,\"totalSegmentCount\":18,\"chunkSequenceNumber\":2999,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},{\"text\":\"0xmmnao\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwlpo0zri9nez0saelu4km07g9l\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\",\"display\":\"inline-block\"}}},\"ikzliy341r2detdov44p3w3dukwgnnl5kk6yi1smefgz8amaj0wzbr8827o59pgpfx00dfthwa5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4b3e4a28-546f-4817-8254-733645439358\",\"display\":\"inline-block\"}}},\"l2nh7qvgp9534j4l9szxhwu66c4pa7fik4f4tybp2te9ga1y1qs8d4f8ljipc23t54ee0ut4r56fysfywahasupwqk20tx2gbw9nubwaa8oyc0w2m0g5sdn372rzpn8y4kkrf0vkkm2ejz69py24rp4leb5p0l93bkoev3dp4tnmlcr5l9hrx7h8kp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"text\":\"6oy8k5w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"3tmv0w67mx1x0e5i948yaediuwqb3wit78lkux9ycuapii5of\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f9ddea32-3acc-4d69-ac32-815f3c8a65e0\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d8dd1f3-6294-4da2-a8d1-63dd030314fd\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2999,\"totalLength\":901,\"totalSegmentCount\":18}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":2616,\"contents\":{\"pos1\":897,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":2999,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1564948654779,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"hjglmr0b4@example.com}\",\"displayName\":\"bp0r1l6d6g4yiig\",\"originalName\":\"mky1pjtkxq5qf5m\",\"dateCreated\":\"2019-08-04T19:54:25.478Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"initialized\":true}},\"4b3e4a28-546f-4817-8254-733645439358\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1rn8app0x@example.com}\",\"displayName\":\"6xxo1juqsqvatx1\",\"originalName\":\"lm2uu45rw8lrsg7\",\"dateCreated\":\"2019-08-04T19:54:54.525Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":2616,\"minimumSequenceNumber\":2999,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1564948654779,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,890 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3999,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"3e1d4dec-e660-4522-ba47-b3640d08629d\",{\"client\":{\"user\":{\"id\":\"stviqaznx@example.com}\",\"name\":\"nz7p6g638247qcz\",\"email\":\"idr3wqzwt@example.com}\"}},\"sequenceNumber\":383}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1388,\"refSeqNumber\":3996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":44,\"chunkLengthChars\":1393,\"totalLengthChars\":1393,\"totalSegmentCount\":44,\"chunkSequenceNumber\":3999,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},{\"text\":\"0xmmnao\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwlpo0zri9nez0saelu4km07g9l\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\",\"display\":\"inline-block\"}}},\"ikzliy341r2detdov44p3w3dukwgnnl5kk6yi1smefgz8amaj0wzbr8827o59pgpfx00dfthwa5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4b3e4a28-546f-4817-8254-733645439358\",\"display\":\"inline-block\"}}},\"l2nh7qvgp9534j4l9szxhwu66c4pa7fik4f4tybp2te9ga1y1qs8d4f8ljipc23t54ee0ut4r56fysfywahasupwqk20tx2gbw9nubwaa8oyc0w2m0g5sdn372rzpn8y4kkrf0vkkm2ejz69py24rp4leb5p0l93bkoev3dp4tnmlcr5l9hrx7h8kp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"text\":\"6oy8k5w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"3tmv0w67mx1x0e5i948yaediuwqb3wit78lkux9ycuapii5of6hwskjptp0mscjzq1krkd0xd9zny0dh15ss7mmd1nsz4egmj72xvckvc2wqnrd25yo4xw0hwc0hafcteto9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0eba8896-5246-4044-9920-5882476e3578\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\",\"display\":\"inline-block\"}}},\"6c\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\",\"display\":\"inline-block\"}}},\"f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f9ddea32-3acc-4d69-ac32-815f3c8a65e0\",\"ItemType\":\"Paragraph\"}},{\"text\":\"pbxgk5y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"h\",{\"text\":\"kemdkxqny689mbarc0cj16cphdzjy39n43oye16uqr8hahoxodql5n31zh2sy24s70c6y35eerfvp4iugwnnsuaiz37jjm1ogk24zjazuh01bjqw7dq0al2nafg8blyky3iaelxc7uxmvcw32bffm3jlsed8bhwtqshrs0fpygvq2q9sbos4uvzsdob9vf45bk90qpp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\",\"display\":\"inline-block\"}}},{\"text\":\"e6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\",\"display\":\"inline-block\"}}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c86a820e-b85d-449f-9836-9c033a82e474\",\"ItemType\":\"Paragraph\"}},{\"text\":\"oym4bqa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"vjzkzdgkete85w3vmej48syt8hjl7i8cft3722k9txamcyawczc86oobi5xb5mtnidt74xmchtgf4p5ta4qy5v134djall408662b0qin40hstl2o5lrl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6a0d6696-a318-41eb-8164-2a7f13d6e8a0\",\"display\":\"inline-block\"}}},{\"text\":\"g6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\",\"display\":\"inline-block\"}}},{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9123b78a-bdb1-4eb0-a8be-fea617579eaa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"zrwp3n2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"2\",{\"text\":\"q8myag0m47jbh3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"a\",{\"text\":\"jxain1pxm9iq4i0twgx4r22h0s9c3lezf60w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e2f769a9-6dbd-431c-87f5-4b227c705b19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bd6259ae-53d2-446b-a21a-e193113d5ff4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d8dd1f3-6294-4da2-a8d1-63dd030314fd\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3999,\"totalLength\":1393,\"totalSegmentCount\":44}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":3616,\"contents\":{\"pos1\":1388,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3999,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1564949135548,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"hjglmr0b4@example.com}\",\"displayName\":\"bp0r1l6d6g4yiig\",\"originalName\":\"mky1pjtkxq5qf5m\",\"dateCreated\":\"2019-08-04T19:54:25.478Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"initialized\":true}},\"4b3e4a28-546f-4817-8254-733645439358\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1rn8app0x@example.com}\",\"displayName\":\"6xxo1juqsqvatx1\",\"originalName\":\"lm2uu45rw8lrsg7\",\"dateCreated\":\"2019-08-04T19:54:54.525Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"initialized\":true}},\"27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"r8pbx3bv8@example.com}\",\"displayName\":\"cyuzp0jnhol9uy5\",\"originalName\":\"jidv7u6docqe0hr\",\"dateCreated\":\"2019-08-04T20:01:56.743Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"0eba8896-5246-4044-9920-5882476e3578\",\"initialized\":true}},\"d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"pak7rc1i6@example.com}\",\"displayName\":\"luc5x6jbw8c2z7z\",\"originalName\":\"c56z4myczykt3hp\",\"dateCreated\":\"2019-08-04T20:02:01.516Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"initialized\":true}},\"d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"39rjtw1za@example.com}\",\"displayName\":\"rpvf7juh62rsn86\",\"originalName\":\"dmtruot17pwymxl\",\"dateCreated\":\"2019-08-04T20:03:04.332Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"initialized\":true}},\"4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"ktf7oa74w@example.com}\",\"displayName\":\"1vqrnczvwztjldw\",\"originalName\":\"kq427wpz9h27yw3\",\"dateCreated\":\"2019-08-04T20:03:13.277Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"initialized\":true}},\"6a0d6696-a318-41eb-8164-2a7f13d6e8a0\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vqt82neml@example.com}\",\"displayName\":\"gbifb3livptjkvc\",\"originalName\":\"i6xoughu3g45ahz\",\"dateCreated\":\"2019-08-04T20:04:21.605Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"initialized\":true}},\"1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dwwmrgnp0@example.com}\",\"displayName\":\"av9k76puoqsfnht\",\"originalName\":\"nu7b1zqc48qnigb\",\"dateCreated\":\"2019-08-04T20:04:24.66Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"3e1d4dec-e660-4522-ba47-b3640d08629d\",\"clientSequenceNumber\":3616,\"minimumSequenceNumber\":3999,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1564949135548,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,962 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4998,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"685663d8-b87b-4040-af13-ffc3d4d4b386\",{\"client\":{\"user\":{\"id\":\"pw98ivq10@example.com}\",\"name\":\"wbze5dae5jkjg5p\",\"email\":\"e9wzz8bj2@example.com}\"}},\"sequenceNumber\":4170}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"hjglmr0b4@example.com}\",\"displayName\":\"bp0r1l6d6g4yiig\",\"originalName\":\"mky1pjtkxq5qf5m\",\"dateCreated\":\"2019-08-04T19:54:25.478Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"initialized\":true}},\"4b3e4a28-546f-4817-8254-733645439358\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1rn8app0x@example.com}\",\"displayName\":\"6xxo1juqsqvatx1\",\"originalName\":\"lm2uu45rw8lrsg7\",\"dateCreated\":\"2019-08-04T19:54:54.525Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"initialized\":true}},\"27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"r8pbx3bv8@example.com}\",\"displayName\":\"cyuzp0jnhol9uy5\",\"originalName\":\"jidv7u6docqe0hr\",\"dateCreated\":\"2019-08-04T20:01:56.743Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"0eba8896-5246-4044-9920-5882476e3578\",\"initialized\":true}},\"d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"pak7rc1i6@example.com}\",\"displayName\":\"luc5x6jbw8c2z7z\",\"originalName\":\"c56z4myczykt3hp\",\"dateCreated\":\"2019-08-04T20:02:01.516Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"initialized\":true}},\"d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"39rjtw1za@example.com}\",\"displayName\":\"rpvf7juh62rsn86\",\"originalName\":\"dmtruot17pwymxl\",\"dateCreated\":\"2019-08-04T20:03:04.332Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"initialized\":true}},\"4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"ktf7oa74w@example.com}\",\"displayName\":\"1vqrnczvwztjldw\",\"originalName\":\"kq427wpz9h27yw3\",\"dateCreated\":\"2019-08-04T20:03:13.277Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"initialized\":true}},\"6a0d6696-a318-41eb-8164-2a7f13d6e8a0\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vqt82neml@example.com}\",\"displayName\":\"gbifb3livptjkvc\",\"originalName\":\"i6xoughu3g45ahz\",\"dateCreated\":\"2019-08-04T20:04:21.605Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"initialized\":true}},\"1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dwwmrgnp0@example.com}\",\"displayName\":\"av9k76puoqsfnht\",\"originalName\":\"nu7b1zqc48qnigb\",\"dateCreated\":\"2019-08-04T20:04:24.66Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"initialized\":true}},\"9a83b348-dd6f-4b89-a7e9-15c237b28881\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cvszp97q7@example.com}\",\"displayName\":\"lkuycb1d2oc9lcv\",\"originalName\":\"0hswjw5qvhdeqzn\",\"dateCreated\":\"2019-08-04T20:06:43.81Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"initialized\":true}},\"41108ff3-77cb-4c67-85ee-e891a8ea97fb\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"jnphkm3d1@example.com}\",\"displayName\":\"nusdu10x3kp00zi\",\"originalName\":\"h98nklorzvlbu2b\",\"dateCreated\":\"2019-08-04T20:06:48.236Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/10e771f0-a3f4-461e-9af8-9f3e58ef7c8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1461,\"refSeqNumber\":4164}},\"685663d8-b87b-4040-af13-ffc3d4d4b386\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":1858,\"pos\":1809,\"refSeqNumber\":4944}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":63,\"chunkLengthChars\":2041,\"totalLengthChars\":2041,\"totalSegmentCount\":63,\"chunkSequenceNumber\":4998,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},{\"text\":\"0xmmnao\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwlpo0zri9nez0saelu4km07g9l\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\",\"display\":\"inline-block\"}}},\"ikzliy341r2detdov44p3w3dukwgnnl5kk6yi1smefgz8amaj0wzbr8827o59pgpfx00dfthwa5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4b3e4a28-546f-4817-8254-733645439358\",\"display\":\"inline-block\"}}},\"l2nh7qvgp9534j4l9szxhwu66c4pa7fik4f4tybp2te9ga1y1qs8d4f8ljipc23t54ee0ut4r56fysfywahasupwqk20tx2gbw9nubwaa8oyc0w2m0g5sdn372rzpn8y4kkrf0vkkm2ejz69py24rp4leb5p0l93bkoev3dp4tnmlcr5l9hrx7h8kp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"text\":\"6oy8k5w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"3tmv0w67mx1x0e5i948yaediuwqb3wit78lkux9ycuapii5of6hwskjptp0mscjzq1krkd0xd9zny0dh15ss7mmd1nsz4egmj72xvckvc2wqnrd25yo4xw0hwc0hafcteto9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0eba8896-5246-4044-9920-5882476e3578\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\",\"display\":\"inline-block\"}}},\"6c\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\",\"display\":\"inline-block\"}}},\"f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f9ddea32-3acc-4d69-ac32-815f3c8a65e0\",\"ItemType\":\"Paragraph\"}},{\"text\":\"pbxgk5y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"h\",{\"text\":\"kemdkxqny689mbarc0cj16cphdzjy39n43oye16uqr8hahoxodql5n31zh2sy24s70c6y35eerfvp4iugwnnsuaiz37jjm1ogk24zjazuh01bjqw7dq0al2nafg8blyky3iaelxc7uxmvcw32bffm3jlsed8bhwtqshrs0fpygvq2q9sbos4uvzsdob9vf45bk90qpp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\",\"display\":\"inline-block\"}}},{\"text\":\"e6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\",\"display\":\"inline-block\"}}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c86a820e-b85d-449f-9836-9c033a82e474\",\"ItemType\":\"Paragraph\"}},{\"text\":\"oym4bqa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"vjzkzdgkete85w3vmej48syt8hjl7i8cft3722k9txamcyawczc86oobi5xb5mtnidt74xmchtgf4p5ta4qy5v134djall408662b0qin40hstl2o5lrl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6a0d6696-a318-41eb-8164-2a7f13d6e8a0\",\"display\":\"inline-block\"}}},{\"text\":\"g6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\",\"display\":\"inline-block\"}}},{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9123b78a-bdb1-4eb0-a8be-fea617579eaa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"zrwp3n2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"2\",{\"text\":\"q8myag0m47jbh3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"a\",{\"text\":\"jxain1pxm9iq4i0twgx4r22h0s9c3lezf60wr3i4j23rislkzbse4yfi2lwb7mzy3tzqts1v9kfp7xduav0a2h23c66igc777n7cm3u3gjs9xco0o2ty2hr1a1u51odudutr0pbt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9a83b348-dd6f-4b89-a7e9-15c237b28881\",\"display\":\"inline-block\"}}},{\"text\":\"6a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/41108ff3-77cb-4c67-85ee-e891a8ea97fb\",\"display\":\"inline-block\"}}},{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e2f769a9-6dbd-431c-87f5-4b227c705b19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9b613b88-6f1a-4671-9431-269130b9139a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78685b7e-785f-49bf-a59c-d03555f7f3e9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f8fd63f-2d32-4ff3-b291-ec5cdd1687ec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"pjiziasu5koqey9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cad94923-3875-4f8c-94f0-ca631e904af4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"klpxi15ncneramm4squ31eerye12nb9gt8kjeimcsa58edqr36icxacqfx04u06qjk0l1hhw7r5pxrw03sjsrleii5zcsfn6narc\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"045b450b-1e17-4230-b640-1f10c2875c91\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"text\":\"gd8fgjiq7nuybxyw5mutdj7qyv0lbh5measw9pwfyx66v2ny83dvycdmbncurigq5rf3ynw1ld1l6p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dc7ee428-3069-483b-8f22-53a5cdfc70e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-128\"}}},\"rehn923stm3gw8\",{\"text\":\"m9rlewyzhu69c6qlivxk6694olqw9ylntewckc4g9yf2t363vum2q58pfqzy3gfm98k369uaywd415chx0r2j8y2ph05utkewrfsp7qy5dmc3c6p0bu2eam4r6q1tnr26as7ktrlar22cdy37yg1wv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"436ec42f-441c-4fb9-ae41-a0ef3c8b9473\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5dbdc386-05ca-41a6-92e3-d25f2d562c43\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"l8rzak7afreis77ng3p0wjoq4qs6we28f1998bp08xhgtccvss3palnxgzw73ae68qxxe9k09ddt98pq8by0gvugg7ia77ji7ewv326hdbk6xpomytymbq59hof318eekpnj7dtpcspd9qbxmspaftar4wql3zjutznpi51bz27ju8ag\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6713b09-2fd2-4668-89e1-2d54c17c0e3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bd6259ae-53d2-446b-a21a-e193113d5ff4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d8dd1f3-6294-4da2-a8d1-63dd030314fd\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4998,\"totalLength\":2041,\"totalSegmentCount\":63}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "10e771f0-a3f4-461e-9af8-9f3e58ef7c8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList54\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/76321120-80f5-44be-9cec-cf2128f8316f\"}},\"listRegistryList-128\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bc078b3b-4764-4569-accf-a09475490b82\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "76321120-80f5-44be-9cec-cf2128f8316f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList54\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc078b3b-4764-4569-accf-a09475490b82",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-128\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"685663d8-b87b-4040-af13-ffc3d4d4b386\",\"clientSequenceNumber\":830,\"minimumSequenceNumber\":4998,\"referenceSequenceNumber\":4998,\"sequenceNumber\":5000,\"timestamp\":1564949387364,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,971 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5998,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"685663d8-b87b-4040-af13-ffc3d4d4b386\",{\"client\":{\"user\":{\"id\":\"pw98ivq10@example.com}\",\"name\":\"wbze5dae5jkjg5p\",\"email\":\"e9wzz8bj2@example.com}\"}},\"sequenceNumber\":4170}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/10e771f0-a3f4-461e-9af8-9f3e58ef7c8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1461,\"refSeqNumber\":4164}},\"685663d8-b87b-4040-af13-ffc3d4d4b386\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2144,\"refSeqNumber\":5997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":65,\"chunkLengthChars\":2148,\"totalLengthChars\":2148,\"totalSegmentCount\":65,\"chunkSequenceNumber\":5998,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},{\"text\":\"0xmmnao\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwlpo0zri9nez0saelu4km07g9l\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\",\"display\":\"inline-block\"}}},\"ikzliy341r2detdov44p3w3dukwgnnl5kk6yi1smefgz8amaj0wzbr8827o59pgpfx00dfthwa5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4b3e4a28-546f-4817-8254-733645439358\",\"display\":\"inline-block\"}}},\"l2nh7qvgp9534j4l9szxhwu66c4pa7fik4f4tybp2te9ga1y1qs8d4f8ljipc23t54ee0ut4r56fysfywahasupwqk20tx2gbw9nubwaa8oyc0w2m0g5sdn372rzpn8y4kkrf0vkkm2ejz69py24rp4leb5p0l93bkoev3dp4tnmlcr5l9hrx7h8kp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"text\":\"6oy8k5w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"3tmv0w67mx1x0e5i948yaediuwqb3wit78lkux9ycuapii5of6hwskjptp0mscjzq1krkd0xd9zny0dh15ss7mmd1nsz4egmj72xvckvc2wqnrd25yo4xw0hwc0hafcteto9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0eba8896-5246-4044-9920-5882476e3578\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\",\"display\":\"inline-block\"}}},\"6c\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\",\"display\":\"inline-block\"}}},\"f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f9ddea32-3acc-4d69-ac32-815f3c8a65e0\",\"ItemType\":\"Paragraph\"}},{\"text\":\"pbxgk5y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"h\",{\"text\":\"kemdkxqny689mbarc0cj16cphdzjy39n43oye16uqr8hahoxodql5n31zh2sy24s70c6y35eerfvp4iugwnnsuaiz37jjm1ogk24zjazuh01bjqw7dq0al2nafg8blyky3iaelxc7uxmvcw32bffm3jlsed8bhwtqshrs0fpygvq2q9sbos4uvzsdob9vf45bk90qpp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\",\"display\":\"inline-block\"}}},{\"text\":\"e6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\",\"display\":\"inline-block\"}}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c86a820e-b85d-449f-9836-9c033a82e474\",\"ItemType\":\"Paragraph\"}},{\"text\":\"oym4bqa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"vjzkzdgkete85w3vmej48syt8hjl7i8cft3722k9txamcyawczc86oobi5xb5mtnidt74xmchtgf4p5ta4qy5v134djall408662b0qin40hstl2o5lrl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6a0d6696-a318-41eb-8164-2a7f13d6e8a0\",\"display\":\"inline-block\"}}},{\"text\":\"g6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\",\"display\":\"inline-block\"}}},{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9123b78a-bdb1-4eb0-a8be-fea617579eaa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"zrwp3n2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"2\",{\"text\":\"q8myag0m47jbh3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"a\",{\"text\":\"jxain1pxm9iq4i0twgx4r22h0s9c3lezf60wr3i4j23rislkzbse4yfi2lwb7mzy3tzqts1v9kfp7xduav0a2h23c66igc777n7cm3u3gjs9xco0o2ty2hr1a1u51odudutr0pbt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9a83b348-dd6f-4b89-a7e9-15c237b28881\",\"display\":\"inline-block\"}}},{\"text\":\"6a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/41108ff3-77cb-4c67-85ee-e891a8ea97fb\",\"display\":\"inline-block\"}}},{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e2f769a9-6dbd-431c-87f5-4b227c705b19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9b613b88-6f1a-4671-9431-269130b9139a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78685b7e-785f-49bf-a59c-d03555f7f3e9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f8fd63f-2d32-4ff3-b291-ec5cdd1687ec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"pjiziasu5koqey9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cad94923-3875-4f8c-94f0-ca631e904af4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"klpxi15ncneramm4squ31eerye12nb9gt8kjeimcsa58edqr36icxacqfx04u06qjk0l1hhw7r5pxrw03sjsrleii5zcsfn6narc\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"045b450b-1e17-4230-b640-1f10c2875c91\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"text\":\"gd8fgjiq7nuybxyw5mutdj7qyv0lbh5measw9pwfyx66v2ny83dvycdmbncurigq5rf3ynw1ld1l6p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dc7ee428-3069-483b-8f22-53a5cdfc70e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-128\"}}},\"rehn923stm3gw8\",{\"text\":\"m9rlewyzhu69c6qlivxk6694ohw22rzspxsr02jji140w9jlsk46nuhr9pqxcmsc4krhbx8t9je7l2nfje9jbxuqtf79a0bx964sp51d7echwv88au8q4yeqzwfkz3agjnuyeyx6f4d45o7zklcgjyzj31q0dj530hv21cdaymc7sk3yl0ojz0t6wjfzmk084161d1s9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caa46aae-5d1b-42c4-9abb-232080f79d91\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"text\":\"l8rzak7afreis77ng3p0wjoq4qs6we28f1998bp08xhgtccvss3palnxgzw73ae68qxxe9k09ddt98pq8by0gvugg7ia77ji7ewv326hdbk6xpomytymbq59hof318eekpnj7dtpcspd9qbxmspaftar4wql3zjutznpi51bz27ju8ag\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6713b09-2fd2-4668-89e1-2d54c17c0e3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-128\"}}},\"1n7va8y6n3r9y5re1\",{\"text\":\"kuiyhe6shzogl0emgdbykwhcl6bfemr8p7db3tx3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6ff47508-5d4e-49ef-9f4a-2993e774d2e1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\",\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bd6259ae-53d2-446b-a21a-e193113d5ff4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d8dd1f3-6294-4da2-a8d1-63dd030314fd\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5998,\"totalLength\":2148,\"totalSegmentCount\":65}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"685663d8-b87b-4040-af13-ffc3d4d4b386\",\"clientSequenceNumber\":1829,\"contents\":{\"pos1\":2143,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5998,\"referenceSequenceNumber\":5998,\"sequenceNumber\":5999,\"timestamp\":1564949503149,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "10e771f0-a3f4-461e-9af8-9f3e58ef7c8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList54\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/76321120-80f5-44be-9cec-cf2128f8316f\"}},\"listRegistryList-128\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bc078b3b-4764-4569-accf-a09475490b82\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "76321120-80f5-44be-9cec-cf2128f8316f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList54\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc078b3b-4764-4569-accf-a09475490b82",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-128\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"hjglmr0b4@example.com}\",\"displayName\":\"bp0r1l6d6g4yiig\",\"originalName\":\"mky1pjtkxq5qf5m\",\"dateCreated\":\"2019-08-04T19:54:25.478Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"initialized\":true}},\"4b3e4a28-546f-4817-8254-733645439358\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1rn8app0x@example.com}\",\"displayName\":\"6xxo1juqsqvatx1\",\"originalName\":\"lm2uu45rw8lrsg7\",\"dateCreated\":\"2019-08-04T19:54:54.525Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"initialized\":true}},\"27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"r8pbx3bv8@example.com}\",\"displayName\":\"cyuzp0jnhol9uy5\",\"originalName\":\"jidv7u6docqe0hr\",\"dateCreated\":\"2019-08-04T20:01:56.743Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"0eba8896-5246-4044-9920-5882476e3578\",\"initialized\":true}},\"d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"pak7rc1i6@example.com}\",\"displayName\":\"luc5x6jbw8c2z7z\",\"originalName\":\"c56z4myczykt3hp\",\"dateCreated\":\"2019-08-04T20:02:01.516Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"initialized\":true}},\"d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"39rjtw1za@example.com}\",\"displayName\":\"rpvf7juh62rsn86\",\"originalName\":\"dmtruot17pwymxl\",\"dateCreated\":\"2019-08-04T20:03:04.332Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"initialized\":true}},\"4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"ktf7oa74w@example.com}\",\"displayName\":\"1vqrnczvwztjldw\",\"originalName\":\"kq427wpz9h27yw3\",\"dateCreated\":\"2019-08-04T20:03:13.277Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"initialized\":true}},\"6a0d6696-a318-41eb-8164-2a7f13d6e8a0\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vqt82neml@example.com}\",\"displayName\":\"gbifb3livptjkvc\",\"originalName\":\"i6xoughu3g45ahz\",\"dateCreated\":\"2019-08-04T20:04:21.605Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"initialized\":true}},\"1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dwwmrgnp0@example.com}\",\"displayName\":\"av9k76puoqsfnht\",\"originalName\":\"nu7b1zqc48qnigb\",\"dateCreated\":\"2019-08-04T20:04:24.66Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"initialized\":true}},\"9a83b348-dd6f-4b89-a7e9-15c237b28881\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cvszp97q7@example.com}\",\"displayName\":\"lkuycb1d2oc9lcv\",\"originalName\":\"0hswjw5qvhdeqzn\",\"dateCreated\":\"2019-08-04T20:06:43.81Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"initialized\":true}},\"41108ff3-77cb-4c67-85ee-e891a8ea97fb\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"jnphkm3d1@example.com}\",\"displayName\":\"nusdu10x3kp00zi\",\"originalName\":\"h98nklorzvlbu2b\",\"dateCreated\":\"2019-08-04T20:06:48.236Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"initialized\":true}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"685663d8-b87b-4040-af13-ffc3d4d4b386\",\"clientSequenceNumber\":1830,\"minimumSequenceNumber\":5998,\"referenceSequenceNumber\":5998,\"sequenceNumber\":6000,\"timestamp\":1564949503149,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_6984_0.json
+++ b/snapshotTestContent/HotBugs7/src_snapshots/0.59.3000/snapshot_6984_0.json
@@ -1,0 +1,962 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6982,\"sequenceNumber\":6984,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"23d73088-4557-4caa-a869-27a51ff71124\",{\"client\":{\"user\":{\"id\":\"yqs2alj8z@example.com}\",\"name\":\"oeo7h7ogsygnshc\",\"email\":\"5c2y67tsl@example.com}\"}},\"sequenceNumber\":6978}],[\"b57f8259-e75f-476f-a056-31f9527d3add\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"mtt8f7kxj@example.com}\",\"name\":\"lqzc0hk0jpol1mc\",\"email\":\"r794ck02t@example.com}\"}},\"sequenceNumber\":6984}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/03994935-e9dd-475c-8d76-69a6b557867d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03994935-e9dd-475c-8d76-69a6b557867d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}},\"versions\":[{\"sequenceNumber\":66,\"value\":{\"type\":\"Plain\",\"value\":\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b594397-32da-4d3a-836f-5bc81fed9c4a\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eca95811-992e-48b4-93cb-98b436024565\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/841b85cd-4e70-49b1-b15c-d3f345adf4dc\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4e84853a-8f5d-4f69-9955-81bdaa6d11d9\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/10e771f0-a3f4-461e-9af8-9f3e58ef7c8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b594397-32da-4d3a-836f-5bc81fed9c4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"cf045b0e-767a-421d-9e5c-01a590d67668\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"d2a8a3c3-d2ba-48ed-9837-8ea330cf2c33\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":127,\"refSeqNumber\":378}},\"3e1d4dec-e660-4522-ba47-b3640d08629d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1461,\"refSeqNumber\":4164}},\"685663d8-b87b-4040-af13-ffc3d4d4b386\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1781,\"refSeqNumber\":6829}},\"ec9b2ccf-b178-4d32-a47c-43c493ffc489\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1781,\"refSeqNumber\":6886}},\"9439dc2a-e452-40aa-a0e2-9550f332614a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6894}},\"7b7ee702-c67b-488f-99ad-db277bd0f1d3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1597,\"refSeqNumber\":6926}},\"a68ed7a5-2883-44f0-a919-7521bc7f96ad\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6934}},\"e3d53679-cec2-425f-af75-39a4aa66ae8e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6934}},\"5fb7ba88-ea8b-4f69-9413-7d61bc360b89\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1598,\"refSeqNumber\":6951}},\"696e6622-2ae6-47d5-b2df-7cf9c650ab1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6964}},\"23d73088-4557-4caa-a869-27a51ff71124\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6975}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eca95811-992e-48b4-93cb-98b436024565",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "841b85cd-4e70-49b1-b15c-d3f345adf4dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":107,\"chunkLengthChars\":3318,\"totalLengthChars\":3318,\"totalSegmentCount\":107,\"chunkSequenceNumber\":6982,\"segmentTexts\":[{\"text\":\"uqzf2a9sevrhorcy5ve9u3n7f1q4lshg7g18n6xo2rpga8\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c81bc2ca-91aa-4f05-911d-8df5b340a27b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"dsap6hf8yoclb7rhrcguadqey63zpfa2eeb8bacr6t9teakvi8nxjawywn4f8s4g2bwn61oo5zoz4d19lo554c5z1vtsxaxc7av2mjlxm7qy7ca8xbfkn7eyyygcvp0jcm8l75ahe54u59oc7zvaxvkzeyrlb7g3fqqb5zn9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"492e81da-aef5-46cb-8d3d-bab08392e890\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d804d913-0041-4906-8c3f-a77c27f3fb60\",\"ItemType\":\"Paragraph\"}},{\"text\":\"0xmmnao\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vec0drn4nvadkd0m1s48dhbtjon5z0i3onhxn6pof3m1ipdkbt46vk3kuomirl5p1srquzat5luq22vd1otluny35ti8l76wlpbmlazrf7pr5i1or790lwin69832aalnl3cj20h1ztx7s0wxiqp6ni05ipesl5bbfhb5ykp2ki7mc3nqzo5308i8hjp9yz5ceezti6umpg15kbupwz6r0sig71ftjzn57t32pv6m5cr5o3xhcurmx3uq9b3odw1f625tull768rcaxvluz91fpwjapryc0c8r2164pzwwcs7zwoy9bu9aso76e9ukvewj1hshwlpo0zri9nez0saelu4km07g9l\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\",\"display\":\"inline-block\"}}},\"ikzliy341r2detdov44p3w3dukwgnnl5kk6yi1smefgz8amaj0wzbr8827o59pgpfx00dfthwa5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4b3e4a28-546f-4817-8254-733645439358\",\"display\":\"inline-block\"}}},\"l2nh7qvgp9534j4l9szxhwu66c4pa7fik4f4tybp2te9ga1y1qs8d4f8ljipc23t54ee0ut4r56fysfywahasupwqk20tx2gbw9nubwaa8oyc0w2m0g5sdn372rzpn8y4kkrf0vkkm2ejz69py24rp4leb5p0l93bkoev3dp4tnmlcr5l9hrx7h8kp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3a67fc02-1d3c-41d9-8b26-fd22896e2e83\",\"ItemType\":\"Paragraph\"}},{\"text\":\"6oy8k5w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"3tmv0w67mx1x0e5i948yaediuwqb3wit78lkux9ycuapii5of6hwskjptp0mscjzq1krkd0xd9zny0dh15ss7mmd1nsz4egmj72xvckvc2wqnrd25yo4xw0hwc0hafcteto9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"0eba8896-5246-4044-9920-5882476e3578\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\",\"display\":\"inline-block\"}}},\"6c\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\",\"display\":\"inline-block\"}}},\"f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f9ddea32-3acc-4d69-ac32-815f3c8a65e0\",\"ItemType\":\"Paragraph\"}},{\"text\":\"pbxgk5y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"h\",{\"text\":\"kemdkxqny689mbarc0cj16cphdzjy39n43oye16uqr8hahoxodql5n31zh2sy24s70c6y35eerfvp4iugwnnsuaiz37jjm1ogk24zjazuh01bjqw7dq0al2nafg8blyky3iaelxc7uxmvcw32bffm3jlsed8bhwtqshrs0fpygvq2q9sbos4uvzsdob9vf45bk90qpp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\",\"display\":\"inline-block\"}}},{\"text\":\"e6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\",\"display\":\"inline-block\"}}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c86a820e-b85d-449f-9836-9c033a82e474\",\"ItemType\":\"Paragraph\"}},{\"text\":\"oym4bqa\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"vjzkzdgkete85w3vmej48syt8hjl7i8cft3722k9txamcyawczc86oobi5xb5mtnidt74xmchtgf4p5ta4qy5v134djall408662b0qin40hstl2o5lrl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/6a0d6696-a318-41eb-8164-2a7f13d6e8a0\",\"display\":\"inline-block\"}}},{\"text\":\"g6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\",\"display\":\"inline-block\"}}},{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9123b78a-bdb1-4eb0-a8be-fea617579eaa\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"zrwp3n2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"2\",{\"text\":\"q8myag0m47jbh3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"a\",{\"text\":\"jxain1pxm9iq4i0twgx4r22h0s9c3lezf60wr3i4j23rislkzbse4yfi2lwb7mzy3tzqts1v9kfp7xduav0a2h23c66igc777n7cm3u3gjs9xco0o2ty2hr1a1u51odudutr0pbt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/9a83b348-dd6f-4b89-a7e9-15c237b28881\",\"display\":\"inline-block\"}}},{\"text\":\"6a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/41108ff3-77cb-4c67-85ee-e891a8ea97fb\",\"display\":\"inline-block\"}}},{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e2f769a9-6dbd-431c-87f5-4b227c705b19\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"oghihwup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"rzyxzfapp5exfqfz2fv38vpqon4stv8nv3jby7kbgob9gtwxbazqlc72bo664jf5q0vbe27jzmhssrmusnbs2oh9ju8ok\",{\"text\":\"2f\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3583643a-bcf8-453d-914f-6fe9a4d4c545\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/160419be-de40-426c-a8f3-4710a3a5ad45\",\"display\":\"inline-block\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"07f63a49-7397-48e5-be28-ee179137d43b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"052jxx9pm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"haxn6bmwtdpvcdrt90zi0qyphk1y7et11tyenvkhkg73q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6eebe519-c785-4b91-b413-21918d15cd8a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"e0ye0k9q3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"p6p85yjw5stmexs3mdwhjltk6wlg6e9wjbpvde94vyveubj7137v151wjg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3d0b5e-a497-4c91-b1e1-042cd18ad2b4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"612ihegw2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"5p0dwjcoj7pnfln8ka29wkwikahaenbpudhje2xincjr0frnf11q\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d060caf2-fe30-4b74-aceb-4385e5fd3201\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"0dl88zhfq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"e1qftykdlc3x5m43ucn75s7iztdq3c2zq2fb14yyciwi8l9jcavoqv21oou1z2gff3qn7kl32a8p0xq84bytwtr8nxuxomym9xmcjm7bujeanddpfu04mbis1dz4lmllq4jwdb5b9o9b1shig6fo6vbzc04vdy4r66q0lq2mtqobqr6yezx2u6lakyjhjnfr5jt2\",{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"3c6ea57f-85e8-41f8-aa48-1fa951031c32\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d85d902a-53ba-4a6f-a5d4-aab9e11eb1e9\",\"display\":\"inline-block\"}}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98cdc66c-bd12-484a-9428-d89acc8eb867\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"ofsk68wn0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"vdsn3heig4yt71b8orqykk8w8bz2xf689k1tyjb1xbg21lptl5hhamynbaoi17\",{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"1aa286c4-6d42-4862-ab4d-5b6cbe556b04\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/d1803fa9-895b-465c-afa8-878f8fa29751\",\"display\":\"inline-block\"}}},{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4582879f-7a29-4451-a825-c31375b0613d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"e90oum5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"1f9ft39hvmwi87slg9uipn5k08q55843jujxwlgdra3qmmpdhffv8m0jca023vs0bmj39gqmypivlpe4oult2m71leuitx5cjjcqgdmbyksur4ej2b5g21gou0ufnrlwlst5gcgy2rw1fdpkfz9qjsgiu47ipm8jsvfobcjdp124licuj9thizpy3psj\",{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"4aebc3bd-8837-4790-a6e1-65de157b3251\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/bbfd8610-2196-4afc-b6fc-65d203f89d6a\",\"display\":\"inline-block\"}}},{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"31a8429f-3d79-48a4-83c2-321629e0371e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"hq76zvx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"0toa9kjwd3ctvk38ug1upunvuvv3mj0czpyn6zg9brhuv724616nfrml0vwgjiabxn4mko3s0zplopkifz8furycj4hvil1g61rfry7qdzjuu4i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"73b21c60-fbcb-4a9c-9690-44e80653bf4b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"d98wy4u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"2ldl9ukvd8398aek0mcwm19mxqg2qkb7dwp6sm8rtbzgu60x9cbfenwwubynflacnohxgejreoy5m1vt6wvmqojqk64v3iedxqjgg\",{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Symbol\"],\"markerId\":\"748cb271-c6fe-4cb5-9e26-e6ce0b8f7125\",\"ItemType\":\"PragueComponent\",\"Properties\":{\"componentUrl\":\"/atMentions/b2d83e74-be77-4228-961f-dfe91663b0a8\",\"display\":\"inline-block\"}}},{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9b613b88-6f1a-4671-9431-269130b9139a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78685b7e-785f-49bf-a59c-d03555f7f3e9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f8fd63f-2d32-4ff3-b291-ec5cdd1687ec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"text\":\"pjiziasu5koqey9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cad94923-3875-4f8c-94f0-ca631e904af4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"isRtl\":false}}},{\"text\":\"klpxi15ncneramm4squ31eerye12nb9gt8kjeimcsa58edqr36icxacqfx04u06qjk0l1hhw7r5pxrw03sjsrleii5zcsfn6narc\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"045b450b-1e17-4230-b640-1f10c2875c91\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"text\":\"gd8fgjiq7nuybxyw5mutdj7qyv0lbh5measw9pwfyx66v2ny83dvycdmbncurigq5rf3ynw1ld1l6p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dc7ee428-3069-483b-8f22-53a5cdfc70e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-128\"}}},\"rehn923stm3gw8\",{\"text\":\"m9rlewyzhu69c6qlivxk6694ohw22rzspxsr02jji140w9jlsk46nuhr9pqxcmsc4krhbx8t9je7l2nfje9jbxuqtf79a0bx964sp51d7echwv88au8q4yeqzwfkz3agjnuyeyx6f4d45o7zklcgjyzj31q0dj530hv21cdaymc7sk3yl0ojz0t6wjfzmk084161d1s9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caa46aae-5d1b-42c4-9abb-232080f79d91\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\"}}},{\"text\":\"l8rzak7afreis77ng3p0wjoq4qs6we28f1998bp08xhgtccvss3palnxgzw73ae68qxxe9k09ddt98pq8by0gvugg7ia77ji7ewv326hdbk6xpomytymbq59hof318eekpnj7dtpcspd9qbxmspaftar4wql3zjutznpi51bz27ju8ag\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6713b09-2fd2-4668-89e1-2d54c17c0e3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-128\"}}},\"1n7va8y6n3r9y5re1\",{\"text\":\"kuiyhe6shzogl0emgdbykwhcl6bfemr8p7db3tx3bzeh3vugjtxp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"l\",{\"text\":\"c70kykte6rngjx9rigafajt65dmxyi2gvqm1e6mkclroo4z4fpj19j79og6vrirfsj03uxkozu0nwq5bfjpzczjifko3ogwi39lg9j1tq100ntaub52xlazngzin58f6n2h4ab7vxrbhwasg6615wytq2u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6ff47508-5d4e-49ef-9f4a-2993e774d2e1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-128\",\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bd6259ae-53d2-446b-a21a-e193113d5ff4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d8dd1f3-6294-4da2-a8d1-63dd030314fd\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"33aa14c7-98c2-48b5-99d9-f871322b7144\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efc00fcf-b2d0-45e4-974d-9542351317cd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6982,\"totalLength\":3318,\"totalSegmentCount\":107}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "835ff19a-9d5c-48c3-b1b7-1a135e6d9a20",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/55089d02-7c07-4e23-8f5b-dc329716d24b\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/633ac078-4614-4381-bbc2-df02318596d4\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa66de94-27d7-4f24-9341-e1af2c581412\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e1538879-2d0f-4e13-b3c1-d39d9f346aca\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85dd6e7e-a3d8-4cf3-832c-239a28553244\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1a0b283f-a30c-4a2b-bfe4-db49f83357f7\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/40e16060-c0b4-4eec-9cf5-cbe83a781a5b\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "55089d02-7c07-4e23-8f5b-dc329716d24b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "633ac078-4614-4381-bbc2-df02318596d4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa66de94-27d7-4f24-9341-e1af2c581412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e1538879-2d0f-4e13-b3c1-d39d9f346aca",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85dd6e7e-a3d8-4cf3-832c-239a28553244",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1a0b283f-a30c-4a2b-bfe4-db49f83357f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "40e16060-c0b4-4eec-9cf5-cbe83a781a5b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4e84853a-8f5d-4f69-9955-81bdaa6d11d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b38ee8d8-6844-43be-8d93-8dc9bc5e9095\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64282f82-43b0-4769-9714-7bb272dc32bd\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e53791b5-d454-47b1-9dc6-c69708d00a51\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fc5786f2-3dd1-4a8e-bf74-e23ca418fa53\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/313ed8fa-e871-4d08-ba9e-7c5354d8a2e2\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6c5d5680-6144-4fdb-8dd9-5f5a949c9143\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ce8e05b8-448c-4ec3-bdc8-80f5ab058cc8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b38ee8d8-6844-43be-8d93-8dc9bc5e9095",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64282f82-43b0-4769-9714-7bb272dc32bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e53791b5-d454-47b1-9dc6-c69708d00a51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fc5786f2-3dd1-4a8e-bf74-e23ca418fa53",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "313ed8fa-e871-4d08-ba9e-7c5354d8a2e2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6c5d5680-6144-4fdb-8dd9-5f5a949c9143",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "10e771f0-a3f4-461e-9af8-9f3e58ef7c8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList54\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/76321120-80f5-44be-9cec-cf2128f8316f\"}},\"listRegistryList-128\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/bc078b3b-4764-4569-accf-a09475490b82\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "76321120-80f5-44be-9cec-cf2128f8316f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList54\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc078b3b-4764-4569-accf-a09475490b82",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-128\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"9c60dcd6-a7a7-4a9d-8e06-1ba6c35b5232\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"hjglmr0b4@example.com}\",\"displayName\":\"bp0r1l6d6g4yiig\",\"originalName\":\"mky1pjtkxq5qf5m\",\"dateCreated\":\"2019-08-04T19:54:25.478Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ce4ecaf4-46de-42d8-b53f-a9d37f00705f\",\"initialized\":true}},\"4b3e4a28-546f-4817-8254-733645439358\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"1rn8app0x@example.com}\",\"displayName\":\"6xxo1juqsqvatx1\",\"originalName\":\"lm2uu45rw8lrsg7\",\"dateCreated\":\"2019-08-04T19:54:54.525Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"623c0cc7-252a-4533-85c6-556182f37bfb\",\"initialized\":true}},\"27ea7f3e-22f1-4ae4-9ab0-9f2cc984bbb8\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"r8pbx3bv8@example.com}\",\"displayName\":\"cyuzp0jnhol9uy5\",\"originalName\":\"jidv7u6docqe0hr\",\"dateCreated\":\"2019-08-04T20:01:56.743Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"0eba8896-5246-4044-9920-5882476e3578\",\"initialized\":true}},\"d1ab4bed-b507-4bb6-8b8f-79131c7d8e3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"pak7rc1i6@example.com}\",\"displayName\":\"luc5x6jbw8c2z7z\",\"originalName\":\"c56z4myczykt3hp\",\"dateCreated\":\"2019-08-04T20:02:01.516Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed98ee89-74a9-4b12-98e8-44651a539675\",\"initialized\":true}},\"d0dd1ed6-4622-46d6-b7ca-a0e60d18456a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"39rjtw1za@example.com}\",\"displayName\":\"rpvf7juh62rsn86\",\"originalName\":\"dmtruot17pwymxl\",\"dateCreated\":\"2019-08-04T20:03:04.332Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3eb7bb53-fae0-431a-a013-35c962ffc4d3\",\"initialized\":true}},\"4089ca8c-72eb-4d1c-8ec3-375d0176e1ad\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"ktf7oa74w@example.com}\",\"displayName\":\"1vqrnczvwztjldw\",\"originalName\":\"kq427wpz9h27yw3\",\"dateCreated\":\"2019-08-04T20:03:13.277Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"b85c62b3-0339-479f-8dbd-45dcd300fe86\",\"initialized\":true}},\"6a0d6696-a318-41eb-8164-2a7f13d6e8a0\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vqt82neml@example.com}\",\"displayName\":\"gbifb3livptjkvc\",\"originalName\":\"i6xoughu3g45ahz\",\"dateCreated\":\"2019-08-04T20:04:21.605Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"bc6e554d-352a-4b2b-b658-02e3defe5808\",\"initialized\":true}},\"1b68eb5b-20d3-47cd-9f7a-f9c675eb0f3c\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"dwwmrgnp0@example.com}\",\"displayName\":\"av9k76puoqsfnht\",\"originalName\":\"nu7b1zqc48qnigb\",\"dateCreated\":\"2019-08-04T20:04:24.66Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"6306855b-aa68-4a1e-9a56-276257fd6a0b\",\"initialized\":true}},\"9a83b348-dd6f-4b89-a7e9-15c237b28881\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"cvszp97q7@example.com}\",\"displayName\":\"lkuycb1d2oc9lcv\",\"originalName\":\"0hswjw5qvhdeqzn\",\"dateCreated\":\"2019-08-04T20:06:43.81Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"ed7280e6-2709-49c3-9a84-ba89d18b4534\",\"initialized\":true}},\"41108ff3-77cb-4c67-85ee-e891a8ea97fb\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"jnphkm3d1@example.com}\",\"displayName\":\"nusdu10x3kp00zi\",\"originalName\":\"h98nklorzvlbu2b\",\"dateCreated\":\"2019-08-04T20:06:48.236Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"7f2efbfe-0dd6-4136-996c-baf98601e2b6\",\"initialized\":true}},\"b2d83e74-be77-4228-961f-dfe91663b0a8\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"piqnyubkh@example.com}\",\"displayName\":\"7t34gjddnfdpw5l\",\"originalName\":\"u97ziqawij27oof\",\"dateCreated\":\"2019-08-04T20:14:51.17Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"748cb271-c6fe-4cb5-9e26-e6ce0b8f7125\",\"initialized\":true}},\"bbfd8610-2196-4afc-b6fc-65d203f89d6a\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"oeecap1u0@example.com}\",\"displayName\":\"n9au27x8jrspbki\",\"originalName\":\"qoco9g9h8cpt2al\",\"dateCreated\":\"2019-08-04T20:15:04.967Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"4aebc3bd-8837-4790-a6e1-65de157b3251\",\"initialized\":true}},\"d1803fa9-895b-465c-afa8-878f8fa29751\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"d7e519nqc@example.com}\",\"displayName\":\"1stzm5ndvkj3i24\",\"originalName\":\"tanpkpfhszf8amh\",\"dateCreated\":\"2019-08-04T20:15:10.216Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"1aa286c4-6d42-4862-ab4d-5b6cbe556b04\",\"initialized\":true}},\"d85d902a-53ba-4a6f-a5d4-aab9e11eb1e9\":{\"type\":\"Plain\",\"value\":{\"userPrincipalName\":\"vb8wfcfsf@example.com}\",\"displayName\":\"zsqnexw8up7tsrw\",\"originalName\":\"w99nufbr5t56n6b\",\"dateCreated\":\"2019-08-04T20:15:17.271Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3c6ea57f-85e8-41f8-aa48-1fa951031c32\",\"initialized\":true}},\"160419be-de40-426c-a8f3-4710a3a5ad45\":{\"type\":\"Plain\",\"value\":{\"dateCreated\":\"2019-08-04T20:16:32.481Z\",\"parentUrl\":\"/defaultComponent\",\"backReference\":\"3583643a-bcf8-453d-914f-6fe9a4d4c545\",\"initialized\":false}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":6982,\"referenceSequenceNumber\":-1,\"sequenceNumber\":6984,\"timestamp\":1564966532253,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,755 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":868,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"a8d0a78f-b794-4c3f-a450-5591d666af47\",{\"client\":{\"user\":{\"id\":\"k54rzd25c@example.com}\",\"name\":\"ap8qjpv4hodxdju\",\"email\":\"ofruykvj0@example.com}\"}},\"sequenceNumber\":468}],[\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\",{\"client\":{\"user\":{\"id\":\"5kjrxan6y@example.com}\",\"name\":\"49n9gxrzrdfk3gi\",\"email\":\"ov5kkghnq@example.com}\"}},\"sequenceNumber\":738}],[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":254,\"refSeqNumber\":996}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":8,\"chunkLengthChars\":191,\"totalLengthChars\":191,\"totalSegmentCount\":8,\"chunkSequenceNumber\":868,\"segmentTexts\":[{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f8188a8-65c5-495c-99fd-66a030329ca2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"18qr335e7h6em5pcltxflspt96v6zqwkys96zwq821co9col971qmwev93xp1hlo97bennb4338i9qd0exqkdxlh1anfja2\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"15e97ead-692d-4cc1-a026-3246a83823ad\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true}}},{\"text\":\"5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":868,\"totalLength\":191,\"totalSegmentCount\":8}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":430,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listId\":\"listRegistryList49\",\"italic\":false}},\"relativePos1\":{\"id\":\"3070a597-1363-4652-904b-2e8d88542353\",\"before\":true},\"relativePos2\":{\"id\":\"3070a597-1363-4652-904b-2e8d88542353\"},\"type\":2},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":869,\"sequenceNumber\":870,\"timestamp\":1565135849721,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":431,\"contents\":{\"pos1\":190,\"pos2\":191,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}},\"type\":2},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":870,\"sequenceNumber\":871,\"timestamp\":1565135849721,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":432,\"contents\":{\"pos1\":191,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a78491ed-bc81-488a-9edf-cf47ca4a76a9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":871,\"sequenceNumber\":872,\"timestamp\":1565135849893,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":434,\"contents\":{\"pos1\":192,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17c3e20b-e502-47cf-8fde-6b34a5caa821\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":873,\"sequenceNumber\":874,\"timestamp\":1565135850049,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":437,\"contents\":{\"pos1\":193,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"566179ee-13ed-4751-ba4d-4ab0448d3cee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":875,\"sequenceNumber\":876,\"timestamp\":1565135850393,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":440,\"contents\":{\"pos1\":193,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":877,\"sequenceNumber\":878,\"timestamp\":1565135851112,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":443,\"contents\":{\"pos1\":194,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":879,\"sequenceNumber\":880,\"timestamp\":1565135851362,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":445,\"contents\":{\"pos1\":195,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":881,\"sequenceNumber\":882,\"timestamp\":1565135851549,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":447,\"contents\":{\"pos1\":196,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":883,\"sequenceNumber\":884,\"timestamp\":1565135851659,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":449,\"contents\":{\"pos1\":197,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":885,\"sequenceNumber\":886,\"timestamp\":1565135851768,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":451,\"contents\":{\"pos1\":198,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":887,\"sequenceNumber\":888,\"timestamp\":1565135851955,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":453,\"contents\":{\"pos1\":199,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":889,\"sequenceNumber\":890,\"timestamp\":1565135852033,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":456,\"contents\":{\"pos1\":200,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":891,\"sequenceNumber\":892,\"timestamp\":1565135852440,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":458,\"contents\":{\"pos1\":201,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":893,\"sequenceNumber\":894,\"timestamp\":1565135852549,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":460,\"contents\":{\"pos1\":202,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":895,\"sequenceNumber\":896,\"timestamp\":1565135852705,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":462,\"contents\":{\"pos1\":203,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":897,\"sequenceNumber\":898,\"timestamp\":1565135852893,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":464,\"contents\":{\"pos1\":204,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":899,\"sequenceNumber\":900,\"timestamp\":1565135852940,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":467,\"contents\":{\"pos1\":205,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":901,\"sequenceNumber\":902,\"timestamp\":1565135853646,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":469,\"contents\":{\"pos1\":206,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":903,\"sequenceNumber\":904,\"timestamp\":1565135853724,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":471,\"contents\":{\"pos1\":207,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":905,\"sequenceNumber\":906,\"timestamp\":1565135853896,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":473,\"contents\":{\"pos1\":208,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":907,\"sequenceNumber\":908,\"timestamp\":1565135853990,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":475,\"contents\":{\"pos1\":209,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":909,\"sequenceNumber\":910,\"timestamp\":1565135854006,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":478,\"contents\":{\"pos1\":210,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":911,\"sequenceNumber\":912,\"timestamp\":1565135854335,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":480,\"contents\":{\"pos1\":211,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":913,\"sequenceNumber\":914,\"timestamp\":1565135854413,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":482,\"contents\":{\"pos1\":212,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":915,\"sequenceNumber\":916,\"timestamp\":1565135854554,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":484,\"contents\":{\"pos1\":213,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":917,\"sequenceNumber\":918,\"timestamp\":1565135854647,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":486,\"contents\":{\"pos1\":214,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":919,\"sequenceNumber\":920,\"timestamp\":1565135854741,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":489,\"contents\":{\"pos1\":215,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":921,\"sequenceNumber\":922,\"timestamp\":1565135855194,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":491,\"contents\":{\"pos1\":216,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":923,\"sequenceNumber\":924,\"timestamp\":1565135855335,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":493,\"contents\":{\"pos1\":217,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":925,\"sequenceNumber\":926,\"timestamp\":1565135855460,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":496,\"contents\":{\"pos1\":218,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":927,\"sequenceNumber\":928,\"timestamp\":1565135855991,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":498,\"contents\":{\"pos1\":219,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":929,\"sequenceNumber\":930,\"timestamp\":1565135856054,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":501,\"contents\":{\"pos1\":221,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":931,\"sequenceNumber\":932,\"timestamp\":1565135856444,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":503,\"contents\":{\"pos1\":222,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"07c9806e-1fea-49c7-8130-f58b675074fe\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":933,\"sequenceNumber\":934,\"timestamp\":1565135856647,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":505,\"contents\":{\"pos1\":223,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":935,\"sequenceNumber\":936,\"timestamp\":1565135856804,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":507,\"contents\":{\"pos1\":224,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":937,\"sequenceNumber\":938,\"timestamp\":1565135856960,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":510,\"contents\":{\"pos1\":224,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":939,\"sequenceNumber\":940,\"timestamp\":1565135857449,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":513,\"contents\":{\"pos1\":225,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":941,\"sequenceNumber\":942,\"timestamp\":1565135857731,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":515,\"contents\":{\"pos1\":226,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":943,\"sequenceNumber\":944,\"timestamp\":1565135857903,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":517,\"contents\":{\"pos1\":227,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":945,\"sequenceNumber\":946,\"timestamp\":1565135857997,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":519,\"contents\":{\"pos1\":228,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":947,\"sequenceNumber\":948,\"timestamp\":1565135858106,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":521,\"contents\":{\"pos1\":229,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":949,\"sequenceNumber\":950,\"timestamp\":1565135858309,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":523,\"contents\":{\"pos1\":230,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":951,\"sequenceNumber\":952,\"timestamp\":1565135858403,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":526,\"contents\":{\"pos1\":231,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":953,\"sequenceNumber\":954,\"timestamp\":1565135858733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":528,\"contents\":{\"pos1\":232,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":955,\"sequenceNumber\":956,\"timestamp\":1565135858827,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":530,\"contents\":{\"pos1\":233,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":957,\"sequenceNumber\":958,\"timestamp\":1565135858952,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":532,\"contents\":{\"pos1\":234,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":959,\"sequenceNumber\":960,\"timestamp\":1565135859140,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":534,\"contents\":{\"pos1\":235,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":961,\"sequenceNumber\":962,\"timestamp\":1565135859202,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":537,\"contents\":{\"pos1\":236,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":963,\"sequenceNumber\":964,\"timestamp\":1565135859468,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":539,\"contents\":{\"pos1\":237,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":965,\"sequenceNumber\":966,\"timestamp\":1565135859624,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":541,\"contents\":{\"pos1\":238,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":967,\"sequenceNumber\":968,\"timestamp\":1565135859702,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":543,\"contents\":{\"pos1\":239,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":969,\"sequenceNumber\":970,\"timestamp\":1565135859749,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":546,\"contents\":{\"pos1\":240,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":971,\"sequenceNumber\":972,\"timestamp\":1565135860327,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":548,\"contents\":{\"pos1\":241,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":973,\"sequenceNumber\":974,\"timestamp\":1565135860452,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":550,\"contents\":{\"pos1\":242,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":975,\"sequenceNumber\":976,\"timestamp\":1565135860608,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":552,\"contents\":{\"pos1\":243,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":977,\"sequenceNumber\":978,\"timestamp\":1565135860718,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":554,\"contents\":{\"pos1\":244,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":979,\"sequenceNumber\":980,\"timestamp\":1565135860812,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":556,\"contents\":{\"pos1\":245,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":981,\"sequenceNumber\":982,\"timestamp\":1565135860905,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":558,\"contents\":{\"pos1\":246,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":983,\"sequenceNumber\":984,\"timestamp\":1565135861015,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":560,\"contents\":{\"pos1\":247,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":985,\"sequenceNumber\":986,\"timestamp\":1565135861140,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":563,\"contents\":{\"pos1\":248,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":987,\"sequenceNumber\":988,\"timestamp\":1565135861640,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":565,\"contents\":{\"pos1\":249,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":989,\"sequenceNumber\":990,\"timestamp\":1565135861702,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":567,\"contents\":{\"pos1\":250,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":991,\"sequenceNumber\":992,\"timestamp\":1565135861765,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":569,\"contents\":{\"pos1\":251,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":993,\"sequenceNumber\":994,\"timestamp\":1565135861874,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":571,\"contents\":{\"pos1\":252,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":995,\"sequenceNumber\":996,\"timestamp\":1565135862093,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":574,\"contents\":{\"pos1\":253,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":997,\"sequenceNumber\":998,\"timestamp\":1565135862374,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":577,\"contents\":{\"pos1\":254,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1565135862766,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"a8d0a78f-b794-4c3f-a450-5591d666af47\",\"clientSequenceNumber\":577,\"minimumSequenceNumber\":868,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1565135862766,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,827 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1996,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\",{\"client\":{\"user\":{\"id\":\"ruk3bg7g3@example.com}\",\"name\":\"bcm9e1e12fak0js\",\"email\":\"kdnyn3hrk@example.com}\"}},\"sequenceNumber\":1494}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":943,\"refSeqNumber\":1994}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":75,\"chunkLengthChars\":1795,\"totalLengthChars\":1795,\"totalSegmentCount\":75,\"chunkSequenceNumber\":1996,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17c3e20b-e502-47cf-8fde-6b34a5caa821\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1996,\"totalLength\":1795,\"totalSegmentCount\":75}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":787,\"minimumSequenceNumber\":1996,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1565136734862,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2911,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\",{\"client\":{\"user\":{\"id\":\"6s2935dsj@example.com}\",\"name\":\"5gdq9ouob49rrkm\",\"email\":\"4yovs2dg5@example.com}\"}},\"sequenceNumber\":2298}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1201,\"refSeqNumber\":2958}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1119,\"refSeqNumber\":2996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":79,\"chunkLengthChars\":2081,\"totalLengthChars\":2081,\"totalSegmentCount\":79,\"chunkSequenceNumber\":2911,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},\"shrllw32u7s9itvkprdmg87f2z0l8lamssxswj0t41r14ao74ukkeazovdh14knw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"m8r5j1el7gdf7kjxkrmttk2map5pby8z9yq0h20iw5m5ya213b1jcpojnhz9mso98qjg908awv8fgw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17c3e20b-e502-47cf-8fde-6b34a5caa821\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1e764da-520f-4f38-84eb-2eb5240058c7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2911,\"totalLength\":2081,\"totalSegmentCount\":79}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1373,\"contents\":{\"pos1\":1180,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2914,\"sequenceNumber\":2915,\"timestamp\":1565138004374,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1375,\"contents\":{\"pos1\":1181,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2917,\"sequenceNumber\":2918,\"timestamp\":1565138004468,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1377,\"contents\":{\"pos1\":1182,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2919,\"sequenceNumber\":2920,\"timestamp\":1565138004577,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1380,\"contents\":{\"pos1\":1183,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2921,\"sequenceNumber\":2922,\"timestamp\":1565138004895,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1382,\"contents\":{\"pos1\":1184,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2923,\"sequenceNumber\":2924,\"timestamp\":1565138005113,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1384,\"contents\":{\"pos1\":1185,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2925,\"sequenceNumber\":2926,\"timestamp\":1565138005192,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1387,\"contents\":{\"pos1\":1186,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2927,\"sequenceNumber\":2928,\"timestamp\":1565138005676,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1389,\"contents\":{\"pos1\":1187,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2929,\"sequenceNumber\":2930,\"timestamp\":1565138005754,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1391,\"contents\":{\"pos1\":1188,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2931,\"sequenceNumber\":2932,\"timestamp\":1565138005848,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1393,\"contents\":{\"pos1\":1189,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2933,\"sequenceNumber\":2934,\"timestamp\":1565138005941,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1395,\"contents\":{\"pos1\":1190,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2935,\"sequenceNumber\":2936,\"timestamp\":1565138006020,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1397,\"contents\":{\"pos1\":1191,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2937,\"sequenceNumber\":2938,\"timestamp\":1565138006207,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1399,\"contents\":{\"pos1\":1192,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2939,\"sequenceNumber\":2940,\"timestamp\":1565138006285,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1402,\"contents\":{\"pos1\":1193,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2941,\"sequenceNumber\":2942,\"timestamp\":1565138006786,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1404,\"contents\":{\"pos1\":1194,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2943,\"sequenceNumber\":2944,\"timestamp\":1565138006895,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1406,\"contents\":{\"pos1\":1195,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2945,\"sequenceNumber\":2946,\"timestamp\":1565138007005,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1408,\"contents\":{\"pos1\":1196,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2947,\"sequenceNumber\":2948,\"timestamp\":1565138007161,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1410,\"contents\":{\"pos1\":1197,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2949,\"sequenceNumber\":2950,\"timestamp\":1565138007239,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1412,\"contents\":{\"pos1\":1198,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2951,\"sequenceNumber\":2952,\"timestamp\":1565138007364,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1415,\"contents\":{\"pos1\":1199,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2953,\"sequenceNumber\":2954,\"timestamp\":1565138009114,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1419,\"contents\":{\"pos1\":1199,\"pos2\":1200,\"type\":1},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2956,\"sequenceNumber\":2957,\"timestamp\":1565138009849,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":437,\"contents\":{\"pos1\":1101,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2957,\"sequenceNumber\":2958,\"timestamp\":1565138009974,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":439,\"contents\":{\"pos1\":1102,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2959,\"sequenceNumber\":2960,\"timestamp\":1565138010005,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1420,\"contents\":{\"pos1\":1201,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2961,\"sequenceNumber\":2962,\"timestamp\":1565138010052,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":441,\"contents\":{\"pos1\":1103,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2963,\"sequenceNumber\":2964,\"timestamp\":1565138010099,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":443,\"contents\":{\"pos1\":1104,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2965,\"sequenceNumber\":2966,\"timestamp\":1565138010130,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":445,\"contents\":{\"pos1\":1105,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2967,\"sequenceNumber\":2968,\"timestamp\":1565138010192,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":447,\"contents\":{\"pos1\":1106,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2969,\"sequenceNumber\":2970,\"timestamp\":1565138010302,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":449,\"contents\":{\"pos1\":1107,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2971,\"sequenceNumber\":2972,\"timestamp\":1565138010427,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":451,\"contents\":{\"pos1\":1108,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2973,\"sequenceNumber\":2974,\"timestamp\":1565138010490,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":454,\"contents\":{\"pos1\":1109,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2975,\"sequenceNumber\":2976,\"timestamp\":1565138010959,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":456,\"contents\":{\"pos1\":1110,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2977,\"sequenceNumber\":2978,\"timestamp\":1565138011021,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":460,\"contents\":{\"pos1\":1110,\"pos2\":1111,\"type\":1},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2980,\"sequenceNumber\":2981,\"timestamp\":1565138011537,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":461,\"contents\":{\"pos1\":1110,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2981,\"sequenceNumber\":2982,\"timestamp\":1565138011599,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":463,\"contents\":{\"pos1\":1111,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2983,\"sequenceNumber\":2984,\"timestamp\":1565138011693,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":465,\"contents\":{\"pos1\":1112,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2985,\"sequenceNumber\":2986,\"timestamp\":1565138011771,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":467,\"contents\":{\"pos1\":1113,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2987,\"sequenceNumber\":2988,\"timestamp\":1565138011865,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":469,\"contents\":{\"pos1\":1114,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2989,\"sequenceNumber\":2990,\"timestamp\":1565138011912,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":471,\"contents\":{\"pos1\":1115,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2991,\"sequenceNumber\":2992,\"timestamp\":1565138011974,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":473,\"contents\":{\"pos1\":1116,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2993,\"sequenceNumber\":2994,\"timestamp\":1565138012021,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":475,\"contents\":{\"pos1\":1117,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2995,\"sequenceNumber\":2996,\"timestamp\":1565138012052,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":477,\"contents\":{\"pos1\":1118,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2997,\"sequenceNumber\":2998,\"timestamp\":1565138012115,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":479,\"contents\":{\"pos1\":1119,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1565138012177,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":479,\"minimumSequenceNumber\":2911,\"referenceSequenceNumber\":2997,\"sequenceNumber\":3000,\"timestamp\":1565138012177,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3628,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\",{\"client\":{\"user\":{\"id\":\"6s2935dsj@example.com}\",\"name\":\"5gdq9ouob49rrkm\",\"email\":\"4yovs2dg5@example.com}\"}},\"sequenceNumber\":2298}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1583,\"refSeqNumber\":3988}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1395,\"refSeqNumber\":3996}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":80,\"chunkLengthChars\":2310,\"totalLengthChars\":2310,\"totalSegmentCount\":80,\"chunkSequenceNumber\":3628,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},\"shrllw32u7s9itvkprdmg87f2z0l8lamssxswj0t41r14ao74ukkeazovdh14knwftdiw9ipt\",{\"text\":\"64psa4mzppkyrpgcl0vtsd29whq5fs3zykuai5x811srxy0yv1awy8wruzz5tlkfcgrtjn88bjeqntlzq02duf77z21klo6nngulcfj432mraz5cbaictl7i9yzpgvpg4qtbd7rek9ohas7cd3fpkiescivdmqkb4ig905huajpiewysxg\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"0a6zidsmlogrnxqm8iscrsva48j0shkny5tgavfdk99rzyzjg607lzbpzj0youe1ze6mzw63voeloe2w8sulrkavc3m2n097f7rg44p6kyxvr798r4ylj6k4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17c3e20b-e502-47cf-8fde-6b34a5caa821\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1e764da-520f-4f38-84eb-2eb5240058c7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3628,\"totalLength\":2310,\"totalSegmentCount\":80}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":882,\"contents\":{\"pos1\":1288,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3628,\"sequenceNumber\":3629,\"timestamp\":1565138058191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1728,\"contents\":{\"pos1\":1410,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3630,\"sequenceNumber\":3631,\"timestamp\":1565138058191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":884,\"contents\":{\"pos1\":1289,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3632,\"sequenceNumber\":3633,\"timestamp\":1565138058253,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":886,\"contents\":{\"pos1\":1290,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3634,\"sequenceNumber\":3635,\"timestamp\":1565138058284,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":888,\"contents\":{\"pos1\":1291,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3636,\"sequenceNumber\":3637,\"timestamp\":1565138058347,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1730,\"contents\":{\"pos1\":1414,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3638,\"sequenceNumber\":3639,\"timestamp\":1565138058363,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1732,\"contents\":{\"pos1\":1415,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3640,\"sequenceNumber\":3641,\"timestamp\":1565138058441,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":890,\"contents\":{\"pos1\":1292,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3642,\"sequenceNumber\":3643,\"timestamp\":1565138058456,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":892,\"contents\":{\"pos1\":1293,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3644,\"sequenceNumber\":3645,\"timestamp\":1565138058503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":894,\"contents\":{\"pos1\":1294,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3646,\"sequenceNumber\":3647,\"timestamp\":1565138058597,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":896,\"contents\":{\"pos1\":1295,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3648,\"sequenceNumber\":3649,\"timestamp\":1565138058738,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":898,\"contents\":{\"pos1\":1296,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3650,\"sequenceNumber\":3651,\"timestamp\":1565138058831,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1734,\"contents\":{\"pos1\":1421,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3652,\"sequenceNumber\":3653,\"timestamp\":1565138058909,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1736,\"contents\":{\"pos1\":1422,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3654,\"sequenceNumber\":3655,\"timestamp\":1565138059081,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":901,\"contents\":{\"pos1\":1297,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3656,\"sequenceNumber\":3657,\"timestamp\":1565138059175,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":903,\"contents\":{\"pos1\":1298,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3658,\"sequenceNumber\":3659,\"timestamp\":1565138059222,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1738,\"contents\":{\"pos1\":1425,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3660,\"sequenceNumber\":3661,\"timestamp\":1565138059253,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":905,\"contents\":{\"pos1\":1299,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3662,\"sequenceNumber\":3663,\"timestamp\":1565138059316,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":907,\"contents\":{\"pos1\":1300,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3664,\"sequenceNumber\":3665,\"timestamp\":1565138059394,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":909,\"contents\":{\"pos1\":1301,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3666,\"sequenceNumber\":3667,\"timestamp\":1565138059488,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":911,\"contents\":{\"pos1\":1302,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3668,\"sequenceNumber\":3669,\"timestamp\":1565138059613,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":913,\"contents\":{\"pos1\":1303,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3670,\"sequenceNumber\":3671,\"timestamp\":1565138059675,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":915,\"contents\":{\"pos1\":1304,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3672,\"sequenceNumber\":3673,\"timestamp\":1565138059831,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":917,\"contents\":{\"pos1\":1305,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3674,\"sequenceNumber\":3675,\"timestamp\":1565138059909,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":919,\"contents\":{\"pos1\":1306,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3676,\"sequenceNumber\":3677,\"timestamp\":1565138060019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":921,\"contents\":{\"pos1\":1307,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3678,\"sequenceNumber\":3679,\"timestamp\":1565138060082,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":923,\"contents\":{\"pos1\":1308,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3680,\"sequenceNumber\":3681,\"timestamp\":1565138060206,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1740,\"contents\":{\"pos1\":1436,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3682,\"sequenceNumber\":3683,\"timestamp\":1565138060222,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":925,\"contents\":{\"pos1\":1309,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3684,\"sequenceNumber\":3685,\"timestamp\":1565138060238,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":927,\"contents\":{\"pos1\":1310,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3686,\"sequenceNumber\":3687,\"timestamp\":1565138060347,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1742,\"contents\":{\"pos1\":1439,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3688,\"sequenceNumber\":3689,\"timestamp\":1565138060363,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":929,\"contents\":{\"pos1\":1311,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3690,\"sequenceNumber\":3691,\"timestamp\":1565138060409,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":931,\"contents\":{\"pos1\":1312,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3692,\"sequenceNumber\":3693,\"timestamp\":1565138060425,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":933,\"contents\":{\"pos1\":1313,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3694,\"sequenceNumber\":3695,\"timestamp\":1565138060503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1744,\"contents\":{\"pos1\":1443,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3696,\"sequenceNumber\":3697,\"timestamp\":1565138060503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":935,\"contents\":{\"pos1\":1314,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3698,\"sequenceNumber\":3699,\"timestamp\":1565138060534,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1746,\"contents\":{\"pos1\":1445,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3700,\"sequenceNumber\":3701,\"timestamp\":1565138060581,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":937,\"contents\":{\"pos1\":1315,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3702,\"sequenceNumber\":3703,\"timestamp\":1565138060675,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1748,\"contents\":{\"pos1\":1447,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3704,\"sequenceNumber\":3705,\"timestamp\":1565138060722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":939,\"contents\":{\"pos1\":1316,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3706,\"sequenceNumber\":3707,\"timestamp\":1565138060722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":941,\"contents\":{\"pos1\":1317,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3708,\"sequenceNumber\":3709,\"timestamp\":1565138060784,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1750,\"contents\":{\"pos1\":1450,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3710,\"sequenceNumber\":3711,\"timestamp\":1565138060816,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":943,\"contents\":{\"pos1\":1318,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3712,\"sequenceNumber\":3713,\"timestamp\":1565138060878,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1752,\"contents\":{\"pos1\":1452,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3714,\"sequenceNumber\":3715,\"timestamp\":1565138060909,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":945,\"contents\":{\"pos1\":1319,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3716,\"sequenceNumber\":3717,\"timestamp\":1565138060956,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":947,\"contents\":{\"pos1\":1320,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3718,\"sequenceNumber\":3719,\"timestamp\":1565138061019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1754,\"contents\":{\"pos1\":1455,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3720,\"sequenceNumber\":3721,\"timestamp\":1565138061035,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1756,\"contents\":{\"pos1\":1456,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3722,\"sequenceNumber\":3723,\"timestamp\":1565138061097,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":949,\"contents\":{\"pos1\":1321,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3724,\"sequenceNumber\":3725,\"timestamp\":1565138061128,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":951,\"contents\":{\"pos1\":1322,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3726,\"sequenceNumber\":3727,\"timestamp\":1565138061191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":953,\"contents\":{\"pos1\":1323,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3728,\"sequenceNumber\":3729,\"timestamp\":1565138061269,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1758,\"contents\":{\"pos1\":1460,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3730,\"sequenceNumber\":3731,\"timestamp\":1565138061503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":957,\"contents\":{\"pos1\":1323,\"pos2\":1324,\"type\":1},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3733,\"sequenceNumber\":3734,\"timestamp\":1565138061550,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1760,\"contents\":{\"pos1\":1460,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3734,\"sequenceNumber\":3735,\"timestamp\":1565138061722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1762,\"contents\":{\"pos1\":1461,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3736,\"sequenceNumber\":3737,\"timestamp\":1565138061878,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":959,\"contents\":{\"pos1\":1323,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3738,\"sequenceNumber\":3739,\"timestamp\":1565138061956,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1764,\"contents\":{\"pos1\":1463,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3740,\"sequenceNumber\":3741,\"timestamp\":1565138061988,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":961,\"contents\":{\"pos1\":1324,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3742,\"sequenceNumber\":3743,\"timestamp\":1565138062097,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":963,\"contents\":{\"pos1\":1325,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3744,\"sequenceNumber\":3745,\"timestamp\":1565138062159,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1766,\"contents\":{\"pos1\":1466,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3746,\"sequenceNumber\":3747,\"timestamp\":1565138062191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1768,\"contents\":{\"pos1\":1467,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3748,\"sequenceNumber\":3749,\"timestamp\":1565138062285,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":966,\"contents\":{\"pos1\":1326,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3750,\"sequenceNumber\":3751,\"timestamp\":1565138062534,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1770,\"contents\":{\"pos1\":1469,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3752,\"sequenceNumber\":3753,\"timestamp\":1565138062550,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1772,\"contents\":{\"pos1\":1470,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3754,\"sequenceNumber\":3755,\"timestamp\":1565138062628,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1774,\"contents\":{\"pos1\":1471,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3756,\"sequenceNumber\":3757,\"timestamp\":1565138062706,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":968,\"contents\":{\"pos1\":1327,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3758,\"sequenceNumber\":3759,\"timestamp\":1565138062816,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1776,\"contents\":{\"pos1\":1473,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3760,\"sequenceNumber\":3761,\"timestamp\":1565138063019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":970,\"contents\":{\"pos1\":1328,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3762,\"sequenceNumber\":3763,\"timestamp\":1565138063159,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1778,\"contents\":{\"pos1\":1475,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3764,\"sequenceNumber\":3765,\"timestamp\":1565138063206,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":973,\"contents\":{\"pos1\":1329,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3766,\"sequenceNumber\":3767,\"timestamp\":1565138063550,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1782,\"contents\":{\"pos1\":1476,\"pos2\":1477,\"type\":1},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3769,\"sequenceNumber\":3770,\"timestamp\":1565138063566,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1783,\"contents\":{\"pos1\":1476,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3770,\"sequenceNumber\":3771,\"timestamp\":1565138063644,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":975,\"contents\":{\"pos1\":1330,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3772,\"sequenceNumber\":3773,\"timestamp\":1565138063691,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1785,\"contents\":{\"pos1\":1478,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3774,\"sequenceNumber\":3775,\"timestamp\":1565138063785,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":977,\"contents\":{\"pos1\":1331,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3776,\"sequenceNumber\":3777,\"timestamp\":1565138063957,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1787,\"contents\":{\"pos1\":1480,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3778,\"sequenceNumber\":3779,\"timestamp\":1565138064004,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1789,\"contents\":{\"pos1\":1481,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3780,\"sequenceNumber\":3781,\"timestamp\":1565138064098,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":979,\"contents\":{\"pos1\":1332,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3782,\"sequenceNumber\":3783,\"timestamp\":1565138064145,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1791,\"contents\":{\"pos1\":1483,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3784,\"sequenceNumber\":3785,\"timestamp\":1565138064176,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":981,\"contents\":{\"pos1\":1333,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3786,\"sequenceNumber\":3787,\"timestamp\":1565138064223,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1793,\"contents\":{\"pos1\":1485,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3788,\"sequenceNumber\":3789,\"timestamp\":1565138064395,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":984,\"contents\":{\"pos1\":1334,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3790,\"sequenceNumber\":3791,\"timestamp\":1565138064473,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":986,\"contents\":{\"pos1\":1334,\"pos2\":1335,\"type\":1},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3792,\"sequenceNumber\":3793,\"timestamp\":1565138064473,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1795,\"contents\":{\"pos1\":1486,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3793,\"sequenceNumber\":3794,\"timestamp\":1565138064473,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1797,\"contents\":{\"pos1\":1487,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3795,\"sequenceNumber\":3796,\"timestamp\":1565138064551,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1800,\"contents\":{\"pos1\":1488,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3797,\"sequenceNumber\":3798,\"timestamp\":1565138064832,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1802,\"contents\":{\"pos1\":1489,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3799,\"sequenceNumber\":3800,\"timestamp\":1565138065004,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":989,\"contents\":{\"pos1\":1334,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3801,\"sequenceNumber\":3802,\"timestamp\":1565138065457,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1806,\"contents\":{\"pos1\":1491,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3802,\"sequenceNumber\":3803,\"timestamp\":1565138065879,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1808,\"contents\":{\"pos1\":1492,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3804,\"sequenceNumber\":3805,\"timestamp\":1565138066020,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":992,\"contents\":{\"pos1\":1335,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3807,\"sequenceNumber\":3808,\"timestamp\":1565138066520,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1811,\"contents\":{\"pos1\":1494,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3809,\"sequenceNumber\":3810,\"timestamp\":1565138066645,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":994,\"contents\":{\"pos1\":1336,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3811,\"sequenceNumber\":3812,\"timestamp\":1565138066879,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1814,\"contents\":{\"pos1\":1496,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3813,\"sequenceNumber\":3814,\"timestamp\":1565138067082,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":997,\"contents\":{\"pos1\":1337,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3815,\"sequenceNumber\":3816,\"timestamp\":1565138069007,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1817,\"contents\":{\"pos1\":1498,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3817,\"sequenceNumber\":3818,\"timestamp\":1565138069085,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1000,\"contents\":{\"pos1\":1338,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3819,\"sequenceNumber\":3820,\"timestamp\":1565138069289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1002,\"contents\":{\"pos1\":1339,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3821,\"sequenceNumber\":3822,\"timestamp\":1565138069320,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1819,\"contents\":{\"pos1\":1501,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3823,\"sequenceNumber\":3824,\"timestamp\":1565138069335,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1821,\"contents\":{\"pos1\":1502,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3825,\"sequenceNumber\":3826,\"timestamp\":1565138069429,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1823,\"contents\":{\"pos1\":1503,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3827,\"sequenceNumber\":3828,\"timestamp\":1565138069523,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1005,\"contents\":{\"pos1\":1340,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3829,\"sequenceNumber\":3830,\"timestamp\":1565138069882,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1007,\"contents\":{\"pos1\":1341,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3831,\"sequenceNumber\":3832,\"timestamp\":1565138069945,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1009,\"contents\":{\"pos1\":1342,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3833,\"sequenceNumber\":3834,\"timestamp\":1565138070210,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1011,\"contents\":{\"pos1\":1343,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3835,\"sequenceNumber\":3836,\"timestamp\":1565138070226,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1826,\"contents\":{\"pos1\":1508,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3837,\"sequenceNumber\":3838,\"timestamp\":1565138070226,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1013,\"contents\":{\"pos1\":1344,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3839,\"sequenceNumber\":3840,\"timestamp\":1565138070242,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1828,\"contents\":{\"pos1\":1510,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3841,\"sequenceNumber\":3842,\"timestamp\":1565138070289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1015,\"contents\":{\"pos1\":1345,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3843,\"sequenceNumber\":3844,\"timestamp\":1565138070367,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1830,\"contents\":{\"pos1\":1512,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3845,\"sequenceNumber\":3846,\"timestamp\":1565138070398,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1017,\"contents\":{\"pos1\":1346,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3847,\"sequenceNumber\":3848,\"timestamp\":1565138070429,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1019,\"contents\":{\"pos1\":1347,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3849,\"sequenceNumber\":3850,\"timestamp\":1565138070554,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1021,\"contents\":{\"pos1\":1348,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3851,\"sequenceNumber\":3852,\"timestamp\":1565138070617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1023,\"contents\":{\"pos1\":1349,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3853,\"sequenceNumber\":3854,\"timestamp\":1565138070695,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1025,\"contents\":{\"pos1\":1350,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3855,\"sequenceNumber\":3856,\"timestamp\":1565138070742,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1027,\"contents\":{\"pos1\":1351,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3857,\"sequenceNumber\":3858,\"timestamp\":1565138070835,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1029,\"contents\":{\"pos1\":1352,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3859,\"sequenceNumber\":3860,\"timestamp\":1565138070945,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1031,\"contents\":{\"pos1\":1353,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3861,\"sequenceNumber\":3862,\"timestamp\":1565138070992,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1033,\"contents\":{\"pos1\":1354,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3863,\"sequenceNumber\":3864,\"timestamp\":1565138071023,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1035,\"contents\":{\"pos1\":1355,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3865,\"sequenceNumber\":3866,\"timestamp\":1565138071070,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1037,\"contents\":{\"pos1\":1356,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3867,\"sequenceNumber\":3868,\"timestamp\":1565138071101,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1039,\"contents\":{\"pos1\":1357,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3869,\"sequenceNumber\":3870,\"timestamp\":1565138071132,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1042,\"contents\":{\"pos1\":1358,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3871,\"sequenceNumber\":3872,\"timestamp\":1565138071586,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1044,\"contents\":{\"pos1\":1359,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3873,\"sequenceNumber\":3874,\"timestamp\":1565138071617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1046,\"contents\":{\"pos1\":1360,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3875,\"sequenceNumber\":3876,\"timestamp\":1565138071726,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1048,\"contents\":{\"pos1\":1361,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3877,\"sequenceNumber\":3878,\"timestamp\":1565138071836,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1050,\"contents\":{\"pos1\":1362,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3879,\"sequenceNumber\":3880,\"timestamp\":1565138071945,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1052,\"contents\":{\"pos1\":1363,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3881,\"sequenceNumber\":3882,\"timestamp\":1565138072023,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1054,\"contents\":{\"pos1\":1364,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3883,\"sequenceNumber\":3884,\"timestamp\":1565138072179,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1833,\"contents\":{\"pos1\":1532,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3885,\"sequenceNumber\":3886,\"timestamp\":1565138072195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1056,\"contents\":{\"pos1\":1365,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3887,\"sequenceNumber\":3888,\"timestamp\":1565138072242,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1058,\"contents\":{\"pos1\":1366,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3889,\"sequenceNumber\":3890,\"timestamp\":1565138072351,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1060,\"contents\":{\"pos1\":1367,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3891,\"sequenceNumber\":3892,\"timestamp\":1565138072414,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1062,\"contents\":{\"pos1\":1368,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3893,\"sequenceNumber\":3894,\"timestamp\":1565138072461,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1064,\"contents\":{\"pos1\":1369,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3895,\"sequenceNumber\":3896,\"timestamp\":1565138072586,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1066,\"contents\":{\"pos1\":1370,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3897,\"sequenceNumber\":3898,\"timestamp\":1565138072601,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1836,\"contents\":{\"pos1\":1539,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3899,\"sequenceNumber\":3900,\"timestamp\":1565138072664,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1068,\"contents\":{\"pos1\":1371,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3901,\"sequenceNumber\":3902,\"timestamp\":1565138072664,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1070,\"contents\":{\"pos1\":1372,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3903,\"sequenceNumber\":3904,\"timestamp\":1565138072742,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1838,\"contents\":{\"pos1\":1542,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3905,\"sequenceNumber\":3906,\"timestamp\":1565138072820,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1072,\"contents\":{\"pos1\":1373,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3907,\"sequenceNumber\":3908,\"timestamp\":1565138072836,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1074,\"contents\":{\"pos1\":1374,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3909,\"sequenceNumber\":3910,\"timestamp\":1565138072914,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1840,\"contents\":{\"pos1\":1545,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3911,\"sequenceNumber\":3912,\"timestamp\":1565138072929,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1076,\"contents\":{\"pos1\":1375,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3913,\"sequenceNumber\":3914,\"timestamp\":1565138073007,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1078,\"contents\":{\"pos1\":1376,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3915,\"sequenceNumber\":3916,\"timestamp\":1565138073054,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1080,\"contents\":{\"pos1\":1377,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3917,\"sequenceNumber\":3918,\"timestamp\":1565138073117,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1082,\"contents\":{\"pos1\":1378,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3919,\"sequenceNumber\":3920,\"timestamp\":1565138073195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1084,\"contents\":{\"pos1\":1379,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3921,\"sequenceNumber\":3922,\"timestamp\":1565138073257,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1086,\"contents\":{\"pos1\":1380,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3923,\"sequenceNumber\":3924,\"timestamp\":1565138073398,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1842,\"contents\":{\"pos1\":1552,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3925,\"sequenceNumber\":3926,\"timestamp\":1565138073461,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1088,\"contents\":{\"pos1\":1381,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3927,\"sequenceNumber\":3928,\"timestamp\":1565138073570,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1844,\"contents\":{\"pos1\":1554,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3929,\"sequenceNumber\":3930,\"timestamp\":1565138073617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1090,\"contents\":{\"pos1\":1382,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3931,\"sequenceNumber\":3932,\"timestamp\":1565138073679,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1846,\"contents\":{\"pos1\":1556,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3933,\"sequenceNumber\":3934,\"timestamp\":1565138073757,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1848,\"contents\":{\"pos1\":1557,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3935,\"sequenceNumber\":3936,\"timestamp\":1565138073898,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1092,\"contents\":{\"pos1\":1383,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3937,\"sequenceNumber\":3938,\"timestamp\":1565138073992,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1094,\"contents\":{\"pos1\":1384,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3939,\"sequenceNumber\":3940,\"timestamp\":1565138074039,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1096,\"contents\":{\"pos1\":1385,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3941,\"sequenceNumber\":3942,\"timestamp\":1565138074242,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1851,\"contents\":{\"pos1\":1561,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3943,\"sequenceNumber\":3944,\"timestamp\":1565138074382,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1099,\"contents\":{\"pos1\":1385,\"pos2\":1386,\"type\":1},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3946,\"sequenceNumber\":3947,\"timestamp\":1565138074476,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1853,\"contents\":{\"pos1\":1561,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3947,\"sequenceNumber\":3948,\"timestamp\":1565138074476,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1100,\"contents\":{\"pos1\":1385,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3949,\"sequenceNumber\":3950,\"timestamp\":1565138074544,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1855,\"contents\":{\"pos1\":1563,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3951,\"sequenceNumber\":3952,\"timestamp\":1565138074591,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1102,\"contents\":{\"pos1\":1386,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3952,\"sequenceNumber\":3953,\"timestamp\":1565138074591,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1104,\"contents\":{\"pos1\":1387,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3955,\"sequenceNumber\":3956,\"timestamp\":1565138074637,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1857,\"contents\":{\"pos1\":1566,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3957,\"sequenceNumber\":3958,\"timestamp\":1565138074716,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1107,\"contents\":{\"pos1\":1388,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3959,\"sequenceNumber\":3960,\"timestamp\":1565138075044,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1860,\"contents\":{\"pos1\":1568,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3961,\"sequenceNumber\":3962,\"timestamp\":1565138075091,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1109,\"contents\":{\"pos1\":1389,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3963,\"sequenceNumber\":3964,\"timestamp\":1565138075107,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1862,\"contents\":{\"pos1\":1570,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3965,\"sequenceNumber\":3966,\"timestamp\":1565138075262,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1111,\"contents\":{\"pos1\":1390,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3967,\"sequenceNumber\":3968,\"timestamp\":1565138075278,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1864,\"contents\":{\"pos1\":1572,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3969,\"sequenceNumber\":3970,\"timestamp\":1565138075325,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1866,\"contents\":{\"pos1\":1573,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3971,\"sequenceNumber\":3972,\"timestamp\":1565138075372,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1868,\"contents\":{\"pos1\":1574,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3973,\"sequenceNumber\":3974,\"timestamp\":1565138075450,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1871,\"contents\":{\"pos1\":1575,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3975,\"sequenceNumber\":3976,\"timestamp\":1565138075826,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1873,\"contents\":{\"pos1\":1576,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3977,\"sequenceNumber\":3978,\"timestamp\":1565138075904,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1875,\"contents\":{\"pos1\":1577,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3979,\"sequenceNumber\":3980,\"timestamp\":1565138076013,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1877,\"contents\":{\"pos1\":1578,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3981,\"sequenceNumber\":3982,\"timestamp\":1565138076200,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1880,\"contents\":{\"pos1\":1579,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3983,\"sequenceNumber\":3984,\"timestamp\":1565138076591,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1883,\"contents\":{\"pos1\":1580,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3985,\"sequenceNumber\":3986,\"timestamp\":1565138077013,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1885,\"contents\":{\"pos1\":1581,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3987,\"sequenceNumber\":3988,\"timestamp\":1565138077247,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":1887,\"contents\":{\"pos1\":1582,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3989,\"sequenceNumber\":3990,\"timestamp\":1565138077372,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1119,\"contents\":{\"pos1\":1391,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3991,\"sequenceNumber\":3992,\"timestamp\":1565138078044,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1121,\"contents\":{\"pos1\":1392,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3993,\"sequenceNumber\":3994,\"timestamp\":1565138078138,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1123,\"contents\":{\"pos1\":1393,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3995,\"sequenceNumber\":3996,\"timestamp\":1565138078185,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1125,\"contents\":{\"pos1\":1394,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3997,\"sequenceNumber\":3998,\"timestamp\":1565138078310,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1127,\"contents\":{\"pos1\":1395,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1565138078388,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1127,\"minimumSequenceNumber\":3628,\"referenceSequenceNumber\":3999,\"sequenceNumber\":4000,\"timestamp\":1565138078388,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4899,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\",{\"client\":{\"user\":{\"id\":\"6s2935dsj@example.com}\",\"name\":\"5gdq9ouob49rrkm\",\"email\":\"4yovs2dg5@example.com}\"}},\"sequenceNumber\":2298}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1764,\"refSeqNumber\":4978}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1733,\"refSeqNumber\":4996}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}},\"ac4e690b-7f9c-4f9f-9874-f71376e74c1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":4850}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":84,\"chunkLengthChars\":2831,\"totalLengthChars\":2831,\"totalSegmentCount\":84,\"chunkSequenceNumber\":4899,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},\"ra2ydad49zmamx6xb4fu5vth6myu5mh54vrpzc3pnb67zprfh6lmi94qjhxpjex2c16fn175ohd9y34zhwqs16uzv9pukkeazovdh14knwftdiw9ipt\",{\"text\":\"64psa4mzppkyrpgcl0vtsd29whq5fs3zykuai5x811srxy0yv1awy8wruzz5tlkfcgrtjn88bjeqntlzq02duf77z21klo6nngulcfj432mraz5cbaictl7i9yzpgvpg4qtbd7rek9ohas7cd3fpkiescivdmqkb4ig905huajpiewysxgzqtw7h2ao4wlxooptv30r4d2kpxsp7xjdsv3ok2z19y5ks\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},\"cc48ph3459gn96a8nbv3816yjhlukn2o3ft44fe5hsgde2ktm3imw177ou7n9aenaq7p5vb9lp7z1ntdj5dqkno78ke8xrsoxukbw4ckwes2yjo6n37tbailmxlaycd7nmkfbqo5dlpr8u1l4iev64vvt3pnnpredn1z9ps81fi1nu60dm8z0tn6liy0xv0c2gptxnkq9l5h3c30qrs49aruuh8j2vng6pnl1wxob1t7cdwr7lzd9w98iflusco1n9vvzuppad7bimq9fj0gtnagmrfvp1rxz3u8z2yy78l3k6ter1pdpkifjhki2ugiavy8wa311n0xmh3qfrsxgv335\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e438a7e6-84a9-4070-90ce-063bccfc8500\",\"ItemType\":\"Paragraph\"}},\"yomcl45pjsstfw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35cc12f7-db7d-4db7-835e-a7e35109e0bd\",\"ItemType\":\"Paragraph\"}},\"0a6zidsmlogrnxqm8iscrsva48j0shkny5tgavfdk99rzyzjg607lzbpzj0youe1ze6mzw63voeloe2w8sulrkavc3m2n097f7rg44p6kyxvr798r4ylj6k4i0z5dmc5duixfqkn0ttychtpp1ygrek6icy39g8s473xoxw7iu0rb1byq8kke8w1ffadvaft\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17c3e20b-e502-47cf-8fde-6b34a5caa821\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1e764da-520f-4f38-84eb-2eb5240058c7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4899,\"totalLength\":2831,\"totalSegmentCount\":84}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2265,\"contents\":{\"pos1\":1737,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4901,\"sequenceNumber\":4902,\"timestamp\":1565138135835,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2267,\"contents\":{\"pos1\":1738,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4903,\"sequenceNumber\":4904,\"timestamp\":1565138135976,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2269,\"contents\":{\"pos1\":1739,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4905,\"sequenceNumber\":4906,\"timestamp\":1565138136179,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2271,\"contents\":{\"pos1\":1740,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4907,\"sequenceNumber\":4908,\"timestamp\":1565138136257,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2273,\"contents\":{\"pos1\":1741,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4909,\"sequenceNumber\":4910,\"timestamp\":1565138136335,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2275,\"contents\":{\"pos1\":1742,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4911,\"sequenceNumber\":4912,\"timestamp\":1565138136539,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2277,\"contents\":{\"pos1\":1743,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4913,\"sequenceNumber\":4914,\"timestamp\":1565138136648,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2279,\"contents\":{\"pos1\":1744,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4917,\"sequenceNumber\":4918,\"timestamp\":1565138136757,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1776,\"contents\":{\"pos1\":1721,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4919,\"sequenceNumber\":4920,\"timestamp\":1565138136835,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2281,\"contents\":{\"pos1\":1746,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4921,\"sequenceNumber\":4922,\"timestamp\":1565138136929,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2283,\"contents\":{\"pos1\":1747,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4923,\"sequenceNumber\":4924,\"timestamp\":1565138137007,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2286,\"contents\":{\"pos1\":1748,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4925,\"sequenceNumber\":4926,\"timestamp\":1565138137710,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1779,\"contents\":{\"pos1\":1722,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4927,\"sequenceNumber\":4928,\"timestamp\":1565138137867,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1781,\"contents\":{\"pos1\":1723,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4929,\"sequenceNumber\":4930,\"timestamp\":1565138137977,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1783,\"contents\":{\"pos1\":1724,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4931,\"sequenceNumber\":4932,\"timestamp\":1565138138117,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1785,\"contents\":{\"pos1\":1725,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4933,\"sequenceNumber\":4934,\"timestamp\":1565138138211,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1787,\"contents\":{\"pos1\":1726,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4935,\"sequenceNumber\":4936,\"timestamp\":1565138138289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1789,\"contents\":{\"pos1\":1727,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4937,\"sequenceNumber\":4938,\"timestamp\":1565138138414,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2288,\"contents\":{\"pos1\":1755,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4939,\"sequenceNumber\":4940,\"timestamp\":1565138138461,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2291,\"contents\":{\"pos1\":1756,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4941,\"sequenceNumber\":4942,\"timestamp\":1565138138711,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1793,\"contents\":{\"pos1\":1727,\"pos2\":1728,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4944,\"sequenceNumber\":4945,\"timestamp\":1565138138758,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2293,\"contents\":{\"pos1\":1756,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4945,\"sequenceNumber\":4946,\"timestamp\":1565138138852,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1795,\"contents\":{\"pos1\":1726,\"pos2\":1727,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4948,\"sequenceNumber\":4949,\"timestamp\":1565138138898,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2295,\"contents\":{\"pos1\":1756,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4949,\"sequenceNumber\":4950,\"timestamp\":1565138138930,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1797,\"contents\":{\"pos1\":1725,\"pos2\":1726,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4952,\"sequenceNumber\":4953,\"timestamp\":1565138139055,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1799,\"contents\":{\"pos1\":1724,\"pos2\":1725,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4954,\"sequenceNumber\":4955,\"timestamp\":1565138139195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1801,\"contents\":{\"pos1\":1723,\"pos2\":1724,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4956,\"sequenceNumber\":4957,\"timestamp\":1565138139383,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1803,\"contents\":{\"pos1\":1722,\"pos2\":1723,\"type\":1},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4958,\"sequenceNumber\":4959,\"timestamp\":1565138139508,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2299,\"contents\":{\"pos1\":1753,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4959,\"sequenceNumber\":4960,\"timestamp\":1565138139680,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2301,\"contents\":{\"pos1\":1754,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4961,\"sequenceNumber\":4962,\"timestamp\":1565138139758,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2303,\"contents\":{\"pos1\":1755,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4963,\"sequenceNumber\":4964,\"timestamp\":1565138139852,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2305,\"contents\":{\"pos1\":1756,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4965,\"sequenceNumber\":4966,\"timestamp\":1565138140039,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2307,\"contents\":{\"pos1\":1757,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4967,\"sequenceNumber\":4968,\"timestamp\":1565138140117,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2309,\"contents\":{\"pos1\":1758,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4969,\"sequenceNumber\":4970,\"timestamp\":1565138140195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1805,\"contents\":{\"pos1\":1722,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4971,\"sequenceNumber\":4972,\"timestamp\":1565138140273,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2311,\"contents\":{\"pos1\":1760,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4973,\"sequenceNumber\":4974,\"timestamp\":1565138140352,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1807,\"contents\":{\"pos1\":1723,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4975,\"sequenceNumber\":4976,\"timestamp\":1565138140383,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2313,\"contents\":{\"pos1\":1762,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4977,\"sequenceNumber\":4978,\"timestamp\":1565138140445,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1809,\"contents\":{\"pos1\":1724,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4979,\"sequenceNumber\":4980,\"timestamp\":1565138140492,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2315,\"contents\":{\"pos1\":1764,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4981,\"sequenceNumber\":4982,\"timestamp\":1565138140523,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1811,\"contents\":{\"pos1\":1725,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4983,\"sequenceNumber\":4984,\"timestamp\":1565138140570,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1813,\"contents\":{\"pos1\":1726,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4985,\"sequenceNumber\":4986,\"timestamp\":1565138140617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1815,\"contents\":{\"pos1\":1727,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4987,\"sequenceNumber\":4988,\"timestamp\":1565138140695,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1817,\"contents\":{\"pos1\":1728,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4989,\"sequenceNumber\":4990,\"timestamp\":1565138140789,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1819,\"contents\":{\"pos1\":1729,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4991,\"sequenceNumber\":4992,\"timestamp\":1565138140867,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1821,\"contents\":{\"pos1\":1730,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4993,\"sequenceNumber\":4994,\"timestamp\":1565138140961,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1823,\"contents\":{\"pos1\":1731,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4995,\"sequenceNumber\":4996,\"timestamp\":1565138141055,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":1825,\"contents\":{\"pos1\":1732,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4997,\"sequenceNumber\":4998,\"timestamp\":1565138141164,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2317,\"contents\":{\"pos1\":1773,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4999,\"sequenceNumber\":5000,\"timestamp\":1565138141227,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",\"clientSequenceNumber\":2317,\"minimumSequenceNumber\":4899,\"referenceSequenceNumber\":4997,\"sequenceNumber\":5000,\"timestamp\":1565138141227,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5969,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}],[\"023b8b90-beca-489f-8278-6c0c2a114951\",{\"client\":{\"user\":{\"id\":\"nzohoa2h2@example.com}\",\"name\":\"r14rnmxvq8m9rgi\",\"email\":\"ezv5e3tcs@example.com}\"}},\"sequenceNumber\":5080}],[\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",{\"client\":{\"user\":{\"id\":\"tr2eiby5j@example.com}\",\"name\":\"sh18tz2wakafx5m\",\"email\":\"5oorf2bga@example.com}\"}},\"sequenceNumber\":5096}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1802,\"refSeqNumber\":5058}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1051,\"refSeqNumber\":5996}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}},\"ac4e690b-7f9c-4f9f-9874-f71376e74c1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":4850}},\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1102,\"refSeqNumber\":5966}},\"e580814f-9bff-4c23-84f8-82d2d0fbfacf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5212}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":79,\"chunkLengthChars\":2004,\"totalLengthChars\":2004,\"totalSegmentCount\":79,\"chunkSequenceNumber\":5969,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"8zbmlqbh7zebknbho1v2ibrycim38knydblaabvczhku3wrru1l3cwze747aztvy\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1e764da-520f-4f38-84eb-2eb5240058c7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f509bc2c-6ac6-4c69-b3af-5e20c3b99f47\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b4987d4e-f4ba-412f-a27f-a765ce1b54ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5969,\"totalLength\":2004,\"totalSegmentCount\":79}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2400,\"contents\":{\"pos1\":1037,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5971,\"sequenceNumber\":5972,\"timestamp\":1565138227277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2402,\"contents\":{\"pos1\":1038,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5973,\"sequenceNumber\":5974,\"timestamp\":1565138227277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2405,\"contents\":{\"pos1\":1039,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5975,\"sequenceNumber\":5976,\"timestamp\":1565138227558,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2407,\"contents\":{\"pos1\":1040,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5977,\"sequenceNumber\":5978,\"timestamp\":1565138227573,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2409,\"contents\":{\"pos1\":1041,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5979,\"sequenceNumber\":5980,\"timestamp\":1565138227652,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2411,\"contents\":{\"pos1\":1042,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5981,\"sequenceNumber\":5982,\"timestamp\":1565138227714,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2413,\"contents\":{\"pos1\":1043,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5983,\"sequenceNumber\":5984,\"timestamp\":1565138227761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2415,\"contents\":{\"pos1\":1044,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5985,\"sequenceNumber\":5986,\"timestamp\":1565138227808,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2417,\"contents\":{\"pos1\":1045,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5987,\"sequenceNumber\":5988,\"timestamp\":1565138227870,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2420,\"contents\":{\"pos1\":1046,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5989,\"sequenceNumber\":5990,\"timestamp\":1565138228074,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2422,\"contents\":{\"pos1\":1047,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5991,\"sequenceNumber\":5992,\"timestamp\":1565138228120,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2424,\"contents\":{\"pos1\":1048,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5993,\"sequenceNumber\":5994,\"timestamp\":1565138228183,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2426,\"contents\":{\"pos1\":1049,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5995,\"sequenceNumber\":5996,\"timestamp\":1565138228277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2428,\"contents\":{\"pos1\":1050,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5997,\"sequenceNumber\":5998,\"timestamp\":1565138228370,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2430,\"contents\":{\"pos1\":1051,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1565138228433,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",\"clientSequenceNumber\":2430,\"minimumSequenceNumber\":5969,\"referenceSequenceNumber\":5999,\"sequenceNumber\":6000,\"timestamp\":1565138228433,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_7000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_7000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6949,\"sequenceNumber\":7000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\",{\"client\":{\"user\":{\"id\":\"i5lm10mke@example.com}\",\"name\":\"sdw31g0igwr24bl\",\"email\":\"ud5mzaaxh@example.com}\"}},\"sequenceNumber\":1353}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}],[\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",{\"client\":{\"user\":{\"id\":\"tr2eiby5j@example.com}\",\"name\":\"sh18tz2wakafx5m\",\"email\":\"5oorf2bga@example.com}\"}},\"sequenceNumber\":5096}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1802,\"refSeqNumber\":5058}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1037,\"refSeqNumber\":6394}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}},\"ac4e690b-7f9c-4f9f-9874-f71376e74c1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":4850}},\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":278,\"refSeqNumber\":6997}},\"e580814f-9bff-4c23-84f8-82d2d0fbfacf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5212}},\"b6c7b259-4ce6-4569-8da0-ea9352fe5a13\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6396}},\"74bb59f3-7266-4d81-b01b-6bd34826065c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6427}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":81,\"chunkLengthChars\":2067,\"totalLengthChars\":2067,\"totalSegmentCount\":81,\"chunkSequenceNumber\":6949,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-0836-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b90492ca-bd3f-47f0-b6a6-40038633aff2\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"upsi35q98h8sr3y2ovzkno4az6e03oh14505oyr0slhv5zf8kdsc6uc1101pfren0lcmehz6ftugtuaijbs9fi9f0tzh54gbaf8lcebu66lum9xjot3zg6l0384t0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e20b09cb-ce09-4e89-a176-7131f168bc46\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f6cd52c-01a6-4756-889d-c081c68c5924\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtabh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6e6be96f-cf9c-45e5-826b-f2cfbf21f191\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f509bc2c-6ac6-4c69-b3af-5e20c3b99f47\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b4987d4e-f4ba-412f-a27f-a765ce1b54ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmdf9pvk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6949,\"totalLength\":2067,\"totalSegmentCount\":81}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1271,\"contents\":{\"pos1\":259,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6949,\"sequenceNumber\":6950,\"timestamp\":1565138794518,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1273,\"contents\":{\"pos1\":260,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6951,\"sequenceNumber\":6952,\"timestamp\":1565138794721,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1275,\"contents\":{\"pos1\":261,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6953,\"sequenceNumber\":6954,\"timestamp\":1565138794799,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1277,\"contents\":{\"pos1\":262,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6956,\"sequenceNumber\":6957,\"timestamp\":1565138794894,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1280,\"contents\":{\"pos1\":263,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6958,\"sequenceNumber\":6959,\"timestamp\":1565138795425,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1284,\"contents\":{\"pos1\":263,\"pos2\":264,\"type\":1},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6961,\"sequenceNumber\":6962,\"timestamp\":1565138795878,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1285,\"contents\":{\"pos1\":263,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6962,\"sequenceNumber\":6963,\"timestamp\":1565138795972,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1287,\"contents\":{\"pos1\":264,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6964,\"sequenceNumber\":6965,\"timestamp\":1565138796019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1290,\"contents\":{\"pos1\":265,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6966,\"sequenceNumber\":6967,\"timestamp\":1565138796238,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1292,\"contents\":{\"pos1\":266,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6968,\"sequenceNumber\":6969,\"timestamp\":1565138796269,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1296,\"contents\":{\"pos1\":266,\"pos2\":267,\"type\":1},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6971,\"sequenceNumber\":6972,\"timestamp\":1565138796956,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1298,\"contents\":{\"pos1\":265,\"pos2\":266,\"type\":1},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6973,\"sequenceNumber\":6974,\"timestamp\":1565138797113,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1299,\"contents\":{\"pos1\":265,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6974,\"sequenceNumber\":6975,\"timestamp\":1565138797363,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1301,\"contents\":{\"pos1\":266,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6976,\"sequenceNumber\":6977,\"timestamp\":1565138797505,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1303,\"contents\":{\"pos1\":267,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6978,\"sequenceNumber\":6979,\"timestamp\":1565138797615,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1305,\"contents\":{\"pos1\":268,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6980,\"sequenceNumber\":6981,\"timestamp\":1565138797693,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1307,\"contents\":{\"pos1\":269,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6982,\"sequenceNumber\":6983,\"timestamp\":1565138797849,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1309,\"contents\":{\"pos1\":270,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6984,\"sequenceNumber\":6985,\"timestamp\":1565138797927,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1311,\"contents\":{\"pos1\":271,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6986,\"sequenceNumber\":6987,\"timestamp\":1565138798005,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1313,\"contents\":{\"pos1\":272,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6988,\"sequenceNumber\":6989,\"timestamp\":1565138798099,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1316,\"contents\":{\"pos1\":273,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6990,\"sequenceNumber\":6991,\"timestamp\":1565138798552,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1318,\"contents\":{\"pos1\":274,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6992,\"sequenceNumber\":6993,\"timestamp\":1565138798693,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1320,\"contents\":{\"pos1\":275,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6994,\"sequenceNumber\":6995,\"timestamp\":1565138798818,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1322,\"contents\":{\"pos1\":276,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6996,\"sequenceNumber\":6997,\"timestamp\":1565138798927,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1325,\"contents\":{\"pos1\":277,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6998,\"sequenceNumber\":6999,\"timestamp\":1565138799271,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\",\"clientSequenceNumber\":1326,\"minimumSequenceNumber\":6949,\"referenceSequenceNumber\":6998,\"sequenceNumber\":7000,\"timestamp\":1565138799271,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_8000_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_8000_0.json
@@ -1,0 +1,827 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":7994,\"sequenceNumber\":8000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\",{\"client\":{\"user\":{\"id\":\"tbltbz15u@example.com}\",\"name\":\"ea8k8mdwsji88sw\",\"email\":\"equ4qd4t8@example.com}\"}},\"sequenceNumber\":862}],[\"ff899238-7fd1-4e6a-8658-57c1744d9de8\",{\"client\":{\"user\":{\"id\":\"b21vt1do7@example.com}\",\"name\":\"15icq0ufp06ytgv\",\"email\":\"kylv8gwx6@example.com}\"}},\"sequenceNumber\":2304}],[\"6518da1c-302c-432c-9c3b-5bf1d212820b\",{\"client\":{\"user\":{\"id\":\"zjb7zxcvv@example.com}\",\"name\":\"1gg6ji8aqhbvokz\",\"email\":\"nr6baygov@example.com}\"}},\"sequenceNumber\":7597}],[\"42e5022b-3faf-4b1f-b29d-951a633ff38f\",{\"client\":{\"user\":{\"id\":\"faxqc43j3@example.com}\",\"name\":\"ah03jn15rkignym\",\"email\":\"4xgxhpxr8@example.com}\"}},\"sequenceNumber\":7991}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1802,\"refSeqNumber\":5058}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1037,\"refSeqNumber\":6394}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}},\"ac4e690b-7f9c-4f9f-9874-f71376e74c1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":4850}},\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":479,\"refSeqNumber\":7339}},\"e580814f-9bff-4c23-84f8-82d2d0fbfacf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5212}},\"b6c7b259-4ce6-4569-8da0-ea9352fe5a13\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6396}},\"74bb59f3-7266-4d81-b01b-6bd34826065c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6427}},\"7873f020-9fcf-477f-a033-6137ccad8567\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":271,\"refSeqNumber\":7525}},\"4ebbf573-c13a-4b7b-8e3b-35a207d1ff36\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1365,\"refSeqNumber\":7664}},\"d102263d-25b2-47ef-bf65-f464bac24cd7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":991,\"refSeqNumber\":7969}},\"42e5022b-3faf-4b1f-b29d-951a633ff38f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7969}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":82,\"chunkLengthChars\":2295,\"totalLengthChars\":2295,\"totalSegmentCount\":82,\"chunkSequenceNumber\":7994,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cb61ac6a-c64a-4e57-a32b-41b6a8010c62\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"upsi35q98h8sr3y2ovzkno4az6e03oh14505oyr0slhv5zf8kdsc6uc1101pfren0lcmehz6ftugtuaijbs9fi9f0tzh54gbaf8lcebu66lum9xjotefjo3om9svsb19u8bd42bij3ve439n8byzc83qm4nh9muvv3mv9xc3ah18fzsgegsepwl68ix9t56endm55uf9a9k92foufphnscixikytqjub2zjbhirkhqf37b0abwadhjvrs6y91b7m6vyf7ldt0tg0osyt9v5hz2p5keq06ixf0xp06viw0z5vs0mcpyhi2yauffmf7w\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e20b09cb-ce09-4e89-a176-7131f168bc46\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f6cd52c-01a6-4756-889d-c081c68c5924\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtlaj74902h15qc9zp7c61habh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz\",{\"text\":\"bfjvri292260\",\"props\":{}},\"9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1f3b0660-b051-4f98-82a0-add988e9c06b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"qfnm61\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"9eezdygjrjo9ehsp3ftcwg9ksnn09ugjwkk8m9avuzop6guiqhetlvjrap38afj7dz48ym7d15t98\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2928499d-3d81-4b71-b6c9-6768a582cd21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b4987d4e-f4ba-412f-a27f-a765ce1b54ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmd\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},\"68fmjwvpy\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a97aa62b-2010-439c-a055-2f3aa8d96f82\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"5qes3btpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"1e0q87x9fzhxafshbkeipoytcph14pe5flhv0gr1d9whxy2ayoth1yhxtw79ci4ewm1fm396gia53h8vsaez7hgindc7asggzcse0hgdzfu9qy3tc9puxmvl2hns8v62m65ewumh0joifs3i9ipisbx9zdtxvc8rn7lgm7ojd8gx6ic8z4b7spqh53vch7d0g6m4p9h2x5k6vje\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a13e1613-bf89-47b0-b074-1215c5947ab2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList29\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":7994,\"totalLength\":2295,\"totalSegmentCount\":82}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":7994,\"referenceSequenceNumber\":-1,\"sequenceNumber\":8000,\"timestamp\":1565139143549,\"type\":\"leave\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_8858_0.json
+++ b/snapshotTestContent/HotBugs8/src_snapshots/0.59.3000/snapshot_8858_0.json
@@ -1,0 +1,854 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":8855,\"sequenceNumber\":8858,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"5c980e8e-e18f-4299-a061-c82bd6554e60\",{\"client\":{\"user\":{\"id\":\"8yhbadlps@example.com}\",\"name\":\"8zacz2on5zrx297\",\"email\":\"e7d4nt50g@example.com}\"}},\"sequenceNumber\":8849}],[\"64468429-808c-4381-8c57-05fedc60e686\",{\"client\":{\"user\":{\"id\":\"sxtbmq8yd@example.com}\",\"name\":\"u37egiew7fkzpj4\",\"email\":\"6m0jvu5ey@example.com}\"}},\"sequenceNumber\":8852}],[\"8c0e9596-89b2-4762-9f34-d51d26b22c32\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"e1vmtaqlm@example.com}\",\"name\":\"6klp2or4y3pemjv\",\"email\":\"xv5nyu8ru@example.com}\"}},\"sequenceNumber\":8858}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "applicationServices",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/application-services\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "augloop",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/augloop\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/a2b2dc01-6191-4f19-a07c-2384baac6b03\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a2b2dc01-6191-4f19-a07c-2384baac6b03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}},\"versions\":[{\"sequenceNumber\":53,\"value\":{\"type\":\"Plain\",\"value\":\"45726b48-c467-4dc2-ab8e-2866e2524273\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/635c7157-f05c-4eba-9459-b411722bc88d\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/cbda7362-6a7f-4c0f-bcdc-4500aafc8d03\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/329170e4-9322-44dd-a55f-fc4fac3c7e8d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/30bac3f4-51a0-4144-b1e0-be3cf2f276ab\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/7f5008bd-e30b-4f12-8e1e-f0cb6700c306\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "635c7157-f05c-4eba-9459-b411722bc88d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"2a088f1c-ba22-45b3-bd22-202c9640b40f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":0}},\"45726b48-c467-4dc2-ab8e-2866e2524273\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":432}},\"2228e7f7-3ddb-4be0-bcd3-be525401ac6d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":150,\"refSeqNumber\":434}},\"580238b4-4492-4662-b82d-81cf2f015ae9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":435}},\"3582e31f-2d9b-4a89-915f-7d7669281268\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":451}},\"7322f213-09ef-455a-9172-60883c240410\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":458}},\"a8d0a78f-b794-4c3f-a450-5591d666af47\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":585,\"refSeqNumber\":1310}},\"71da2dc3-b1ac-42ca-ae4f-77eb996be59e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":596}},\"0a0e7c44-f2b9-4a57-82fa-5b6cc5336145\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":733}},\"2a0a6c45-7f01-41c4-b553-46b9b6c6d546\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":860}},\"49563a70-1fee-48fb-8208-d5754709e155\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1180}},\"31852186-054d-4110-bbdc-bd266e012ae3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1192}},\"3fddbc34-31fd-43d5-83b1-44833a1fec62\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1341}},\"776486ca-3ee4-41d1-91c3-ae33424bf0e5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1802,\"refSeqNumber\":5058}},\"93a78da3-e659-4e07-b8a7-5262f7ea4ccd\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1492}},\"54f867ac-5efc-47c1-9cb3-8a4dc20b31e9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2289}},\"ff899238-7fd1-4e6a-8658-57c1744d9de8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1037,\"refSeqNumber\":6394}},\"e4fb224b-8087-4af4-9851-9c2dbd4273f4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3501}},\"ac4e690b-7f9c-4f9f-9874-f71376e74c1f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":4850}},\"98de5c83-6cf0-4fc1-8ca7-9ceabade87de\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":479,\"refSeqNumber\":7339}},\"e580814f-9bff-4c23-84f8-82d2d0fbfacf\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5212}},\"b6c7b259-4ce6-4569-8da0-ea9352fe5a13\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6396}},\"74bb59f3-7266-4d81-b01b-6bd34826065c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6427}},\"7873f020-9fcf-477f-a033-6137ccad8567\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":271,\"refSeqNumber\":7525}},\"4ebbf573-c13a-4b7b-8e3b-35a207d1ff36\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1365,\"refSeqNumber\":7664}},\"d102263d-25b2-47ef-bf65-f464bac24cd7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":991,\"refSeqNumber\":7969}},\"42e5022b-3faf-4b1f-b29d-951a633ff38f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7969}},\"f2ac8e38-d4a9-4c8a-90c8-aa5292bf16f0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":37,\"pos\":132,\"refSeqNumber\":7969}},\"7d963c0b-02a8-4e3e-b1f3-91c996670562\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":506,\"pos\":454,\"refSeqNumber\":8025}},\"960c25c2-8bbe-46b1-9450-0fc1312e7d79\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1962,\"refSeqNumber\":8102}},\"eed7384d-9b7d-440b-8418-4b87dd7abb07\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1955,\"refSeqNumber\":8180}},\"3dc710be-c210-470f-a8b1-32de84db37c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2122,\"refSeqNumber\":8221}},\"8bd3b781-ed9f-4f88-ab4c-6645059417d4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":2199,\"pos\":0,\"refSeqNumber\":8467}},\"21262178-4d14-418a-8567-0568839a0a6e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":453,\"refSeqNumber\":8499}},\"abfc4a8f-09d3-4b1f-9d6d-c3f12d66b7dc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8576}},\"3a1c08a7-360a-49ef-a870-9e851d85fdd4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":546,\"refSeqNumber\":8696}},\"49d14f85-a4a4-40e5-9b56-76ab1b1117f7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":549,\"refSeqNumber\":8711}},\"3faabfb6-21a9-4613-8c84-07fcc75a02f3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8816}},\"64468429-808c-4381-8c57-05fedc60e686\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":8836}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cbda7362-6a7f-4c0f-bcdc-4500aafc8d03",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "329170e4-9322-44dd-a55f-fc4fac3c7e8d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":78,\"chunkLengthChars\":2201,\"totalLengthChars\":2201,\"totalSegmentCount\":78,\"chunkSequenceNumber\":8855,\"segmentTexts\":[\"vr2ylvt90eahyamtwi1ix5uxijrsz0l7adza\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34b30114-ef9a-4e0a-bd78-fa5d3a3bb84e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"sx71bxgyt58qceeq3rg5t9cdck9jtkg7l2s1xce1um9wb9cfm9kvay1bvocrlqxl1ara60khpd54agmjbzyq3qnhc52tpzm\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3333a18f-899f-4543-8c47-73329b48554f\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cb61ac6a-c64a-4e57-a32b-41b6a8010c62\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},\"upsi35q98h8sr3y2ovzkno4az6e03oh14505oyr0slhv5zf8kdsc6uc1101pfren0lcmehz6ftugtuaijbs9fi9f0tzh54gbaf8lcebu66lum9xjotefjo3om9svsb19u8bd42bij3ve439n8byzc83qm4nh9muvv3mv9xc3ah18fzsgegsepwl68ix9t56endm55uf9a9k92foufphnscixikytqjub2zjbhirkhqf37b0abwadhjvrs6y91b7m6vyf7ldt0tg0osyt9v5hz2p5keq06ixf0xp06viw0z5vs0mcpyhi2yauffmf7w\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e20b09cb-ce09-4e89-a176-7131f168bc46\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f6cd52c-01a6-4756-889d-c081c68c5924\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"m8mc24ixlf4a6o9vzk2npm13uotldxnxbodvmg5h07v0igndeeqk\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d6d4f690-fc70-40ce-add0-28a4ac8aa715\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"p97i3mge74bt\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":true}},{\"text\":\"a5yy5lodtlaj74902h15qc9zp7c61habh699yqnfb9ruvg6hv4b4u8s6fptl5\",\"props\":{\"{00000000-0000-0836-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d0ce737-ff85-4b40-b7db-b9597cb494f5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":true,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"o16cuyrksnue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"wuujdwubz\",{\"text\":\"bfjvri292260\",\"props\":{}},\"9mar8c9zoob9gkdp6ojgt0gqtcdpmsps5i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1c7d7e14-bb3f-4e57-aa84-eff11f2f916b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"italic\":false}}},{\"text\":\"g9j4v645uyouvpq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3fzq4n13br2bkk8wv8qj6qi3x5we5leg27dfuezgxg22jjrx3sc63q193gqiygc1hjzzgjizucrqq3jfpn39zn9m3kh0lqz2ckajjrk4p5bs6v9wa9qf71dz1lzjm2kb92tu4r5w3s7ku2sc2z2jr3e2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"82424625-925f-43bc-80e2-56d45f1761d3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"njbplz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"vqywptsm1beixk0q9z794suvx1gn4he59tne1jfb6m2eh26xpdtkqk7fqiiy172niorwn77r70ocexxlem\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"89cbe02a-fa62-4b8b-a11d-bbbd2f46f9e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"1jwns9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"swn6slg4podhnhw36t2q3e873ugljgjmx1xrwgfuy6jwg1hxmh5pcjdinzz24mt2wevvhe2l9m0bndht6iuxutf44fppcd22rjs5tiowv06f0wo2lf5urzu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bf1bd91f-f402-42ee-b9c5-8c1a02679bd6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"731677\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"3q1kbmzg4rxitp1bcb8907n2u001zzcrupwhdgijrcaocsn2v1r347pm0jprbv7jbkbs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cae0a6d5-448f-438d-83be-d4faa2c5ee6c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"raefai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"5rpicpe9wxkbb630dbs58svomlvyzyngj6ojl25oo81abqrc5iwisbub5e9z00z\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a2f4a66-0a98-4702-bc37-021b2324966c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"text\":\"4qkd1d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"fkh85bv9w5frb9o82xbdye3vvgasbga2oay6gefb0lml0yzuf1s2hl8i5aw75d3ib\",{\"text\":\"2gqdz9ogn1tr5deosunmtc6mvisy26ag2geh7cari6ryv7w6mct\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3070a597-1363-4652-904b-2e8d88542353\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList49\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b4987d4e-f4ba-412f-a27f-a765ce1b54ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"ii3ac0czotd0vz6s1iwlmd68fmjwvpy\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85d9aa4a-4549-4c7e-a885-a719f1bcc8b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"rywhttxgy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"vovh31yfvn0njedykt3uvjo0oht3l6pqjqgkewluf4bbd779uud03viqe8upip375idldgy11jrtnzi8nqj6n6atj8w4jyb9scx6deop0xdeu6o6v8ixtekomcg0ewertdlr8y5gpaoccby3i5n69a0xnn3go0ug1f90v1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f023f7da-d724-4e0f-a0b6-16f9b1851e8e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tgx5v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"zv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"agnej9yqk2jdpn751xmfwo3ddxfmuh0vo3j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"wsk2b706ynmyvftqpa9jykdrph\",{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"ya26kly\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"7uvegri1crt642st0a4sp920lko6jd8seixjn93c38ase7hdv3enibqgfbjhp7uca77btmewz28r4r61i891t7ojsieekhilrmj27qwkodvl2nndrhybtgsp\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8cfa3c3-b5be-4802-8ab9-57dc28190da0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"zle3vtnckonhjyxct\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"hf8ei0v8nht8a4wh40uhafoyvox6ppwwh8ewh9mnwh6uw001bwg601yuc6qqsc6nv9zra55vt0lmmr576t2bwux8rorq04voqb1n0u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6810e7a0-8e7a-4440-8815-8ad6495ad541\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"text\":\"cfqt2f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"n5b29g6vz00sxyi3g7us7dqx4nmgsfpkgltx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"244b0ced-2224-4760-9e1b-5e965d98910c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-93\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"734771a9-af41-4470-8143-c72031212335\",\"ItemType\":\"Paragraph\",\"Properties\":{\"italic\":false}}},{\"text\":\"5r2t6ip987hk4brwtnmk5by0xw7vjhmgs6\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8192d422-1ab6-462d-9255-e55d9cc82318\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"l40aupjdi\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"arev7uvdxyttb780ros5fddxjm8w8zv5r9xuzbjtcskg8otgxfaq3w3d7vvfwdyj99frcqpi6853754p8db8k6emdgvl2urkjdbzlyy4jmtl7nch33jqrrd43mljg5jfc5fqnpeo88iz1fzroc9cx44imrsc6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"470fc9e9-0f2e-4c0a-802d-125e45063bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList112\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8528c393-24bf-482b-8a9a-f64308b45b03\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"o900alni7n2bfli0g32pn21hqjdhypvzx93m1efw9gdou86w09gixi\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fc44cf4-5233-424f-850b-a47614d25789\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"wwcgy88\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"1feoqc5abtjyduhg9gdh8epgezx7dhwribumi4jyg0tg7sa9t7nrck48\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fb029d37-4650-4f20-93b1-d0ad16994e16\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f3ffc054-bbbf-490e-80e1-7c1c612200fd\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":8855,\"totalLength\":2201,\"totalSegmentCount\":78}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "30bac3f4-51a0-4144-b1e0-be3cf2f276ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d5c8f74e-9e08-445a-aef2-437590c8f1e8\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5c441940-5162-4687-90f2-d8d7aea78e95\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9643075c-3eb7-4d34-a24f-fe290c5bfb91\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3fc81af-bbd6-44e4-afd2-4b070d0d8480\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/eb9fa2e4-0071-44f4-9887-4ba86ea36a6c\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a058c256-a8ac-4a3a-a8c8-85b2873e2843\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8653e79c-21b6-4c15-b86d-f303f37624ed\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d5c8f74e-9e08-445a-aef2-437590c8f1e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5c441940-5162-4687-90f2-d8d7aea78e95",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9643075c-3eb7-4d34-a24f-fe290c5bfb91",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3fc81af-bbd6-44e4-afd2-4b070d0d8480",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eb9fa2e4-0071-44f4-9887-4ba86ea36a6c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a058c256-a8ac-4a3a-a8c8-85b2873e2843",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8653e79c-21b6-4c15-b86d-f303f37624ed",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7f5008bd-e30b-4f12-8e1e-f0cb6700c306",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList49\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6318dcf7-7e01-4f4f-bd15-70f23e46fa38\"}},\"listRegistryList-93\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/32061cc8-859e-4258-8449-261b3f270524\"}},\"listRegistryList29\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f7eee80a-031f-417b-b7e7-4a87aa32850f\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/442c14d9-13b3-47d1-8df1-60c4cc76f2c6\"}},\"listRegistryList112\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df305acc-645e-4eba-acf2-c2ad62c6af21\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6318dcf7-7e01-4f4f-bd15-70f23e46fa38",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList49\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "32061cc8-859e-4258-8449-261b3f270524",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-93\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f7eee80a-031f-417b-b7e7-4a87aa32850f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList29\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "442c14d9-13b3-47d1-8df1-60c4cc76f2c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df305acc-645e-4eba-acf2-c2ad62c6af21",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList112\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":8855,\"referenceSequenceNumber\":-1,\"sequenceNumber\":8858,\"timestamp\":1565148898593,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,710 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":930,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"fa52be86-9f26-4108-8211-4d6b1edbd202\",{\"client\":{\"user\":{\"id\":\"fmv7o3421@example.com}\",\"name\":\"1rygky6awi6fx3w\",\"email\":\"xqvznu041@example.com}\"}},\"sequenceNumber\":409}],[\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",{\"client\":{\"user\":{\"id\":\"gk7a3hu6l@example.com}\",\"name\":\"yfhuzrc2bjnwpq1\",\"email\":\"xrilcd0vx@example.com}\"}},\"sequenceNumber\":410}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":444,\"refSeqNumber\":997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":35,\"chunkLengthChars\":736,\"totalLengthChars\":736,\"totalSegmentCount\":35,\"chunkSequenceNumber\":930,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":930,\"totalLength\":736,\"totalSegmentCount\":35}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":580,\"contents\":{\"pos1\":318,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":939,\"sequenceNumber\":940,\"timestamp\":1562604680812,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":582,\"contents\":{\"pos1\":319,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":941,\"sequenceNumber\":942,\"timestamp\":1562604680937,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":584,\"contents\":{\"pos1\":320,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":943,\"sequenceNumber\":944,\"timestamp\":1562604680968,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":586,\"contents\":{\"pos1\":321,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":945,\"sequenceNumber\":946,\"timestamp\":1562604681062,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":588,\"contents\":{\"pos1\":322,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":947,\"sequenceNumber\":948,\"timestamp\":1562604681296,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":592,\"contents\":{\"pos1\":322,\"pos2\":323,\"type\":1},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":950,\"sequenceNumber\":951,\"timestamp\":1562604681766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":594,\"contents\":{\"pos1\":322,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":951,\"sequenceNumber\":952,\"timestamp\":1562604682156,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":596,\"contents\":{\"pos1\":324,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":953,\"sequenceNumber\":954,\"timestamp\":1562604682422,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":599,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}},\"relativePos1\":{\"id\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"before\":true},\"relativePos2\":{\"id\":\"b1935675-46fd-452c-a931-88f4e2952bb5\"},\"type\":2},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":955,\"sequenceNumber\":956,\"timestamp\":1562604682797,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":601,\"contents\":{\"pos1\":324,\"seg\":{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":956,\"sequenceNumber\":957,\"timestamp\":1562604683219,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":604,\"contents\":{\"pos1\":436,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e9d158bc-e69f-41d2-afbd-81868cd6a1b7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":958,\"sequenceNumber\":959,\"timestamp\":1562604683672,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":607,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e9d158bc-e69f-41d2-afbd-81868cd6a1b7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false,\"highlight\":\"\"}},\"relativePos1\":{\"id\":\"e9d158bc-e69f-41d2-afbd-81868cd6a1b7\",\"before\":true},\"relativePos2\":{\"id\":\"e9d158bc-e69f-41d2-afbd-81868cd6a1b7\"},\"type\":2},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":960,\"sequenceNumber\":961,\"timestamp\":1562604684000,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":609,\"contents\":{\"pos1\":436,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":961,\"sequenceNumber\":962,\"timestamp\":1562604685235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":611,\"contents\":{\"pos1\":437,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":963,\"sequenceNumber\":964,\"timestamp\":1562604685250,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":613,\"contents\":{\"pos1\":438,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":965,\"sequenceNumber\":966,\"timestamp\":1562604685344,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":615,\"contents\":{\"pos1\":439,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":967,\"sequenceNumber\":968,\"timestamp\":1562604685375,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":617,\"contents\":{\"pos1\":440,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":969,\"sequenceNumber\":970,\"timestamp\":1562604685547,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":619,\"contents\":{\"pos1\":441,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":971,\"sequenceNumber\":972,\"timestamp\":1562604685579,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":621,\"contents\":{\"pos1\":442,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":973,\"sequenceNumber\":974,\"timestamp\":1562604685703,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":623,\"contents\":{\"pos1\":443,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":975,\"sequenceNumber\":976,\"timestamp\":1562604685766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":625,\"contents\":{\"pos1\":444,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":977,\"sequenceNumber\":978,\"timestamp\":1562604685875,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":627,\"contents\":{\"pos1\":445,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":979,\"sequenceNumber\":980,\"timestamp\":1562604685922,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":629,\"contents\":{\"pos1\":446,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":981,\"sequenceNumber\":982,\"timestamp\":1562604686016,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":631,\"contents\":{\"pos1\":436,\"pos2\":447,\"type\":1},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":983,\"sequenceNumber\":984,\"timestamp\":1562604686235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":633,\"contents\":{\"pos1\":436,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":984,\"sequenceNumber\":985,\"timestamp\":1562604686438,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":635,\"contents\":{\"pos1\":437,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":986,\"sequenceNumber\":987,\"timestamp\":1562604686578,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":637,\"contents\":{\"pos1\":438,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":988,\"sequenceNumber\":989,\"timestamp\":1562604686610,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":639,\"contents\":{\"pos1\":439,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":990,\"sequenceNumber\":991,\"timestamp\":1562604686750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":641,\"contents\":{\"pos1\":440,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":992,\"sequenceNumber\":993,\"timestamp\":1562604686766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":643,\"contents\":{\"pos1\":441,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":994,\"sequenceNumber\":995,\"timestamp\":1562604686875,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":645,\"contents\":{\"pos1\":442,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":996,\"sequenceNumber\":997,\"timestamp\":1562604686985,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":647,\"contents\":{\"pos1\":443,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1562604687078,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":648,\"minimumSequenceNumber\":930,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1562604687078,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,710 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1689,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"fa52be86-9f26-4108-8211-4d6b1edbd202\",{\"client\":{\"user\":{\"id\":\"fmv7o3421@example.com}\",\"name\":\"1rygky6awi6fx3w\",\"email\":\"xqvznu041@example.com}\"}},\"sequenceNumber\":409}],[\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",{\"client\":{\"user\":{\"id\":\"gk7a3hu6l@example.com}\",\"name\":\"yfhuzrc2bjnwpq1\",\"email\":\"xrilcd0vx@example.com}\"}},\"sequenceNumber\":410}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":753,\"refSeqNumber\":1996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":53,\"chunkLengthChars\":1064,\"totalLengthChars\":1064,\"totalSegmentCount\":53,\"chunkSequenceNumber\":1689,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnff\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha0x8gqzg7jocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1689,\"totalLength\":1064,\"totalSegmentCount\":53}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1412,\"contents\":{\"pos1\":646,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1690,\"sequenceNumber\":1691,\"timestamp\":1562606926656,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1416,\"contents\":{\"pos1\":646,\"pos2\":647,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1693,\"sequenceNumber\":1694,\"timestamp\":1562606927062,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1417,\"contents\":{\"pos1\":646,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1694,\"sequenceNumber\":1695,\"timestamp\":1562606927312,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1419,\"contents\":{\"pos1\":647,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1696,\"sequenceNumber\":1697,\"timestamp\":1562606927484,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1421,\"contents\":{\"pos1\":648,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1698,\"sequenceNumber\":1699,\"timestamp\":1562606927609,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1423,\"contents\":{\"pos1\":649,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1700,\"sequenceNumber\":1701,\"timestamp\":1562606927703,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1425,\"contents\":{\"pos1\":650,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1702,\"sequenceNumber\":1703,\"timestamp\":1562606927750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1427,\"contents\":{\"pos1\":651,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1704,\"sequenceNumber\":1705,\"timestamp\":1562606927875,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1429,\"contents\":{\"pos1\":652,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1706,\"sequenceNumber\":1707,\"timestamp\":1562606928000,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1431,\"contents\":{\"pos1\":653,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1708,\"sequenceNumber\":1709,\"timestamp\":1562606928031,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1433,\"contents\":{\"pos1\":654,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1710,\"sequenceNumber\":1711,\"timestamp\":1562606928093,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1435,\"contents\":{\"pos1\":655,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1712,\"sequenceNumber\":1713,\"timestamp\":1562606928156,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1437,\"contents\":{\"pos1\":656,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1714,\"sequenceNumber\":1715,\"timestamp\":1562606928187,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1439,\"contents\":{\"pos1\":657,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1716,\"sequenceNumber\":1717,\"timestamp\":1562606928297,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1441,\"contents\":{\"pos1\":658,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1718,\"sequenceNumber\":1719,\"timestamp\":1562606928422,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1443,\"contents\":{\"pos1\":659,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1720,\"sequenceNumber\":1721,\"timestamp\":1562606928484,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1445,\"contents\":{\"pos1\":660,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1722,\"sequenceNumber\":1723,\"timestamp\":1562606928515,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1447,\"contents\":{\"pos1\":661,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1724,\"sequenceNumber\":1725,\"timestamp\":1562606928656,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1449,\"contents\":{\"pos1\":662,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1726,\"sequenceNumber\":1727,\"timestamp\":1562606928734,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1451,\"contents\":{\"pos1\":663,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1728,\"sequenceNumber\":1729,\"timestamp\":1562606928937,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1453,\"contents\":{\"pos1\":664,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1730,\"sequenceNumber\":1731,\"timestamp\":1562606929046,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1455,\"contents\":{\"pos1\":665,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1732,\"sequenceNumber\":1733,\"timestamp\":1562606929125,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1457,\"contents\":{\"pos1\":666,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1734,\"sequenceNumber\":1735,\"timestamp\":1562606929203,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1460,\"contents\":{\"pos1\":667,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1736,\"sequenceNumber\":1737,\"timestamp\":1562606929703,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1462,\"contents\":{\"pos1\":668,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1738,\"sequenceNumber\":1739,\"timestamp\":1562606929765,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1464,\"contents\":{\"pos1\":669,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1740,\"sequenceNumber\":1741,\"timestamp\":1562606929812,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1466,\"contents\":{\"pos1\":670,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1742,\"sequenceNumber\":1743,\"timestamp\":1562606929890,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1468,\"contents\":{\"pos1\":671,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1744,\"sequenceNumber\":1745,\"timestamp\":1562606929921,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1470,\"contents\":{\"pos1\":672,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1746,\"sequenceNumber\":1747,\"timestamp\":1562606930000,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1472,\"contents\":{\"pos1\":673,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1748,\"sequenceNumber\":1749,\"timestamp\":1562606930031,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1474,\"contents\":{\"pos1\":674,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1750,\"sequenceNumber\":1751,\"timestamp\":1562606930125,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1476,\"contents\":{\"pos1\":675,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1752,\"sequenceNumber\":1753,\"timestamp\":1562606930156,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1478,\"contents\":{\"pos1\":676,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1754,\"sequenceNumber\":1755,\"timestamp\":1562606930250,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1480,\"contents\":{\"pos1\":677,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1756,\"sequenceNumber\":1757,\"timestamp\":1562606930281,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1482,\"contents\":{\"pos1\":678,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1758,\"sequenceNumber\":1759,\"timestamp\":1562606930375,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1484,\"contents\":{\"pos1\":679,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1760,\"sequenceNumber\":1761,\"timestamp\":1562606930421,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1486,\"contents\":{\"pos1\":680,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1762,\"sequenceNumber\":1763,\"timestamp\":1562606930453,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1488,\"contents\":{\"pos1\":681,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1764,\"sequenceNumber\":1765,\"timestamp\":1562606930531,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1490,\"contents\":{\"pos1\":682,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1766,\"sequenceNumber\":1767,\"timestamp\":1562606930600,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1492,\"contents\":{\"pos1\":683,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1768,\"sequenceNumber\":1769,\"timestamp\":1562606930610,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1494,\"contents\":{\"pos1\":684,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1770,\"sequenceNumber\":1771,\"timestamp\":1562606930626,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1496,\"contents\":{\"pos1\":685,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1772,\"sequenceNumber\":1773,\"timestamp\":1562606930704,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1498,\"contents\":{\"pos1\":686,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1774,\"sequenceNumber\":1775,\"timestamp\":1562606930766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1500,\"contents\":{\"pos1\":687,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1776,\"sequenceNumber\":1777,\"timestamp\":1562606930829,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1502,\"contents\":{\"pos1\":688,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1778,\"sequenceNumber\":1779,\"timestamp\":1562606930938,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1504,\"contents\":{\"pos1\":689,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1780,\"sequenceNumber\":1781,\"timestamp\":1562606931095,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1506,\"contents\":{\"pos1\":690,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1782,\"sequenceNumber\":1783,\"timestamp\":1562606931173,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1509,\"contents\":{\"pos1\":691,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1784,\"sequenceNumber\":1785,\"timestamp\":1562606931891,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1513,\"contents\":{\"pos1\":691,\"pos2\":692,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1787,\"sequenceNumber\":1788,\"timestamp\":1562606932360,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1515,\"contents\":{\"pos1\":690,\"pos2\":691,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1789,\"sequenceNumber\":1790,\"timestamp\":1562606932485,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1517,\"contents\":{\"pos1\":689,\"pos2\":690,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1791,\"sequenceNumber\":1792,\"timestamp\":1562606932719,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1518,\"contents\":{\"pos1\":689,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1792,\"sequenceNumber\":1793,\"timestamp\":1562606932908,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1520,\"contents\":{\"pos1\":691,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1794,\"sequenceNumber\":1795,\"timestamp\":1562606933079,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1523,\"contents\":{\"pos1\":691,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1796,\"sequenceNumber\":1797,\"timestamp\":1562606933376,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1525,\"contents\":{\"pos1\":692,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1798,\"sequenceNumber\":1799,\"timestamp\":1562606933536,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1527,\"contents\":{\"pos1\":693,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1800,\"sequenceNumber\":1801,\"timestamp\":1562606933567,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1529,\"contents\":{\"pos1\":694,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1802,\"sequenceNumber\":1803,\"timestamp\":1562606933646,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1533,\"contents\":{\"pos1\":694,\"pos2\":695,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1805,\"sequenceNumber\":1806,\"timestamp\":1562606933911,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1534,\"contents\":{\"pos1\":694,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1806,\"sequenceNumber\":1807,\"timestamp\":1562606933989,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1536,\"contents\":{\"pos1\":695,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1808,\"sequenceNumber\":1809,\"timestamp\":1562606934083,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1538,\"contents\":{\"pos1\":696,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1810,\"sequenceNumber\":1811,\"timestamp\":1562606934114,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1540,\"contents\":{\"pos1\":697,\"seg\":{\"text\":\"5o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1812,\"sequenceNumber\":1813,\"timestamp\":1562606934255,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1542,\"contents\":{\"pos1\":699,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1814,\"sequenceNumber\":1815,\"timestamp\":1562606934333,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1544,\"contents\":{\"pos1\":700,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1816,\"sequenceNumber\":1817,\"timestamp\":1562606934411,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1546,\"contents\":{\"pos1\":701,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1818,\"sequenceNumber\":1819,\"timestamp\":1562606934443,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1548,\"contents\":{\"pos1\":702,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1820,\"sequenceNumber\":1821,\"timestamp\":1562606934505,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1550,\"contents\":{\"pos1\":703,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1822,\"sequenceNumber\":1823,\"timestamp\":1562606934614,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1552,\"contents\":{\"pos1\":698,\"pos2\":704,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1824,\"sequenceNumber\":1825,\"timestamp\":1562606934833,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1555,\"contents\":{\"pos1\":697,\"pos2\":698,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1826,\"sequenceNumber\":1827,\"timestamp\":1562606934989,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1556,\"contents\":{\"pos1\":697,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1827,\"sequenceNumber\":1828,\"timestamp\":1562606935099,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1558,\"contents\":{\"pos1\":698,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1829,\"sequenceNumber\":1830,\"timestamp\":1562606935161,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1560,\"contents\":{\"pos1\":699,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1831,\"sequenceNumber\":1832,\"timestamp\":1562606935255,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1562,\"contents\":{\"pos1\":700,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1833,\"sequenceNumber\":1834,\"timestamp\":1562606935349,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1564,\"contents\":{\"pos1\":701,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1835,\"sequenceNumber\":1836,\"timestamp\":1562606935428,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1566,\"contents\":{\"pos1\":702,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1837,\"sequenceNumber\":1838,\"timestamp\":1562606935521,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1568,\"contents\":{\"pos1\":703,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1839,\"sequenceNumber\":1840,\"timestamp\":1562606935553,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1570,\"contents\":{\"pos1\":704,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1841,\"sequenceNumber\":1842,\"timestamp\":1562606935615,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1572,\"contents\":{\"pos1\":705,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1843,\"sequenceNumber\":1844,\"timestamp\":1562606935740,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1574,\"contents\":{\"pos1\":699,\"pos2\":706,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1845,\"sequenceNumber\":1846,\"timestamp\":1562606935943,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1576,\"contents\":{\"pos1\":699,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1846,\"sequenceNumber\":1847,\"timestamp\":1562606936100,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1578,\"contents\":{\"pos1\":700,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1848,\"sequenceNumber\":1849,\"timestamp\":1562606936179,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1580,\"contents\":{\"pos1\":701,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1850,\"sequenceNumber\":1851,\"timestamp\":1562606936241,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1582,\"contents\":{\"pos1\":702,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1852,\"sequenceNumber\":1853,\"timestamp\":1562606936288,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1584,\"contents\":{\"pos1\":703,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1854,\"sequenceNumber\":1855,\"timestamp\":1562606936398,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1586,\"contents\":{\"pos1\":704,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1856,\"sequenceNumber\":1857,\"timestamp\":1562606936445,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1588,\"contents\":{\"pos1\":705,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1858,\"sequenceNumber\":1859,\"timestamp\":1562606936570,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1590,\"contents\":{\"pos1\":706,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1860,\"sequenceNumber\":1861,\"timestamp\":1562606936633,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1592,\"contents\":{\"pos1\":707,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1862,\"sequenceNumber\":1863,\"timestamp\":1562606936679,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1594,\"contents\":{\"pos1\":708,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1864,\"sequenceNumber\":1865,\"timestamp\":1562606936742,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1596,\"contents\":{\"pos1\":709,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1866,\"sequenceNumber\":1867,\"timestamp\":1562606936773,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1598,\"contents\":{\"pos1\":710,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1868,\"sequenceNumber\":1869,\"timestamp\":1562606936867,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1600,\"contents\":{\"pos1\":711,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1870,\"sequenceNumber\":1871,\"timestamp\":1562606936898,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1602,\"contents\":{\"pos1\":712,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1872,\"sequenceNumber\":1873,\"timestamp\":1562606936961,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1604,\"contents\":{\"pos1\":713,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1874,\"sequenceNumber\":1875,\"timestamp\":1562606937008,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1606,\"contents\":{\"pos1\":714,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1876,\"sequenceNumber\":1877,\"timestamp\":1562606937070,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1608,\"contents\":{\"pos1\":715,\"seg\":{\"text\":\"gz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1878,\"sequenceNumber\":1879,\"timestamp\":1562606937195,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1610,\"contents\":{\"pos1\":717,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1880,\"sequenceNumber\":1881,\"timestamp\":1562606937242,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1612,\"contents\":{\"pos1\":718,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1882,\"sequenceNumber\":1883,\"timestamp\":1562606937289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1614,\"contents\":{\"pos1\":719,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1884,\"sequenceNumber\":1885,\"timestamp\":1562606937352,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1616,\"contents\":{\"pos1\":720,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1886,\"sequenceNumber\":1887,\"timestamp\":1562606937430,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1618,\"contents\":{\"pos1\":721,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1888,\"sequenceNumber\":1889,\"timestamp\":1562606937541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1620,\"contents\":{\"pos1\":722,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1890,\"sequenceNumber\":1891,\"timestamp\":1562606937603,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1622,\"contents\":{\"pos1\":723,\"seg\":{\"text\":\"bd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1892,\"sequenceNumber\":1893,\"timestamp\":1562606937681,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1624,\"contents\":{\"pos1\":725,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1894,\"sequenceNumber\":1895,\"timestamp\":1562606937775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1626,\"contents\":{\"pos1\":726,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1896,\"sequenceNumber\":1897,\"timestamp\":1562606937822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1628,\"contents\":{\"pos1\":727,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1898,\"sequenceNumber\":1899,\"timestamp\":1562606937900,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1630,\"contents\":{\"pos1\":728,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1900,\"sequenceNumber\":1901,\"timestamp\":1562606937978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1632,\"contents\":{\"pos1\":729,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1902,\"sequenceNumber\":1903,\"timestamp\":1562606938056,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1634,\"contents\":{\"pos1\":724,\"pos2\":730,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1904,\"sequenceNumber\":1905,\"timestamp\":1562606938275,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1636,\"contents\":{\"pos1\":723,\"pos2\":724,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1906,\"sequenceNumber\":1907,\"timestamp\":1562606938431,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1637,\"contents\":{\"pos1\":723,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1907,\"sequenceNumber\":1908,\"timestamp\":1562606938541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1639,\"contents\":{\"pos1\":724,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1909,\"sequenceNumber\":1910,\"timestamp\":1562606938650,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1641,\"contents\":{\"pos1\":725,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1911,\"sequenceNumber\":1912,\"timestamp\":1562606938697,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1643,\"contents\":{\"pos1\":726,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1913,\"sequenceNumber\":1914,\"timestamp\":1562606938775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1645,\"contents\":{\"pos1\":727,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1915,\"sequenceNumber\":1916,\"timestamp\":1562606938869,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1647,\"contents\":{\"pos1\":728,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1917,\"sequenceNumber\":1918,\"timestamp\":1562606938994,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1649,\"contents\":{\"pos1\":729,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1919,\"sequenceNumber\":1920,\"timestamp\":1562606939088,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1651,\"contents\":{\"pos1\":730,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1921,\"sequenceNumber\":1922,\"timestamp\":1562606939150,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1653,\"contents\":{\"pos1\":731,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1923,\"sequenceNumber\":1924,\"timestamp\":1562606939197,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1655,\"contents\":{\"pos1\":732,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1925,\"sequenceNumber\":1926,\"timestamp\":1562606939291,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1657,\"contents\":{\"pos1\":733,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1927,\"sequenceNumber\":1928,\"timestamp\":1562606939369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1659,\"contents\":{\"pos1\":734,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1929,\"sequenceNumber\":1930,\"timestamp\":1562606939431,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1662,\"contents\":{\"pos1\":735,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1931,\"sequenceNumber\":1932,\"timestamp\":1562606939697,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1664,\"contents\":{\"pos1\":736,\"seg\":{\"text\":\"x\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1933,\"sequenceNumber\":1934,\"timestamp\":1562606939838,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1666,\"contents\":{\"pos1\":737,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1935,\"sequenceNumber\":1936,\"timestamp\":1562606939900,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1668,\"contents\":{\"pos1\":738,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1937,\"sequenceNumber\":1938,\"timestamp\":1562606939978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1670,\"contents\":{\"pos1\":739,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1939,\"sequenceNumber\":1940,\"timestamp\":1562606940056,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1673,\"contents\":{\"pos1\":740,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1941,\"sequenceNumber\":1942,\"timestamp\":1562606940775,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1676,\"contents\":{\"pos1\":741,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1943,\"sequenceNumber\":1944,\"timestamp\":1562606941478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1678,\"contents\":{\"pos1\":742,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1945,\"sequenceNumber\":1946,\"timestamp\":1562606941572,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1680,\"contents\":{\"pos1\":743,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1947,\"sequenceNumber\":1948,\"timestamp\":1562606941651,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1683,\"contents\":{\"pos1\":740,\"pos2\":744,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1949,\"sequenceNumber\":1950,\"timestamp\":1562606942167,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1684,\"contents\":{\"pos1\":735,\"pos2\":740,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1950,\"sequenceNumber\":1951,\"timestamp\":1562606942292,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1686,\"contents\":{\"pos1\":735,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1951,\"sequenceNumber\":1952,\"timestamp\":1562606942495,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1688,\"contents\":{\"pos1\":736,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1953,\"sequenceNumber\":1954,\"timestamp\":1562606942620,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1690,\"contents\":{\"pos1\":737,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1955,\"sequenceNumber\":1956,\"timestamp\":1562606942683,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1692,\"contents\":{\"pos1\":738,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1957,\"sequenceNumber\":1958,\"timestamp\":1562606942761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1694,\"contents\":{\"pos1\":739,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1959,\"sequenceNumber\":1960,\"timestamp\":1562606942855,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1696,\"contents\":{\"pos1\":740,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1961,\"sequenceNumber\":1962,\"timestamp\":1562606942886,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1698,\"contents\":{\"pos1\":741,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1963,\"sequenceNumber\":1964,\"timestamp\":1562606942933,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1700,\"contents\":{\"pos1\":742,\"seg\":{\"text\":\"6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1965,\"sequenceNumber\":1966,\"timestamp\":1562606943011,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1702,\"contents\":{\"pos1\":743,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1967,\"sequenceNumber\":1968,\"timestamp\":1562606943105,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1704,\"contents\":{\"pos1\":744,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1969,\"sequenceNumber\":1970,\"timestamp\":1562606943183,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1708,\"contents\":{\"pos1\":744,\"pos2\":745,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1972,\"sequenceNumber\":1973,\"timestamp\":1562606943652,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1710,\"contents\":{\"pos1\":743,\"pos2\":744,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1974,\"sequenceNumber\":1975,\"timestamp\":1562606943777,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1711,\"contents\":{\"pos1\":743,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1975,\"sequenceNumber\":1976,\"timestamp\":1562606943808,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1713,\"contents\":{\"pos1\":744,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1977,\"sequenceNumber\":1978,\"timestamp\":1562606943902,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1715,\"contents\":{\"pos1\":745,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1979,\"sequenceNumber\":1980,\"timestamp\":1562606943948,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1717,\"contents\":{\"pos1\":746,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1981,\"sequenceNumber\":1982,\"timestamp\":1562606944011,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1719,\"contents\":{\"pos1\":747,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1983,\"sequenceNumber\":1984,\"timestamp\":1562606944073,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1721,\"contents\":{\"pos1\":748,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1985,\"sequenceNumber\":1986,\"timestamp\":1562606944183,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1725,\"contents\":{\"pos1\":748,\"pos2\":749,\"type\":1},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1988,\"sequenceNumber\":1989,\"timestamp\":1562606944511,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1726,\"contents\":{\"pos1\":748,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1989,\"sequenceNumber\":1990,\"timestamp\":1562606944636,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1728,\"contents\":{\"pos1\":749,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1991,\"sequenceNumber\":1992,\"timestamp\":1562606944777,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1730,\"contents\":{\"pos1\":750,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1993,\"sequenceNumber\":1994,\"timestamp\":1562606944870,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1732,\"contents\":{\"pos1\":751,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1995,\"sequenceNumber\":1996,\"timestamp\":1562606944917,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1734,\"contents\":{\"pos1\":752,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1997,\"sequenceNumber\":1998,\"timestamp\":1562606944980,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1736,\"contents\":{\"pos1\":753,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1562606945073,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":1736,\"minimumSequenceNumber\":1689,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1562606945073,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,710 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2953,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"fa52be86-9f26-4108-8211-4d6b1edbd202\",{\"client\":{\"user\":{\"id\":\"fmv7o3421@example.com}\",\"name\":\"1rygky6awi6fx3w\",\"email\":\"xqvznu041@example.com}\"}},\"sequenceNumber\":409}],[\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",{\"client\":{\"user\":{\"id\":\"gk7a3hu6l@example.com}\",\"name\":\"yfhuzrc2bjnwpq1\",\"email\":\"xrilcd0vx@example.com}\"}},\"sequenceNumber\":410}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1065,\"refSeqNumber\":2997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":67,\"chunkLengthChars\":1468,\"totalLengthChars\":1468,\"totalSegmentCount\":67,\"chunkSequenceNumber\":2953,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnff\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2953,\"totalLength\":1468,\"totalSegmentCount\":67}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2758,\"contents\":{\"pos1\":1050,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2954,\"sequenceNumber\":2955,\"timestamp\":1562607286273,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2760,\"contents\":{\"pos1\":1051,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2956,\"sequenceNumber\":2957,\"timestamp\":1562607286382,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2762,\"contents\":{\"pos1\":1052,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2958,\"sequenceNumber\":2959,\"timestamp\":1562607286523,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2764,\"contents\":{\"pos1\":1053,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2960,\"sequenceNumber\":2961,\"timestamp\":1562607286539,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2766,\"contents\":{\"pos1\":1054,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2962,\"sequenceNumber\":2963,\"timestamp\":1562607286585,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2768,\"contents\":{\"pos1\":1055,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2964,\"sequenceNumber\":2965,\"timestamp\":1562607286632,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2770,\"contents\":{\"pos1\":1056,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2966,\"sequenceNumber\":2967,\"timestamp\":1562607286789,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2772,\"contents\":{\"pos1\":1057,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2968,\"sequenceNumber\":2969,\"timestamp\":1562607286851,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2774,\"contents\":{\"pos1\":1058,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2970,\"sequenceNumber\":2971,\"timestamp\":1562607286929,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2776,\"contents\":{\"pos1\":1059,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2972,\"sequenceNumber\":2973,\"timestamp\":1562607286976,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2778,\"contents\":{\"pos1\":1060,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2974,\"sequenceNumber\":2975,\"timestamp\":1562607287039,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2780,\"contents\":{\"pos1\":1061,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2976,\"sequenceNumber\":2977,\"timestamp\":1562607287210,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2784,\"contents\":{\"pos1\":1061,\"pos2\":1062,\"type\":1},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2979,\"sequenceNumber\":2980,\"timestamp\":1562607287492,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2786,\"contents\":{\"pos1\":1060,\"pos2\":1061,\"type\":1},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2981,\"sequenceNumber\":2982,\"timestamp\":1562607287617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2788,\"contents\":{\"pos1\":1059,\"pos2\":1060,\"type\":1},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2983,\"sequenceNumber\":2984,\"timestamp\":1562607287742,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2790,\"contents\":{\"pos1\":1058,\"pos2\":1059,\"type\":1},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2985,\"sequenceNumber\":2986,\"timestamp\":1562607287883,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2791,\"contents\":{\"pos1\":1058,\"seg\":{\"text\":\"s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2986,\"sequenceNumber\":2987,\"timestamp\":1562607287930,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2793,\"contents\":{\"pos1\":1059,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2988,\"sequenceNumber\":2989,\"timestamp\":1562607287961,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2795,\"contents\":{\"pos1\":1060,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2990,\"sequenceNumber\":2991,\"timestamp\":1562607288055,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2797,\"contents\":{\"pos1\":1061,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2992,\"sequenceNumber\":2993,\"timestamp\":1562607288289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2799,\"contents\":{\"pos1\":1062,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2994,\"sequenceNumber\":2995,\"timestamp\":1562607288523,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2801,\"contents\":{\"pos1\":1063,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2996,\"sequenceNumber\":2997,\"timestamp\":1562607288570,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2803,\"contents\":{\"pos1\":1064,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2998,\"sequenceNumber\":2999,\"timestamp\":1562607288633,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":2804,\"minimumSequenceNumber\":2953,\"referenceSequenceNumber\":2998,\"sequenceNumber\":3000,\"timestamp\":1562607288633,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,737 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3991,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"fa52be86-9f26-4108-8211-4d6b1edbd202\",{\"client\":{\"user\":{\"id\":\"fmv7o3421@example.com}\",\"name\":\"1rygky6awi6fx3w\",\"email\":\"xqvznu041@example.com}\"}},\"sequenceNumber\":409}],[\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",{\"client\":{\"user\":{\"id\":\"gk7a3hu6l@example.com}\",\"name\":\"yfhuzrc2bjnwpq1\",\"email\":\"xrilcd0vx@example.com}\"}},\"sequenceNumber\":410}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1268,\"refSeqNumber\":3998}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":81,\"chunkLengthChars\":1764,\"totalLengthChars\":1764,\"totalSegmentCount\":81,\"chunkSequenceNumber\":3991,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"zcezgj6nt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"00114d7a-5530-45c7-8d8e-0e001496679f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnf5x3p7jhmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"3q1c3o9s\",{\"text\":\"sl2hfjky31i4p9q8privqi841s8l2envsq12ogpcsqe7y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"vn6n56n1vjp8gnoioed3ogvte6tg9lzllieytn5x6k37m4weivoeuhke3661erwrgx7n8em5eypj7edfb3aeejyzes7ftjtdcyi0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fb48be9-23c4-4a75-81ca-d01733ce3dbc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"jm5jbp17pdepab5rvoszvq\",{\"text\":\"72ub3qyjj9vxo4o9v9wck0a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cecf4e84-9677-4a5a-9e3e-7dedf900ca6e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"vndh\",{\"text\":\"6w0acri0pqb7545666ezxbkmft5fxweoi8v4lsr72ncsr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ba8936-1592-42ef-bb6c-fd0a81a51225\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},{\"text\":\"6rfal0ljp11y295jh6kwjeo46w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32169ded-dd64-42a1-a933-d4bfaf8f3e49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3991,\"totalLength\":1764,\"totalSegmentCount\":81}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":3873,\"contents\":{\"pos1\":1268,\"pos2\":1269,\"type\":1},\"minimumSequenceNumber\":3991,\"referenceSequenceNumber\":3995,\"sequenceNumber\":3996,\"timestamp\":1562607952050,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":3875,\"contents\":{\"pos1\":1267,\"pos2\":1268,\"type\":1},\"minimumSequenceNumber\":3991,\"referenceSequenceNumber\":3997,\"sequenceNumber\":3998,\"timestamp\":1562607952161,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":3877,\"contents\":{\"pos1\":1267,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":3991,\"referenceSequenceNumber\":3998,\"sequenceNumber\":3999,\"timestamp\":1562607953895,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}},\"listRegistryList-97\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64e54950-4954-484d-879e-506ffd2d369f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64e54950-4954-484d-879e-506ffd2d369f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-97\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":3878,\"minimumSequenceNumber\":3991,\"referenceSequenceNumber\":3998,\"sequenceNumber\":4000,\"timestamp\":1562607953895,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,737 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4768,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"fa52be86-9f26-4108-8211-4d6b1edbd202\",{\"client\":{\"user\":{\"id\":\"fmv7o3421@example.com}\",\"name\":\"1rygky6awi6fx3w\",\"email\":\"xqvznu041@example.com}\"}},\"sequenceNumber\":409}],[\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",{\"client\":{\"user\":{\"id\":\"gk7a3hu6l@example.com}\",\"name\":\"yfhuzrc2bjnwpq1\",\"email\":\"xrilcd0vx@example.com}\"}},\"sequenceNumber\":410}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1590,\"refSeqNumber\":4988}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":95,\"chunkLengthChars\":1971,\"totalLengthChars\":1971,\"totalSegmentCount\":95,\"chunkSequenceNumber\":4768,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"zcezgj6nt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"00114d7a-5530-45c7-8d8e-0e001496679f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnf5x3p7jhmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"3q1c3o9s\",{\"text\":\"sl2hfjky31i4p9q8privqi841s8l2envsq12ogpcsqe7y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"vn6n56n1vjp8gnoioed3ogvte6tg9lzllieytn5x6k37m4weivoeuhke3661erwrgx7n8em5eypj7edfb3aeejyzes7ftjtdcyi0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fb48be9-23c4-4a75-81ca-d01733ce3dbc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"jm5jbp17pd\",{\"text\":\"q3ljge\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"epab5rvoszvq\",{\"text\":\"72ub3qyjj9vxo4o9v9wckz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cecf4e84-9677-4a5a-9e3e-7dedf900ca6e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"vndh\",{\"text\":\"6w0acri0pqb7545666ezxbkmft5fxweoi8v4lsr72ncsr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ba8936-1592-42ef-bb6c-fd0a81a51225\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"lfj6zdrrm\",{\"text\":\"uzl4bq1q7t13huc2236o0sdfu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"598d0dd1-6289-4913-bbfe-6d030d78804a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"3\",{\"text\":\"hraeqjua3w4l23g9o8ubxkzj6sxsp7fhkn9lbixydc9s45lkf9vwv0kxvqwd09l8nfgl5707rx6mqlxzpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"235ec65e-13ff-4d3d-a2dc-b6dc4f50c709\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"s6hl72xh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ba425202-6728-4d8f-a222-97e5ab11e0b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i1ir97j7yw7gbkp43\",{\"text\":\"7yqznczkkxrceqpzgiyhjvudnzuqycwmh8k3qv88z4fmroqlsfq0ph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3bef5181-f976-4296-83ab-e8b2a15b0ec0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5fcae607-d710-4b1c-9d32-e97b0d954406\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},{\"text\":\"6rfal0ljp11y295jh6kwjeo46w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32169ded-dd64-42a1-a933-d4bfaf8f3e49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4768,\"totalLength\":1971,\"totalSegmentCount\":95}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4711,\"contents\":{\"pos1\":1526,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4769,\"sequenceNumber\":4770,\"timestamp\":1562608773852,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4713,\"contents\":{\"pos1\":1527,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4771,\"sequenceNumber\":4772,\"timestamp\":1562608774024,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4715,\"contents\":{\"pos1\":1528,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4773,\"sequenceNumber\":4774,\"timestamp\":1562608774149,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4717,\"contents\":{\"pos1\":1529,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4775,\"sequenceNumber\":4776,\"timestamp\":1562608774259,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4719,\"contents\":{\"pos1\":1530,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4777,\"sequenceNumber\":4778,\"timestamp\":1562608774321,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4721,\"contents\":{\"pos1\":1531,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4779,\"sequenceNumber\":4780,\"timestamp\":1562608774399,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4723,\"contents\":{\"pos1\":1532,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4781,\"sequenceNumber\":4782,\"timestamp\":1562608774415,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4725,\"contents\":{\"pos1\":1533,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4783,\"sequenceNumber\":4784,\"timestamp\":1562608774462,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4727,\"contents\":{\"pos1\":1534,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4785,\"sequenceNumber\":4786,\"timestamp\":1562608774524,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4729,\"contents\":{\"pos1\":1535,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4787,\"sequenceNumber\":4788,\"timestamp\":1562608774555,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4731,\"contents\":{\"pos1\":1536,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4789,\"sequenceNumber\":4790,\"timestamp\":1562608774618,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4733,\"contents\":{\"pos1\":1537,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4791,\"sequenceNumber\":4792,\"timestamp\":1562608774774,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4735,\"contents\":{\"pos1\":1538,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4793,\"sequenceNumber\":4794,\"timestamp\":1562608774930,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4737,\"contents\":{\"pos1\":1539,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4795,\"sequenceNumber\":4796,\"timestamp\":1562608775118,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4739,\"contents\":{\"pos1\":1540,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4797,\"sequenceNumber\":4798,\"timestamp\":1562608775212,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4741,\"contents\":{\"pos1\":1541,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4799,\"sequenceNumber\":4800,\"timestamp\":1562608775290,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4743,\"contents\":{\"pos1\":1542,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4801,\"sequenceNumber\":4802,\"timestamp\":1562608775337,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4745,\"contents\":{\"pos1\":1543,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4803,\"sequenceNumber\":4804,\"timestamp\":1562608775430,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4747,\"contents\":{\"pos1\":1544,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4805,\"sequenceNumber\":4806,\"timestamp\":1562608775509,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4749,\"contents\":{\"pos1\":1545,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4807,\"sequenceNumber\":4808,\"timestamp\":1562608775696,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4751,\"contents\":{\"pos1\":1546,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4809,\"sequenceNumber\":4810,\"timestamp\":1562608775743,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4753,\"contents\":{\"pos1\":1547,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4811,\"sequenceNumber\":4812,\"timestamp\":1562608775884,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4755,\"contents\":{\"pos1\":1548,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4813,\"sequenceNumber\":4814,\"timestamp\":1562608775993,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4757,\"contents\":{\"pos1\":1549,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4815,\"sequenceNumber\":4816,\"timestamp\":1562608776024,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4759,\"contents\":{\"pos1\":1550,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4817,\"sequenceNumber\":4818,\"timestamp\":1562608776134,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4761,\"contents\":{\"pos1\":1551,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4819,\"sequenceNumber\":4820,\"timestamp\":1562608776149,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4763,\"contents\":{\"pos1\":1552,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4821,\"sequenceNumber\":4822,\"timestamp\":1562608776259,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4765,\"contents\":{\"pos1\":1553,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4823,\"sequenceNumber\":4824,\"timestamp\":1562608776321,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4767,\"contents\":{\"pos1\":1554,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4825,\"sequenceNumber\":4826,\"timestamp\":1562608776337,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4769,\"contents\":{\"pos1\":1555,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4827,\"sequenceNumber\":4828,\"timestamp\":1562608776415,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4771,\"contents\":{\"pos1\":1556,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4829,\"sequenceNumber\":4830,\"timestamp\":1562608776446,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4773,\"contents\":{\"pos1\":1557,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4831,\"sequenceNumber\":4832,\"timestamp\":1562608776587,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4775,\"contents\":{\"pos1\":1558,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4833,\"sequenceNumber\":4834,\"timestamp\":1562608776665,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4777,\"contents\":{\"pos1\":1559,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4835,\"sequenceNumber\":4836,\"timestamp\":1562608776727,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4779,\"contents\":{\"pos1\":1560,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4837,\"sequenceNumber\":4838,\"timestamp\":1562608776790,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4781,\"contents\":{\"pos1\":1561,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4839,\"sequenceNumber\":4840,\"timestamp\":1562608776821,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4783,\"contents\":{\"pos1\":1562,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4841,\"sequenceNumber\":4842,\"timestamp\":1562608776915,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4785,\"contents\":{\"pos1\":1563,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4843,\"sequenceNumber\":4844,\"timestamp\":1562608776977,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4787,\"contents\":{\"pos1\":1564,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4845,\"sequenceNumber\":4846,\"timestamp\":1562608777040,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4789,\"contents\":{\"pos1\":1565,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4847,\"sequenceNumber\":4848,\"timestamp\":1562608777087,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4791,\"contents\":{\"pos1\":1566,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4849,\"sequenceNumber\":4850,\"timestamp\":1562608777149,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4793,\"contents\":{\"pos1\":1567,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4851,\"sequenceNumber\":4852,\"timestamp\":1562608777212,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4795,\"contents\":{\"pos1\":1568,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4853,\"sequenceNumber\":4854,\"timestamp\":1562608777259,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4797,\"contents\":{\"pos1\":1569,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4855,\"sequenceNumber\":4856,\"timestamp\":1562608777399,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4799,\"contents\":{\"pos1\":1570,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4857,\"sequenceNumber\":4858,\"timestamp\":1562608777462,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4801,\"contents\":{\"pos1\":1571,\"seg\":\"24\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4859,\"sequenceNumber\":4860,\"timestamp\":1562608777555,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4803,\"contents\":{\"pos1\":1573,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4861,\"sequenceNumber\":4862,\"timestamp\":1562608777696,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4805,\"contents\":{\"pos1\":1574,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4863,\"sequenceNumber\":4864,\"timestamp\":1562608777727,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4807,\"contents\":{\"pos1\":1575,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4865,\"sequenceNumber\":4866,\"timestamp\":1562608777790,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4809,\"contents\":{\"pos1\":1576,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4867,\"sequenceNumber\":4868,\"timestamp\":1562608777884,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4811,\"contents\":{\"pos1\":1577,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4869,\"sequenceNumber\":4870,\"timestamp\":1562608777963,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4813,\"contents\":{\"pos1\":1578,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4871,\"sequenceNumber\":4872,\"timestamp\":1562608778026,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4815,\"contents\":{\"pos1\":1579,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4873,\"sequenceNumber\":4874,\"timestamp\":1562608778119,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4817,\"contents\":{\"pos1\":1580,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4875,\"sequenceNumber\":4876,\"timestamp\":1562608778182,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4819,\"contents\":{\"pos1\":1581,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4877,\"sequenceNumber\":4878,\"timestamp\":1562608778291,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4822,\"contents\":{\"pos1\":1581,\"pos2\":1582,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4880,\"sequenceNumber\":4881,\"timestamp\":1562608778604,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4823,\"contents\":{\"pos1\":1581,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4881,\"sequenceNumber\":4882,\"timestamp\":1562608778744,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4825,\"contents\":{\"pos1\":1582,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4883,\"sequenceNumber\":4884,\"timestamp\":1562608778822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4827,\"contents\":{\"pos1\":1583,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4885,\"sequenceNumber\":4886,\"timestamp\":1562608778916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4829,\"contents\":{\"pos1\":1584,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4887,\"sequenceNumber\":4888,\"timestamp\":1562608778963,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4831,\"contents\":{\"pos1\":1585,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4889,\"sequenceNumber\":4890,\"timestamp\":1562608779026,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4833,\"contents\":{\"pos1\":1586,\"seg\":{\"text\":\"y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4891,\"sequenceNumber\":4892,\"timestamp\":1562608779072,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4835,\"contents\":{\"pos1\":1587,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4893,\"sequenceNumber\":4894,\"timestamp\":1562608779151,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4837,\"contents\":{\"pos1\":1588,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4895,\"sequenceNumber\":4896,\"timestamp\":1562608779229,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4839,\"contents\":{\"pos1\":1589,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4897,\"sequenceNumber\":4898,\"timestamp\":1562608779307,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4847,\"contents\":{\"pos1\":1552,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4902,\"sequenceNumber\":4903,\"timestamp\":1562608781276,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4849,\"contents\":{\"pos1\":1553,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4904,\"sequenceNumber\":4905,\"timestamp\":1562608781494,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4852,\"contents\":{\"pos1\":1553,\"pos2\":1554,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4907,\"sequenceNumber\":4908,\"timestamp\":1562608781713,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4854,\"contents\":{\"pos1\":1552,\"pos2\":1553,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4909,\"sequenceNumber\":4910,\"timestamp\":1562608781822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4855,\"contents\":{\"pos1\":1552,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4910,\"sequenceNumber\":4911,\"timestamp\":1562608781979,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4857,\"contents\":{\"pos1\":1553,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4912,\"sequenceNumber\":4913,\"timestamp\":1562608782088,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4859,\"contents\":{\"pos1\":1554,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4914,\"sequenceNumber\":4915,\"timestamp\":1562608782166,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4861,\"contents\":{\"pos1\":1555,\"seg\":{\"text\":\"4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4916,\"sequenceNumber\":4917,\"timestamp\":1562608782260,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4863,\"contents\":{\"pos1\":1556,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4918,\"sequenceNumber\":4919,\"timestamp\":1562608782401,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4865,\"contents\":{\"pos1\":1557,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4920,\"sequenceNumber\":4921,\"timestamp\":1562608782541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4867,\"contents\":{\"pos1\":1558,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4922,\"sequenceNumber\":4923,\"timestamp\":1562608782619,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4869,\"contents\":{\"pos1\":1559,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4924,\"sequenceNumber\":4925,\"timestamp\":1562608782729,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4871,\"contents\":{\"pos1\":1560,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4926,\"sequenceNumber\":4927,\"timestamp\":1562608782791,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4873,\"contents\":{\"pos1\":1561,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4928,\"sequenceNumber\":4929,\"timestamp\":1562608782854,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4875,\"contents\":{\"pos1\":1562,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4930,\"sequenceNumber\":4931,\"timestamp\":1562608782932,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4877,\"contents\":{\"pos1\":1563,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4932,\"sequenceNumber\":4933,\"timestamp\":1562608782963,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4879,\"contents\":{\"pos1\":1564,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4934,\"sequenceNumber\":4935,\"timestamp\":1562608783057,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4881,\"contents\":{\"pos1\":1565,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4936,\"sequenceNumber\":4937,\"timestamp\":1562608783369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4883,\"contents\":{\"pos1\":1566,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4938,\"sequenceNumber\":4939,\"timestamp\":1562608783479,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4885,\"contents\":{\"pos1\":1567,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4940,\"sequenceNumber\":4941,\"timestamp\":1562608783510,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4887,\"contents\":{\"pos1\":1568,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4942,\"sequenceNumber\":4943,\"timestamp\":1562608783557,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4889,\"contents\":{\"pos1\":1569,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4944,\"sequenceNumber\":4945,\"timestamp\":1562608783667,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4891,\"contents\":{\"pos1\":1570,\"seg\":{\"text\":\"az\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4946,\"sequenceNumber\":4947,\"timestamp\":1562608783886,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4893,\"contents\":{\"pos1\":1572,\"seg\":{\"text\":\"q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4948,\"sequenceNumber\":4949,\"timestamp\":1562608783933,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4895,\"contents\":{\"pos1\":1573,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4950,\"sequenceNumber\":4951,\"timestamp\":1562608784027,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4898,\"contents\":{\"pos1\":1573,\"pos2\":1574,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4953,\"sequenceNumber\":4954,\"timestamp\":1562608784464,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4899,\"contents\":{\"pos1\":1565,\"pos2\":1573,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4954,\"sequenceNumber\":4955,\"timestamp\":1562608784745,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4900,\"contents\":{\"pos1\":1565,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4955,\"sequenceNumber\":4956,\"timestamp\":1562608784995,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4902,\"contents\":{\"pos1\":1566,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4957,\"sequenceNumber\":4958,\"timestamp\":1562608785151,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4904,\"contents\":{\"pos1\":1567,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4959,\"sequenceNumber\":4960,\"timestamp\":1562608785261,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4906,\"contents\":{\"pos1\":1568,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4961,\"sequenceNumber\":4962,\"timestamp\":1562608785292,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4908,\"contents\":{\"pos1\":1569,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4963,\"sequenceNumber\":4964,\"timestamp\":1562608785339,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4910,\"contents\":{\"pos1\":1570,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4965,\"sequenceNumber\":4966,\"timestamp\":1562608785464,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4912,\"contents\":{\"pos1\":1571,\"seg\":{\"text\":\"0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4967,\"sequenceNumber\":4968,\"timestamp\":1562608785558,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4914,\"contents\":{\"pos1\":1572,\"seg\":{\"text\":\"1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4969,\"sequenceNumber\":4970,\"timestamp\":1562608785589,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4916,\"contents\":{\"pos1\":1573,\"seg\":{\"text\":\"v\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4971,\"sequenceNumber\":4972,\"timestamp\":1562608785636,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4918,\"contents\":{\"pos1\":1574,\"seg\":{\"text\":\"w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4973,\"sequenceNumber\":4974,\"timestamp\":1562608785714,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4923,\"contents\":{\"pos1\":1574,\"pos2\":1575,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4976,\"sequenceNumber\":4977,\"timestamp\":1562608786480,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4925,\"contents\":{\"pos1\":1573,\"pos2\":1574,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4978,\"sequenceNumber\":4979,\"timestamp\":1562608786621,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4927,\"contents\":{\"pos1\":1572,\"pos2\":1573,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4980,\"sequenceNumber\":4981,\"timestamp\":1562608786747,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4929,\"contents\":{\"pos1\":1571,\"pos2\":1572,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4982,\"sequenceNumber\":4983,\"timestamp\":1562608786888,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4930,\"contents\":{\"pos1\":1571,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4983,\"sequenceNumber\":4984,\"timestamp\":1562608786903,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4932,\"contents\":{\"pos1\":1572,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4985,\"sequenceNumber\":4986,\"timestamp\":1562608786935,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4934,\"contents\":{\"pos1\":1573,\"seg\":{\"text\":\"7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4987,\"sequenceNumber\":4988,\"timestamp\":1562608786997,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4946,\"contents\":{\"pos1\":1591,\"pos2\":1610,\"type\":1},\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4998,\"sequenceNumber\":4999,\"timestamp\":1562608788732,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}},\"listRegistryList-97\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64e54950-4954-484d-879e-506ffd2d369f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64e54950-4954-484d-879e-506ffd2d369f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-97\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"caff9589-9475-42dc-98b0-d2ed3fef2a95\",\"clientSequenceNumber\":4947,\"minimumSequenceNumber\":4768,\"referenceSequenceNumber\":4997,\"sequenceNumber\":5000,\"timestamp\":1562608789028,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,845 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5803,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"752719a4-4632-43cc-8e72-e56fcfc96019\",{\"client\":{\"user\":{\"id\":\"o7emtmfvh@example.com}\",\"name\":\"kprbioqj45ec442\",\"email\":\"40m55n0vj@example.com}\"}},\"sequenceNumber\":5753}],[\"91d33a60-4934-422a-9d89-607f80433a0c\",{\"client\":{\"user\":{\"id\":\"dlws3rcig@example.com}\",\"name\":\"av80rgvpswa7axo\",\"email\":\"6ycufpcl6@example.com}\"}},\"sequenceNumber\":5756}],[\"2203017f-cc9a-425e-8779-b20385f51eb9\",{\"client\":{\"user\":{\"id\":\"syn4jnw0t@example.com}\",\"name\":\"yo3uhdujsbjka6y\",\"email\":\"b9u3w75sw@example.com}\"}},\"sequenceNumber\":5772}],[\"594f7e22-52df-4656-a2b0-3ed6ba5982ae\",{\"client\":{\"user\":{\"id\":\"hfccsx231@example.com}\",\"name\":\"khx2ahrqnljzaj0\",\"email\":\"t0afp4mr9@example.com}\"}},\"sequenceNumber\":5773}],[\"a42ed94e-1852-46a7-83fe-fb41ec9a112e\",{\"client\":{\"user\":{\"id\":\"1jo1vbuwe@example.com}\",\"name\":\"cwzudkwtxpbk526\",\"email\":\"r6vzwx1lh@example.com}\"}},\"sequenceNumber\":5804}],[\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",{\"client\":{\"user\":{\"id\":\"5v8kdi8uu@example.com}\",\"name\":\"ze07jvr7hqf5np9\",\"email\":\"mrakznynw@example.com}\"}},\"sequenceNumber\":5805}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5394}},\"9ae8ce60-7cc4-4bf0-b444-50c460e4cb04\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5454}},\"f89c5fda-6918-4e68-856f-88968b4591ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5497}},\"9d9a0e8d-ce0a-44be-a1b3-9bd935dcbe17\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5574}},\"63461457-31ec-4fb3-90b6-2136da1db4e1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5585}},\"91d33a60-4934-422a-9d89-607f80433a0c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":206,\"refSeqNumber\":5754}},\"ec9a25c3-d7ad-4902-81d6-89e2e8f904c2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5399}},\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":207,\"refSeqNumber\":5995}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":109,\"chunkLengthChars\":2158,\"totalLengthChars\":2158,\"totalSegmentCount\":109,\"chunkSequenceNumber\":5803,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"zcezgj6nt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"00114d7a-5530-45c7-8d8e-0e001496679f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnf5x3p7jhmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"3q1c3o9s\",{\"text\":\"sl2hfjky31i4p9q8privqi841s8l2envsq12ogpcsqe7y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"vn6n56n1vjp8gnoioed3ogvte6tg9lzllieytn5x6k37m4weivoeuhke3661erwrgx7n8em5eypj7edfb3aeejyzes7ftjtdcyi0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fb48be9-23c4-4a75-81ca-d01733ce3dbc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"jm5jbp17pd\",{\"text\":\"q3ljge\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"epab5rvoszvq\",{\"text\":\"72ub3qyjj9vxo4o9v9wckz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cecf4e84-9677-4a5a-9e3e-7dedf900ca6e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"297anyw6si795ld0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"202cda43-1cab-4d9e-84fa-c822467dd00f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"vndh\",{\"text\":\"6w0acri0pqb7545666ezxbkmft5fxweoi8v4lsr72ncsr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ba8936-1592-42ef-bb6c-fd0a81a51225\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"lfj6zdrrm\",{\"text\":\"uzl4bq1q7t13huc2236o0sdfu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"598d0dd1-6289-4913-bbfe-6d030d78804a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"3\",{\"text\":\"hraeqjua3w4l23g9o8ubxkzj6sxsp7fhkn9lbixydc9s45lkf9vwv0kxvqwd09l8nfgl5707rx6mqlxzpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"235ec65e-13ff-4d3d-a2dc-b6dc4f50c709\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"s6hl72xh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ba425202-6728-4d8f-a222-97e5ab11e0b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i1ir97j7yw7gbkp43\",{\"text\":\"7yqznczkkxrceqpzgiyhjvudnzuqycwmh8k3qv88z4fmroqlsfq0ph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3bef5181-f976-4296-83ab-e8b2a15b0ec0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"6xx92ztjjw8yikqynnuygat590\",{\"text\":\"mz84lv8db3i8onnizrurc7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"56k7ydjis43furs0\",{\"text\":\"md\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5fcae607-d710-4b1c-9d32-e97b0d954406\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"yg0o3kt\",{\"text\":\"af0avq9czwc5tjamr0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42ded140-6ca6-4c99-883d-07644e0f6f58\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},{\"text\":\"6rfal0ljp11y295jh6kwjeo46w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32169ded-dd64-42a1-a933-d4bfaf8f3e49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i0\",{\"text\":\"akgcjiuey0yj4clutmd4gf062gfjmiblk7vdejpx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"q27u1u0p3xml8\",{\"text\":\"wycf0np6xgxnwiwb3j8cjt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5826790d-ae58-4189-bf50-6993e3c3a412\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5803,\"totalLength\":2158,\"totalSegmentCount\":109}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":9,\"contents\":{\"pos1\":178,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"452bac6d-bbc2-4c68-9438-fca088ba3d5d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5810,\"sequenceNumber\":5811,\"timestamp\":1563902242724,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":11,\"contents\":{\"pos1\":179,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b86a8881-2a1c-497d-bc84-7e4fcaa66ef1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5812,\"sequenceNumber\":5813,\"timestamp\":1563902242834,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":14,\"contents\":{\"pos1\":179,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5814,\"sequenceNumber\":5815,\"timestamp\":1563902243803,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":16,\"contents\":{\"pos1\":180,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5816,\"sequenceNumber\":5817,\"timestamp\":1563902243943,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":19,\"contents\":{\"pos1\":181,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5818,\"sequenceNumber\":5819,\"timestamp\":1563902244553,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":21,\"contents\":{\"pos1\":182,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5820,\"sequenceNumber\":5821,\"timestamp\":1563902244584,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":23,\"contents\":{\"pos1\":183,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5822,\"sequenceNumber\":5823,\"timestamp\":1563902244724,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":25,\"contents\":{\"pos1\":184,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5824,\"sequenceNumber\":5825,\"timestamp\":1563902244881,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":27,\"contents\":{\"pos1\":185,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5826,\"sequenceNumber\":5827,\"timestamp\":1563902244959,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":29,\"contents\":{\"pos1\":186,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5828,\"sequenceNumber\":5829,\"timestamp\":1563902245193,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":31,\"contents\":{\"pos1\":187,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5830,\"sequenceNumber\":5831,\"timestamp\":1563902245287,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":33,\"contents\":{\"pos1\":188,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5832,\"sequenceNumber\":5833,\"timestamp\":1563902245382,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":35,\"contents\":{\"pos1\":189,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5834,\"sequenceNumber\":5835,\"timestamp\":1563902245570,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":37,\"contents\":{\"pos1\":190,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5836,\"sequenceNumber\":5837,\"timestamp\":1563902245679,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":39,\"contents\":{\"pos1\":191,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5838,\"sequenceNumber\":5839,\"timestamp\":1563902245835,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":41,\"contents\":{\"pos1\":192,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5840,\"sequenceNumber\":5841,\"timestamp\":1563902246070,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":43,\"contents\":{\"pos1\":193,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5842,\"sequenceNumber\":5843,\"timestamp\":1563902246179,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":45,\"contents\":{\"pos1\":194,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5844,\"sequenceNumber\":5845,\"timestamp\":1563902246273,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":47,\"contents\":{\"pos1\":195,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5846,\"sequenceNumber\":5847,\"timestamp\":1563902246351,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":50,\"contents\":{\"pos1\":196,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5848,\"sequenceNumber\":5849,\"timestamp\":1563902246836,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":52,\"contents\":{\"pos1\":198,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"068ed76e-0b45-44b9-a182-aaff77e83af1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5850,\"sequenceNumber\":5851,\"timestamp\":1563902247023,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":59,\"contents\":{\"pos1\":179,\"pos2\":197,\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5854,\"sequenceNumber\":5855,\"timestamp\":1563902248492,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":65,\"contents\":{\"pos1\":198,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5857,\"sequenceNumber\":5858,\"timestamp\":1563902390621,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":67,\"contents\":{\"pos1\":199,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5859,\"sequenceNumber\":5860,\"timestamp\":1563902390731,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":69,\"contents\":{\"pos1\":198,\"pos2\":200,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5861,\"sequenceNumber\":5862,\"timestamp\":1563902390731,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":81,\"contents\":{\"pos1\":198,\"pos2\":199,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"068ed76e-0b45-44b9-a182-aaff77e83af1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5873,\"sequenceNumber\":5874,\"timestamp\":1563902390731,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":198,\"pos2\":199,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"068ed76e-0b45-44b9-a182-aaff77e83af1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5874,\"sequenceNumber\":5875,\"timestamp\":1563902390731,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":198,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5875,\"sequenceNumber\":5876,\"timestamp\":1563902408447,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":199,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5877,\"sequenceNumber\":5878,\"timestamp\":1563902408557,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":200,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5879,\"sequenceNumber\":5880,\"timestamp\":1563902408588,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":201,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5881,\"sequenceNumber\":5882,\"timestamp\":1563902408666,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":203,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca82caa7-9127-4f4e-80ac-ef4c49da8a21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5883,\"sequenceNumber\":5884,\"timestamp\":1563902408807,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":95,\"contents\":{\"pos1\":203,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5885,\"sequenceNumber\":5886,\"timestamp\":1563902409150,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":97,\"contents\":{\"pos1\":204,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5887,\"sequenceNumber\":5888,\"timestamp\":1563902409322,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":99,\"contents\":{\"pos1\":205,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5889,\"sequenceNumber\":5890,\"timestamp\":1563902409401,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":206,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5891,\"sequenceNumber\":5892,\"timestamp\":1563902409511,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":207,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5893,\"sequenceNumber\":5894,\"timestamp\":1563902409620,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":207,\"pos2\":208,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5896,\"sequenceNumber\":5897,\"timestamp\":1563902409854,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":206,\"pos2\":207,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5898,\"sequenceNumber\":5899,\"timestamp\":1563902409995,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":110,\"contents\":{\"pos1\":205,\"pos2\":206,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5900,\"sequenceNumber\":5901,\"timestamp\":1563902410120,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":112,\"contents\":{\"pos1\":204,\"pos2\":205,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5902,\"sequenceNumber\":5903,\"timestamp\":1563902410229,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":204,\"seg\":{\"text\":\"8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5903,\"sequenceNumber\":5904,\"timestamp\":1563902410261,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":205,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5905,\"sequenceNumber\":5906,\"timestamp\":1563902410308,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":206,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5907,\"sequenceNumber\":5908,\"timestamp\":1563902410354,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":119,\"contents\":{\"pos1\":207,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5909,\"sequenceNumber\":5910,\"timestamp\":1563902410464,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":121,\"contents\":{\"pos1\":208,\"seg\":{\"text\":\"p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5911,\"sequenceNumber\":5912,\"timestamp\":1563902410511,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":123,\"contents\":{\"pos1\":209,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5913,\"sequenceNumber\":5914,\"timestamp\":1563902410558,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":125,\"contents\":{\"pos1\":210,\"seg\":{\"text\":\"2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5915,\"sequenceNumber\":5916,\"timestamp\":1563902410604,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":127,\"contents\":{\"pos1\":211,\"seg\":{\"text\":\"h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5917,\"sequenceNumber\":5918,\"timestamp\":1563902410714,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":129,\"contents\":{\"pos1\":212,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5919,\"sequenceNumber\":5920,\"timestamp\":1563902410776,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":213,\"seg\":{\"text\":\"5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5921,\"sequenceNumber\":5922,\"timestamp\":1563902410854,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":214,\"seg\":{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5923,\"sequenceNumber\":5924,\"timestamp\":1563902410870,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":215,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5925,\"sequenceNumber\":5926,\"timestamp\":1563902411011,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":216,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5927,\"sequenceNumber\":5928,\"timestamp\":1563902411120,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":216,\"pos2\":217,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5930,\"sequenceNumber\":5931,\"timestamp\":1563902411698,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":203,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5932,\"sequenceNumber\":5933,\"timestamp\":1563902548177,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":203,\"seg\":{\"text\":\"7w8kwf8866\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5939,\"sequenceNumber\":5940,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":158,\"contents\":{\"pos1\":213,\"seg\":{\"text\":\"oribvtd2uuslzbmqrt7kyai2ueoxz9wp8cnzx1exl3360bch3dd2satwz5v751tt8hjkmtwm8o0hny3y5r165fi0axp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5940,\"sequenceNumber\":5941,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":304,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4808c79f-8cb5-470f-8966-e4ded308cf64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\",\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5941,\"sequenceNumber\":5942,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4808c79f-8cb5-470f-8966-e4ded308cf64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-45\",\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5953,\"sequenceNumber\":5954,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4808c79f-8cb5-470f-8966-e4ded308cf64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5954,\"sequenceNumber\":5955,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":173,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4808c79f-8cb5-470f-8966-e4ded308cf64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5955,\"sequenceNumber\":5956,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4808c79f-8cb5-470f-8966-e4ded308cf64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5956,\"sequenceNumber\":5957,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":175,\"contents\":{\"pos1\":305,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0635f16-2cf4-467d-8fc7-fdf6afb3d203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5957,\"sequenceNumber\":5958,\"timestamp\":1563902553761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":187,\"contents\":{\"pos1\":305,\"pos2\":306,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0635f16-2cf4-467d-8fc7-fdf6afb3d203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-45\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5969,\"sequenceNumber\":5970,\"timestamp\":1563902553776,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":305,\"pos2\":306,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0635f16-2cf4-467d-8fc7-fdf6afb3d203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5970,\"sequenceNumber\":5971,\"timestamp\":1563902553776,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":189,\"contents\":{\"pos1\":305,\"pos2\":306,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0635f16-2cf4-467d-8fc7-fdf6afb3d203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5971,\"sequenceNumber\":5972,\"timestamp\":1563902553776,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":305,\"pos2\":306,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f0635f16-2cf4-467d-8fc7-fdf6afb3d203\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-110\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5972,\"sequenceNumber\":5973,\"timestamp\":1563902553776,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":193,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-45\"}},\"relativePos1\":{\"id\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"before\":true},\"relativePos2\":{\"id\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\"},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5974,\"sequenceNumber\":5975,\"timestamp\":1563902554745,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":306,\"pos2\":307,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5975,\"sequenceNumber\":5976,\"timestamp\":1563902554745,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":196,\"contents\":{\"pos1\":305,\"pos2\":306,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5977,\"sequenceNumber\":5978,\"timestamp\":1563902554932,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":198,\"contents\":{\"pos1\":304,\"pos2\":305,\"type\":1},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5979,\"sequenceNumber\":5980,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":199,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5980,\"sequenceNumber\":5981,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":200,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5981,\"sequenceNumber\":5982,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":201,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5982,\"sequenceNumber\":5983,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":202,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5983,\"sequenceNumber\":5984,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":203,\"contents\":{\"pos1\":304,\"pos2\":305,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}},\"type\":2},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5984,\"sequenceNumber\":5985,\"timestamp\":1563902555104,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":213,\"contents\":{\"pos1\":203,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7c42d3a-bc77-4524-9d1a-822eec647e94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5989,\"sequenceNumber\":5990,\"timestamp\":1563902617495,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":203,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5992,\"sequenceNumber\":5993,\"timestamp\":1563902618246,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":204,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5994,\"sequenceNumber\":5995,\"timestamp\":1563902618355,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":222,\"contents\":{\"pos1\":205,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5996,\"sequenceNumber\":5997,\"timestamp\":1563902618433,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":224,\"contents\":{\"pos1\":206,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5998,\"sequenceNumber\":5999,\"timestamp\":1563902618480,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}},\"listRegistryList-97\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64e54950-4954-484d-879e-506ffd2d369f\"}},\"listRegistryList-45\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/26e122fd-1da7-4d87-a76b-1b9e62ecb135\"}},\"listRegistryList-22\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3005bd3-6996-40a5-8e5c-339bc437f9ab\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/27ca1ad1-988c-4329-87db-4e9e63766937\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64e54950-4954-484d-879e-506ffd2d369f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-97\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "26e122fd-1da7-4d87-a76b-1b9e62ecb135",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-45\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3005bd3-6996-40a5-8e5c-339bc437f9ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-22\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "27ca1ad1-988c-4329-87db-4e9e63766937",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\",\"clientSequenceNumber\":225,\"minimumSequenceNumber\":5803,\"referenceSequenceNumber\":5996,\"sequenceNumber\":6000,\"timestamp\":1563902618480,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_7000_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_7000_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6994,\"sequenceNumber\":7000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"752719a4-4632-43cc-8e72-e56fcfc96019\",{\"client\":{\"user\":{\"id\":\"o7emtmfvh@example.com}\",\"name\":\"kprbioqj45ec442\",\"email\":\"40m55n0vj@example.com}\"}},\"sequenceNumber\":5753}],[\"91d33a60-4934-422a-9d89-607f80433a0c\",{\"client\":{\"user\":{\"id\":\"dlws3rcig@example.com}\",\"name\":\"av80rgvpswa7axo\",\"email\":\"6ycufpcl6@example.com}\"}},\"sequenceNumber\":5756}],[\"2203017f-cc9a-425e-8779-b20385f51eb9\",{\"client\":{\"user\":{\"id\":\"syn4jnw0t@example.com}\",\"name\":\"yo3uhdujsbjka6y\",\"email\":\"b9u3w75sw@example.com}\"}},\"sequenceNumber\":5772}],[\"594f7e22-52df-4656-a2b0-3ed6ba5982ae\",{\"client\":{\"user\":{\"id\":\"hfccsx231@example.com}\",\"name\":\"khx2ahrqnljzaj0\",\"email\":\"t0afp4mr9@example.com}\"}},\"sequenceNumber\":5773}],[\"a69c6df6-8c1a-46f4-a5df-32696c89e6c4\",{\"client\":{\"user\":{\"id\":\"omkfwctov@example.com}\",\"name\":\"qtkovfr5buu0vfv\",\"email\":\"7e7lnhave@example.com}\"}},\"sequenceNumber\":6974}],[\"f4ba8cb3-3083-40c2-a7fc-220215e63ff7\",{\"client\":{\"user\":{\"id\":\"noegp1kou@example.com}\",\"name\":\"xev0s6ti5fneozb\",\"email\":\"gmdle1shu@example.com}\"}},\"sequenceNumber\":6977}],[\"76f48fee-c9a2-478f-a454-ceef8002de03\",{\"client\":{\"user\":{\"id\":\"viyb9mcqn@example.com}\",\"name\":\"6ts4rr1ppa76k2a\",\"email\":\"wkdnd06cl@example.com}\"}},\"sequenceNumber\":6980}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5394}},\"9ae8ce60-7cc4-4bf0-b444-50c460e4cb04\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5454}},\"f89c5fda-6918-4e68-856f-88968b4591ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5497}},\"9d9a0e8d-ce0a-44be-a1b3-9bd935dcbe17\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5574}},\"63461457-31ec-4fb3-90b6-2136da1db4e1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5585}},\"91d33a60-4934-422a-9d89-607f80433a0c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":206,\"refSeqNumber\":5754}},\"ec9a25c3-d7ad-4902-81d6-89e2e8f904c2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5399}},\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":402,\"refSeqNumber\":6631}},\"07721ac6-a004-4b41-b408-9076d07941c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6458}},\"cfaaed4f-c773-4c30-bffd-9399ca76777c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6652}},\"e825eb7d-00c4-4475-81d4-7c09476ba95a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6815}},\"f1099007-8283-4cf0-8d58-2fd379f6482c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6918}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":135,\"chunkLengthChars\":2543,\"totalLengthChars\":2543,\"totalSegmentCount\":135,\"chunkSequenceNumber\":6994,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"452bac6d-bbc2-4c68-9438-fca088ba3d5d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ne0bx2ey2cxmw3kf3p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b86a8881-2a1c-497d-bc84-7e4fcaa66ef1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"eeq9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"068ed76e-0b45-44b9-a182-aaff77e83af1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"0t6\",{\"text\":\"0twdj63uzs21q9m4ag6en\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7c42d3a-bc77-4524-9d1a-822eec647e94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},{\"text\":\"7w8kwf8866oribvtd2uuslzbmqrt7kyai2ueoxz9wp8cnzx1exl3360bch3dd2satwz5v751tt8hjkmtwm8o0hny3y5r165fi0axp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},{\"text\":\"bc5ns6pu\",\"props\":{\"{00000000-0000-2a0c-0000-000000000000}\":\"#FFFF00\"}},\"sx\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"q5bd0z5gnq6m01q8zzblw0oxhf7e27bauqubxbo4m612atgk7c2qxgvo28e5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0224df87-ca26-4739-86ef-07110665cd71\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},\"5\",{\"text\":\"8rarpj2hk5b9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca82caa7-9127-4f4e-80ac-ef4c49da8a21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"l\",{\"text\":\"oqofp9letn6tnlmzwos\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e1c2971-6023-4bb8-a3ec-fdfc479e0ec6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\",\"bold\":false}}},\"6xxuctgk6k31n11tpu4rammq7hz18ygj56eqrg98ef9o54gsnvivsgi253\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e609f884-d94e-4ec6-a5aa-8c9dbbe98500\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\",\"bold\":false}}},\"jtd915td49ygxqo6wx1mrqeg28iyflsjkmb6togda9mgcoxp9a8vau66k0p4jltl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd7c6fec-9017-4006-a7b5-ab18d8d1c77c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56317050-d4ad-48be-8565-ca0c28aa6452\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"zcezgj6nt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"00114d7a-5530-45c7-8d8e-0e001496679f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnf5x3p7jhmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"3q1c3o9s\",{\"text\":\"sl2hfjky31i4p9q8privqi841s8l2envsq12ogpcsqe7y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"vn6n56n1vjp8gnoioed3ogvte6tg9lzllieytn5x6k37m4weivoeuhke3661erwrgx7n8em5eypj7edfb3aeejyzes7ftjtdcyi0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fb48be9-23c4-4a75-81ca-d01733ce3dbc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"jm5jbp17pd\",{\"text\":\"q3ljge\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"epab5rvoszvq\",{\"text\":\"72ub3qyjj9vxo4o9v9wckz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cecf4e84-9677-4a5a-9e3e-7dedf900ca6e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"297anyw6si795ld0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"202cda43-1cab-4d9e-84fa-c822467dd00f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"vndh\",{\"text\":\"6w0acri0pqb7545666ezxbkmft5fxweoi8v4lsr72ncsr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ba8936-1592-42ef-bb6c-fd0a81a51225\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"lfj6zdrrm\",{\"text\":\"uzl4bq1q7t13huc2236o0sdfu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"598d0dd1-6289-4913-bbfe-6d030d78804a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"3\",{\"text\":\"hraeqjua3w4l23g9o8ubxkzj6sxsp7fhkn9lbixydc9s45lkf9vwv0kxvqwd09l8nfgl5707rx6mqlxzpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"235ec65e-13ff-4d3d-a2dc-b6dc4f50c709\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"s6hl72xh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ba425202-6728-4d8f-a222-97e5ab11e0b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i1ir97j7yw7gbkp43\",{\"text\":\"7yqznczkkxrceqpzgiyhjvudnzuqycwmh8k3qv88z4fmroqlsfq0ph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3bef5181-f976-4296-83ab-e8b2a15b0ec0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"6xx92ztjjw8yikqynnuygat590\",{\"text\":\"mz84lv8db3i8onnizrurc7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"56k7ydjis43furs0\",{\"text\":\"md\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5fcae607-d710-4b1c-9d32-e97b0d954406\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"yg0o3kt\",{\"text\":\"af0avq9czwc5tjamr0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42ded140-6ca6-4c99-883d-07644e0f6f58\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},{\"text\":\"6rfal0ljp11y295jh6kwjeo46w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32169ded-dd64-42a1-a933-d4bfaf8f3e49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i0\",{\"text\":\"akgcjiuey0yj4clutmd4gf062gfjmiblk7vdejpx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"q27u1u0p3xml8\",{\"text\":\"wycf0np6xgxnwiwb3j8cjt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5826790d-ae58-4189-bf50-6993e3c3a412\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6994,\"totalLength\":2543,\"totalSegmentCount\":135}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}},\"listRegistryList-97\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64e54950-4954-484d-879e-506ffd2d369f\"}},\"listRegistryList-45\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/26e122fd-1da7-4d87-a76b-1b9e62ecb135\"}},\"listRegistryList-22\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3005bd3-6996-40a5-8e5c-339bc437f9ab\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/27ca1ad1-988c-4329-87db-4e9e63766937\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64e54950-4954-484d-879e-506ffd2d369f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-97\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "26e122fd-1da7-4d87-a76b-1b9e62ecb135",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-45\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3005bd3-6996-40a5-8e5c-339bc437f9ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-22\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "27ca1ad1-988c-4329-87db-4e9e63766937",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"a69c6df6-8c1a-46f4-a5df-32696c89e6c4\",\"clientSequenceNumber\":12,\"minimumSequenceNumber\":6994,\"referenceSequenceNumber\":6994,\"sequenceNumber\":7000,\"timestamp\":1564172701320,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_7804_0.json
+++ b/snapshotTestContent/ScriptorSprintPlanning2/src_snapshots/0.59.3000/snapshot_7804_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":7797,\"sequenceNumber\":7804,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"90a852d2-0949-437f-a96a-5dd28a7894c9\",{\"client\":{\"user\":{\"id\":\"txfzlmrv4@example.com}\",\"name\":\"oznukq0j4ujb4w3\",\"email\":\"5vyqm2s19@example.com}\"}},\"sequenceNumber\":242}],[\"9a5e75aa-cf40-4b25-80d8-a1afb0a6d399\",{\"client\":{\"user\":{\"id\":\"6u5qj0a4w@example.com}\",\"name\":\"5e4634e6pmevcdy\",\"email\":\"41xk537np@example.com}\"}},\"sequenceNumber\":243}],[\"752719a4-4632-43cc-8e72-e56fcfc96019\",{\"client\":{\"user\":{\"id\":\"o7emtmfvh@example.com}\",\"name\":\"kprbioqj45ec442\",\"email\":\"40m55n0vj@example.com}\"}},\"sequenceNumber\":5753}],[\"91d33a60-4934-422a-9d89-607f80433a0c\",{\"client\":{\"user\":{\"id\":\"dlws3rcig@example.com}\",\"name\":\"av80rgvpswa7axo\",\"email\":\"6ycufpcl6@example.com}\"}},\"sequenceNumber\":5756}],[\"2203017f-cc9a-425e-8779-b20385f51eb9\",{\"client\":{\"user\":{\"id\":\"syn4jnw0t@example.com}\",\"name\":\"yo3uhdujsbjka6y\",\"email\":\"b9u3w75sw@example.com}\"}},\"sequenceNumber\":5772}],[\"594f7e22-52df-4656-a2b0-3ed6ba5982ae\",{\"client\":{\"user\":{\"id\":\"hfccsx231@example.com}\",\"name\":\"khx2ahrqnljzaj0\",\"email\":\"t0afp4mr9@example.com}\"}},\"sequenceNumber\":5773}],[\"10c1bb1a-9ec1-432e-95b5-8cb43aa1af25\",{\"client\":{\"user\":{\"id\":\"72rl2das6@example.com}\",\"name\":\"c1xhfov01chupnf\",\"email\":\"s59jjceij@example.com}\"}},\"sequenceNumber\":7776}],[\"929c7748-e200-43cd-a504-51964948030d\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"fc4kw8om0@example.com}\",\"name\":\"qsrqdqyqwjhplmy\",\"email\":\"xil45xzvh@example.com}\"}},\"sequenceNumber\":7804}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/38d6f6f7-b638-45fe-857b-4a37a48d40f5\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/df5eb3d6-885a-4049-93aa-40557d8a9412\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/5d1d6074-0270-498d-8886-d4a7d169bde6\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9f32d0fa-a487-4235-8e8f-dadcfdb00bc6\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e656101e-230f-4d46-85b5-ac529a07d7ce\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38d6f6f7-b638-45fe-857b-4a37a48d40f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"e35ae945-9dce-4405-8bcb-f3b053e0827e\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":500,\"refSeqNumber\":213}},\"976fa0a2-a2a5-4db4-8725-6ad03c2e9b8c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":263}},\"982e744b-8a18-4c91-9502-36784797501f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":273}},\"5991044c-134f-4419-b21d-663b022ee823\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":289}},\"5991e18a-fd0f-4acc-81a8-512c17c15d44\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":341}},\"caff9589-9475-42dc-98b0-d2ed3fef2a95\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5394}},\"9ae8ce60-7cc4-4bf0-b444-50c460e4cb04\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5454}},\"f89c5fda-6918-4e68-856f-88968b4591ea\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1292,\"refSeqNumber\":5497}},\"9d9a0e8d-ce0a-44be-a1b3-9bd935dcbe17\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5574}},\"63461457-31ec-4fb3-90b6-2136da1db4e1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5585}},\"91d33a60-4934-422a-9d89-607f80433a0c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":206,\"refSeqNumber\":5754}},\"ec9a25c3-d7ad-4902-81d6-89e2e8f904c2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5399}},\"a87adae8-3c20-45e7-bd5c-96a65787c2ff\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":402,\"refSeqNumber\":6631}},\"07721ac6-a004-4b41-b408-9076d07941c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6458}},\"cfaaed4f-c773-4c30-bffd-9399ca76777c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6652}},\"e825eb7d-00c4-4475-81d4-7c09476ba95a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6815}},\"f1099007-8283-4cf0-8d58-2fd379f6482c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":6918}},\"10c1bb1a-9ec1-432e-95b5-8cb43aa1af25\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":2542,\"refSeqNumber\":6631}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "df5eb3d6-885a-4049-93aa-40557d8a9412",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f94f4423-5464-403d-9197-35838845afd7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5d1d6074-0270-498d-8886-d4a7d169bde6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/f94f4423-5464-403d-9197-35838845afd7\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":135,\"chunkLengthChars\":2543,\"totalLengthChars\":2543,\"totalSegmentCount\":135,\"chunkSequenceNumber\":7797,\"segmentTexts\":[{\"text\":\"ed58k2g9bdhxnp6edonvzrhl\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b2bce3b6-3b8d-40e5-9693-6da99d71141c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"wl66seczozgnpt9e9eumbb728yqha8xbjp2xacfv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8620ab21-860a-4834-b7f1-8a0fdf776e95\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"746bc43f-1396-4195-ac0b-aaf3d25dcf9f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9nv8w8yn4occg1f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1a952958-3983-4ac0-b881-ed6345e79196\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"zfdy5eph9pq1aq25ganirdnb1xq9bp9j6mix5n7al23cwt347xsk25e098q7dm34uys3p71asnc7o2v11tk64dbtlr347d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"efa50f3a-35fa-4f7e-97cb-d455a6287a81\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"452bac6d-bbc2-4c68-9438-fca088ba3d5d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ne0bx2ey2cxmw3kf3p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b86a8881-2a1c-497d-bc84-7e4fcaa66ef1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"eeq9\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"068ed76e-0b45-44b9-a182-aaff77e83af1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"0t6\",{\"text\":\"0twdj63uzs21q9m4ag6en\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7c42d3a-bc77-4524-9d1a-822eec647e94\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},{\"text\":\"7w8kwf8866oribvtd2uuslzbmqrt7kyai2ueoxz9wp8cnzx1exl3360bch3dd2satwz5v751tt8hjkmtwm8o0hny3y5r165fi0axp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"509fef51-91ad-44ad-91cb-bdca7ff64bc5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},{\"text\":\"bc5ns6pu\",\"props\":{\"{00000000-0000-2a0c-0000-000000000000}\":\"#FFFF00\"}},\"sx\",{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"q5bd0z5gnq6m01q8zzblw0oxhf7e27bauqubxbo4m612atgk7c2qxgvo28e5r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0224df87-ca26-4739-86ef-07110665cd71\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-22\"}}},\"5\",{\"text\":\"8rarpj2hk5b9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca82caa7-9127-4f4e-80ac-ef4c49da8a21\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\"}}},\"l\",{\"text\":\"oqofp9letn6tnlmzwos\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e1c2971-6023-4bb8-a3ec-fdfc479e0ec6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-45\",\"bold\":false}}},\"6xxuctgk6k31n11tpu4rammq7hz18ygj56eqrg98ef9o54gsnvivsgi253\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e609f884-d94e-4ec6-a5aa-8c9dbbe98500\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\",\"bold\":false}}},\"jtd915td49ygxqo6wx1mrqeg28iyflsjkmb6togda9mgcoxp9a8vau66k0p4jltl\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fd7c6fec-9017-4006-a7b5-ab18d8d1c77c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"56317050-d4ad-48be-8565-ca0c28aa6452\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-45\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"be710130-ad4b-4031-8b0a-2fbe624e4057\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ab67jnb975cily0ke\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7f80832d-b2c2-49f2-af63-abcb25481df1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"u3fg42md64rbg4rnswy6ka1qetl1nrbyfu7uknry9qpgurfb3soy4xjl7pvwww1g54zuev3k5d0t4djv7777ota41yarh7m0v1oxvzn2kn069bbtjbw01tou\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8380526d-65f9-4355-9b98-6ede2f259f18\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"bdx4f\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6a715125-6ee3-4707-a12b-bb45a3f5ade0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},{\"text\":\"4t3pevv4zy6ezpm7p6pgeh6r9kjmdo174w7shbtzvu6bni3py9da9771vovggxhh3pk8eb67n95woy4sylxjiskzuqseyocoseeymtp5rncmdxh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b1935675-46fd-452c-a931-88f4e2952bb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-126\"}}},\"2gbltzgrsjm\",{\"text\":\"xlbbem6q2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83f5f791-08c0-4ea5-bb16-1bc1e12787c3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\"}}},\"zcezgj6nt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"00114d7a-5530-45c7-8d8e-0e001496679f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-126\",\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"tfpdr4mjk4k8e8a1uo5rznrnf5x3p7jhmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dca82c48-4c77-4a86-bbe8-f15c78285add\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"q52osmy3ztnpt9kcd8fk2e\",{\"text\":\"mgn1uyf48sa6ecbw91seatceqwmtha00ohr8ejocnq2dqrt4sm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26627f46-0455-409e-bb8a-f359346dd550\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"301dee1qh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"xafktbhegek15\",{\"text\":\"54sq3frr8nqworpq0g7zsi5lvkf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"s2zejtuz0dm2o6\",{\"text\":\"7p2gujr043d2dlsbnynmsyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c2b91db0-6e60-40b0-8520-ff222b4b14b1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"djdgnepsekd7e4xbfafwlu2pb5hgkyfsxl76jjnnnvx6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"61430c7e-bf50-4e1f-93e3-1534eb0d2f30\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"62s\",{\"text\":\"zur5y1ut8oyc1n07zg9sggzuk5rpybypfwn7yawj3scbcp9006ppfyxsr3lryz62hibf02es1n20ow3gc5wn7uyjye7l113yq3ip0c3d9p36537wn7cqy4mbynv7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f15b13eb-5b8a-4f89-b599-d56e5aad68f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"xbdxuaaf2lh5cussj6qfz\",{\"text\":\"ik3ztx5j4xnfzw6ojsxrd7qo6jia98hu7vnwc10mv0ksxksjkk0wxz86vdwogqa7e84y7i7zjbsgig3sgga2vq1gcp5fdfrkdvddocb2j4q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a4edf88d-25f4-4a86-8415-602b392adf87\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"i2n64bmaemq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"e1j4sinntuqzy0y5kz\",{\"text\":\"sa961tyka6fiepa7zwh\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"iysb7wndqj\",{\"text\":\"xdqeo9ysw4acde5eze8lnymbn81d6glnq4tjc68v9urk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2c3c73f4-9607-4a22-9d40-8a5c66f1f935\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"3q1c3o9s\",{\"text\":\"sl2hfjky31i4p9q8privqi841s8l2envsq12ogpcsqe7y\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"812058ae-508f-43cf-b0d9-d124c45fc2ff\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},{\"text\":\"vn6n56n1vjp8gnoioed3ogvte6tg9lzllieytn5x6k37m4weivoeuhke3661erwrgx7n8em5eypj7edfb3aeejyzes7ftjtdcyi0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3fb48be9-23c4-4a75-81ca-d01733ce3dbc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2}}},\"jm5jbp17pd\",{\"text\":\"q3ljge\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"epab5rvoszvq\",{\"text\":\"72ub3qyjj9vxo4o9v9wckz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cecf4e84-9677-4a5a-9e3e-7dedf900ca6e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"297anyw6si795ld0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"202cda43-1cab-4d9e-84fa-c822467dd00f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":2,\"bold\":false}}},\"vndh\",{\"text\":\"6w0acri0pqb7545666ezxbkmft5fxweoi8v4lsr72ncsr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"87ba8936-1592-42ef-bb6c-fd0a81a51225\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"lfj6zdrrm\",{\"text\":\"uzl4bq1q7t13huc2236o0sdfu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"598d0dd1-6289-4913-bbfe-6d030d78804a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"3\",{\"text\":\"hraeqjua3w4l23g9o8ubxkzj6sxsp7fhkn9lbixydc9s45lkf9vwv0kxvqwd09l8nfgl5707rx6mqlxzpo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"235ec65e-13ff-4d3d-a2dc-b6dc4f50c709\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},\"s6hl72xh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ba425202-6728-4d8f-a222-97e5ab11e0b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i1ir97j7yw7gbkp43\",{\"text\":\"7yqznczkkxrceqpzgiyhjvudnzuqycwmh8k3qv88z4fmroqlsfq0ph\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3bef5181-f976-4296-83ab-e8b2a15b0ec0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"6xx92ztjjw8yikqynnuygat590\",{\"text\":\"mz84lv8db3i8onnizrurc7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"56k7ydjis43furs0\",{\"text\":\"md\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5fcae607-d710-4b1c-9d32-e97b0d954406\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1,\"bold\":false}}},\"yg0o3kt\",{\"text\":\"af0avq9czwc5tjamr0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42ded140-6ca6-4c99-883d-07644e0f6f58\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":1}}},{\"text\":\"6rfal0ljp11y295jh6kwjeo46w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32169ded-dd64-42a1-a933-d4bfaf8f3e49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},\"i0\",{\"text\":\"akgcjiuey0yj4clutmd4gf062gfjmiblk7vdejpx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},\"q27u1u0p3xml8\",{\"text\":\"wycf0np6xgxnwiwb3j8cjt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5826790d-ae58-4189-bf50-6993e3c3a412\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listId\":\"listRegistryList-126\",\"listItemFormatIndex\":0,\"bold\":false}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b9889424-93a3-480a-9846-2d27d1478835\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"079g63q8ca3asiiko\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"768033a4-6cb1-4d5a-843a-80f075698073\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"mvlaw5g9azlkfbds2872vlz2v2uh0kspmvfqddhdbup9f6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f2da2b66-5fc2-4ef8-bccc-c6c64994ec6a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"oymkylxxm18kir3hy\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5cd877d3-708f-4bf3-9878-78747f817947\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList61\"}}},{\"text\":\"djh5256o38ex2j2eva08hb2fya8mvozzqxv6vdaa9dsjr4z2qumg5t80mf88dlwvg29kahairq8k1cehgz4phlilro5436tow6uqy7tm4e7hq0j\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef8ffa37-4430-4687-900d-c80c6a794277\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList33\"}}},{\"text\":\"g8san5rkbflrrn0v9mbz6jgvj6m9bfott4oi30juiusqamahmlfw0w6di8ol7lonknc4ue\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"65e7d314-a122-4b71-8ae6-3b4d06769769\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList33\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5e20a4b2-5c6c-4559-888a-8868e3f39fcc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gw66p7ofvj9kbxmk7ll\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e563051c-b2dd-4248-b3f3-6c1ecb3adcb5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false}}},{\"text\":\"dmb97c8m8um9tar0dmrlre3srbk4jhgkio\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2fe7fbb5-9f1a-48c2-bb7a-fed69ada03a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"o6ro7eyhu6skv1zxdwt7eaixkie3k5tr33bpp6goclsvccafoc2qx3v2z\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35b112fe-c14c-4f27-b73e-c1d1722a7ce1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}},{\"text\":\"x3k1g05s98kao9pi1p0jxh6ij0uzpr5e2vu\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d8802a67-b965-4c48-8ad2-52d4d1595278\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-66\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":7797,\"totalLength\":2543,\"totalSegmentCount\":135}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9f32d0fa-a487-4235-8e8f-dadcfdb00bc6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0651ef88-e35b-4d6c-9897-b78508e72e32\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/84dc0b8d-e03a-442e-8b8e-6851c341e669\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1726e8ac-a0fa-404a-8f90-355f03d06e51\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/6e7bc915-72a8-4ae3-a993-c7764b106601\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/fb8817a0-c927-40f2-8169-9744d854c57f\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0dc9d556-625f-471a-9ff9-3cb653f51994\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/dd866d7f-b49d-441b-b53e-02bdca4add8e\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0651ef88-e35b-4d6c-9897-b78508e72e32",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "84dc0b8d-e03a-442e-8b8e-6851c341e669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1726e8ac-a0fa-404a-8f90-355f03d06e51",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6e7bc915-72a8-4ae3-a993-c7764b106601",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "fb8817a0-c927-40f2-8169-9744d854c57f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0dc9d556-625f-471a-9ff9-3cb653f51994",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dd866d7f-b49d-441b-b53e-02bdca4add8e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e656101e-230f-4d46-85b5-ac529a07d7ce",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList33\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/aa7af431-0fe2-44a6-bc92-27039519650c\"}},\"listRegistryList61\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/e9fd108c-6d06-43b7-ad60-8d5751784227\"}},\"listRegistryList-66\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/abf5a46b-e265-4cfb-ba07-eedb2256f13a\"}},\"listRegistryList-126\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/714e3953-2425-44b0-ac20-c47bcb0b1669\"}},\"listRegistryList-97\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/64e54950-4954-484d-879e-506ffd2d369f\"}},\"listRegistryList-45\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/26e122fd-1da7-4d87-a76b-1b9e62ecb135\"}},\"listRegistryList-22\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b3005bd3-6996-40a5-8e5c-339bc437f9ab\"}},\"listRegistryList-110\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/27ca1ad1-988c-4329-87db-4e9e63766937\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "aa7af431-0fe2-44a6-bc92-27039519650c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList33\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e9fd108c-6d06-43b7-ad60-8d5751784227",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList61\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "abf5a46b-e265-4cfb-ba07-eedb2256f13a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-66\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "714e3953-2425-44b0-ac20-c47bcb0b1669",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-126\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "64e54950-4954-484d-879e-506ffd2d369f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-97\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "26e122fd-1da7-4d87-a76b-1b9e62ecb135",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-45\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b3005bd3-6996-40a5-8e5c-339bc437f9ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-22\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "27ca1ad1-988c-4329-87db-4e9e63766937",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-110\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":7797,\"referenceSequenceNumber\":-1,\"sequenceNumber\":7804,\"timestamp\":1564422250303,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_125_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_125_0.json
@@ -1,0 +1,2888 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":123,\"sequenceNumber\":125,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"2043528d-03b2-4eac-afd4-6f05ed83d1ac\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688274807,\"mode\":\"write\"},\"sequenceNumber\":78}],[\"bcbbe258-bd3d-479d-8ea0-c6873855bca1\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688324435,\"mode\":\"write\"},\"sequenceNumber\":102}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":3,\"length\":6,\"segments\":[[1,4],[3,1],[2,5]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":123,\"sequenceNumber\":125,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":6,\"totalSegmentCount\":3}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[7,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":123,\"sequenceNumber\":125,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},null,null,{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"bcbbe258-bd3d-479d-8ea0-c6873855bca1\",\"clientSequenceNumber\":19,\"minimumSequenceNumber\":123,\"referenceSequenceNumber\":124,\"sequenceNumber\":125,\"timestamp\":1646688337947,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\",\"/570f508d-007d-4502-8213-c8cb1c51f018\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_128_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_128_0.json
@@ -1,0 +1,2888 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":123,\"sequenceNumber\":128,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"bcbbe258-bd3d-479d-8ea0-c6873855bca1\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688324435,\"mode\":\"write\"},\"sequenceNumber\":102}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":3,\"length\":6,\"segments\":[[1,4],[3,1],[2,5]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":123,\"sequenceNumber\":128,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":6,\"totalSegmentCount\":3}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[7,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":123,\"sequenceNumber\":128,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},null,null,{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":123,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":123,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":123,\"referenceSequenceNumber\":-1,\"sequenceNumber\":128,\"timestamp\":1646688360834,\"type\":\"leave\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\",\"/570f508d-007d-4502-8213-c8cb1c51f018\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_189_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_189_0.json
@@ -1,0 +1,3608 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":187,\"sequenceNumber\":189,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688384281,\"mode\":\"write\"},\"sequenceNumber\":131}],[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688401739,\"mode\":\"write\"},\"sequenceNumber\":154}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":3,\"length\":8,\"segments\":[[1,4],[3,1],[4,5]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":187,\"sequenceNumber\":189,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":8,\"totalSegmentCount\":3}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[9,0,0,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":187,\"sequenceNumber\":189,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,{\"id\":\"0f163713-5ea0-40f3-b69e-390a358a7c22\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"}}},{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,{\"id\":\"cc4f51b2-938b-4f1d-969d-26bcbbb2aa28\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e\"}}},null,null,null,null,null,null,null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b4c1c436-d533-4d3c-abbc-c60e8ae1be95",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c25bf0d5-ff0a-42a0-9689-280eb09aac1c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":4,\"totalLengthChars\":4,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"asd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"ads\",\"Asd\",\"as\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"95f8d7e1-9024-4ddf-bc34-b114befa158c\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "48285434-9a83-41cc-8ae5-f5dcb49d8369",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5aa31e6a-3749-4ba2-9305-2aa0512ec5b0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"b4abc57c-1270-4a64-a1d1-803b9833dd45\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "471bc487-438e-4f95-b33d-f4b1d7f2aace",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46b84a10-53f7-469f-a849-04db1d8918b6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"242480b0-ae14-49ea-a545-3274183a1478\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "490e917c-9805-40b5-93d9-3b52c444f8c8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf847818-809d-41f4-9dc8-e9389d87b82d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"988e4338-27fb-4124-a330-63fc8d5cb818\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2f989fd2-bb56-4d76-809e-b672000fa9f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":7,\"totalLengthChars\":7,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"asdsad\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsad\",\"Assad\",\"assay\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7b1d9334-4447-41e9-8134-4090cb9352bd\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":7,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "af627ff8-30d1-4e89-8220-12c59b99016e",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d2dba981-eeb5-4fdc-aa91-8549d108f8bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":9,\"totalLengthChars\":9,\"totalSegmentCount\":2,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"text\":\"asdasdsd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsads'd\",\"Sadsads\",\"Sadsads'\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"1fc7dbca-f11f-4693-872f-c63827533a35\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":9,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f3a00f9-e6ce-40c1-a206-1650c1280a86",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0f98d43-9e0c-41d1-9bee-e72fd5407d90",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"5ef1d1b7-ccb3-4f11-9e9f-1443cb3bceb4\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b194361b-3b4b-4623-b7b9-fe5857095751",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc03124d-5ee3-4a74-b3bc-fd2c5f93b954",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":187,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8859a370-84e1-4e01-914f-0e5a0553b3ee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":187,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",\"clientSequenceNumber\":24,\"minimumSequenceNumber\":187,\"referenceSequenceNumber\":188,\"sequenceNumber\":189,\"timestamp\":1646688419462,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\",\"/570f508d-007d-4502-8213-c8cb1c51f018\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\",\"/af627ff8-30d1-4e89-8220-12c59b99016e\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\",\"/b194361b-3b4b-4623-b7b9-fe5857095751\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"]},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"]},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"]},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"]},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"]},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"]},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"]},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"]},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"]},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"]},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"]},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"]},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"]},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"]},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"]},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"]},\"/490e917c-9805-40b5-93d9-3b52c444f8c8\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"]},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"]},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"]},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"]},\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\",\"/af627ff8-30d1-4e89-8220-12c59b99016e\"]},\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e\"]},\"/af627ff8-30d1-4e89-8220-12c59b99016e\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\",\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"]},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"]},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"]},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"]},\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\",\"/b194361b-3b4b-4623-b7b9-fe5857095751\"]},\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751\"]},\"/b194361b-3b4b-4623-b7b9-fe5857095751\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\",\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_457_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_457_0.json
@@ -1,0 +1,3645 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":189,\"sequenceNumber\":457,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688384281,\"mode\":\"write\"},\"sequenceNumber\":131}],[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688401739,\"mode\":\"write\"},\"sequenceNumber\":154}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":2,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"nodeType\":\"Paragraph\",\"markerId\":\"be62d0e4-0791-4cd2-973c-012d813ec960\"}},\"type\":0},\"metadata\":{\"batch\":true},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":227,\"sequenceNumber\":228,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":2,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{\"batch\":false},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":228,\"sequenceNumber\":229,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":3,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":229,\"sequenceNumber\":230,\"term\":1,\"timestamp\":1646688471871,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":4,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":230,\"sequenceNumber\":231,\"term\":1,\"timestamp\":1646688471905,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":5,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":231,\"sequenceNumber\":232,\"term\":1,\"timestamp\":1646688471942,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":6,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":232,\"sequenceNumber\":233,\"term\":1,\"timestamp\":1646688471970,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":7,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":233,\"sequenceNumber\":234,\"term\":1,\"timestamp\":1646688471996,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":8,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":234,\"sequenceNumber\":235,\"term\":1,\"timestamp\":1646688472053,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":9,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":235,\"sequenceNumber\":236,\"term\":1,\"timestamp\":1646688472076,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":91,\"contents\":{\"pos1\":10,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":236,\"sequenceNumber\":237,\"term\":1,\"timestamp\":1646688472113,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":11,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":237,\"sequenceNumber\":238,\"term\":1,\"timestamp\":1646688472140,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":93,\"contents\":{\"pos1\":12,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":238,\"sequenceNumber\":239,\"term\":1,\"timestamp\":1646688472170,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":13,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":239,\"sequenceNumber\":240,\"term\":1,\"timestamp\":1646688472210,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":95,\"contents\":{\"pos1\":14,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":240,\"sequenceNumber\":241,\"term\":1,\"timestamp\":1646688472242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":15,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":241,\"sequenceNumber\":242,\"term\":1,\"timestamp\":1646688472265,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":97,\"contents\":{\"pos1\":16,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":242,\"sequenceNumber\":243,\"term\":1,\"timestamp\":1646688472299,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":17,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":243,\"sequenceNumber\":244,\"term\":1,\"timestamp\":1646688472332,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":99,\"contents\":{\"pos1\":18,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":244,\"sequenceNumber\":245,\"term\":1,\"timestamp\":1646688472382,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":19,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":245,\"sequenceNumber\":246,\"term\":1,\"timestamp\":1646688472406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":20,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":246,\"sequenceNumber\":247,\"term\":1,\"timestamp\":1646688472442,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":21,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":247,\"sequenceNumber\":248,\"term\":1,\"timestamp\":1646688472470,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":22,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":248,\"sequenceNumber\":249,\"term\":1,\"timestamp\":1646688472513,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":23,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":249,\"sequenceNumber\":250,\"term\":1,\"timestamp\":1646688472537,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":105,\"contents\":{\"pos1\":24,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":250,\"sequenceNumber\":251,\"term\":1,\"timestamp\":1646688472568,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":25,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":251,\"sequenceNumber\":252,\"term\":1,\"timestamp\":1646688472603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":107,\"contents\":{\"pos1\":26,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":252,\"sequenceNumber\":253,\"term\":1,\"timestamp\":1646688472630,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":27,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":253,\"sequenceNumber\":254,\"term\":1,\"timestamp\":1646688472661,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":109,\"contents\":{\"pos1\":28,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":254,\"sequenceNumber\":255,\"term\":1,\"timestamp\":1646688472692,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":110,\"contents\":{\"pos1\":29,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":255,\"sequenceNumber\":256,\"term\":1,\"timestamp\":1646688472727,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":30,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":256,\"sequenceNumber\":257,\"term\":1,\"timestamp\":1646688472756,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":112,\"contents\":{\"pos1\":31,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":257,\"sequenceNumber\":258,\"term\":1,\"timestamp\":1646688472803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":32,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":258,\"sequenceNumber\":259,\"term\":1,\"timestamp\":1646688472834,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":114,\"contents\":{\"pos1\":33,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":259,\"sequenceNumber\":260,\"term\":1,\"timestamp\":1646688472870,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":34,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":260,\"sequenceNumber\":261,\"term\":1,\"timestamp\":1646688472918,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":116,\"contents\":{\"pos1\":35,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":261,\"sequenceNumber\":262,\"term\":1,\"timestamp\":1646688472935,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":36,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":262,\"sequenceNumber\":263,\"term\":1,\"timestamp\":1646688472969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":37,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":263,\"sequenceNumber\":264,\"term\":1,\"timestamp\":1646688473006,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":119,\"contents\":{\"pos1\":38,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":264,\"sequenceNumber\":265,\"term\":1,\"timestamp\":1646688473030,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":39,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":265,\"sequenceNumber\":266,\"term\":1,\"timestamp\":1646688473063,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":121,\"contents\":{\"pos1\":40,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":266,\"sequenceNumber\":267,\"term\":1,\"timestamp\":1646688473093,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":41,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":267,\"sequenceNumber\":268,\"term\":1,\"timestamp\":1646688473120,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":123,\"contents\":{\"pos1\":42,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":268,\"sequenceNumber\":269,\"term\":1,\"timestamp\":1646688473168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":43,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":269,\"sequenceNumber\":270,\"term\":1,\"timestamp\":1646688473199,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":125,\"contents\":{\"pos1\":44,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":270,\"sequenceNumber\":271,\"term\":1,\"timestamp\":1646688473244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":45,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":271,\"sequenceNumber\":272,\"term\":1,\"timestamp\":1646688473264,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":127,\"contents\":{\"pos1\":46,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":272,\"sequenceNumber\":273,\"term\":1,\"timestamp\":1646688473294,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":47,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":273,\"sequenceNumber\":274,\"term\":1,\"timestamp\":1646688473326,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":129,\"contents\":{\"pos1\":48,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":274,\"sequenceNumber\":275,\"term\":1,\"timestamp\":1646688473360,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":49,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":275,\"sequenceNumber\":276,\"term\":1,\"timestamp\":1646688473399,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":50,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":276,\"sequenceNumber\":277,\"term\":1,\"timestamp\":1646688473428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":132,\"contents\":{\"pos1\":51,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":277,\"sequenceNumber\":278,\"term\":1,\"timestamp\":1646688473457,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":52,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":278,\"sequenceNumber\":279,\"term\":1,\"timestamp\":1646688473492,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":53,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":279,\"sequenceNumber\":280,\"term\":1,\"timestamp\":1646688473517,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":54,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":280,\"sequenceNumber\":281,\"term\":1,\"timestamp\":1646688473547,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":136,\"contents\":{\"pos1\":55,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":281,\"sequenceNumber\":282,\"term\":1,\"timestamp\":1646688473596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":56,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":282,\"sequenceNumber\":283,\"term\":1,\"timestamp\":1646688473634,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":138,\"contents\":{\"pos1\":57,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":283,\"sequenceNumber\":284,\"term\":1,\"timestamp\":1646688473662,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":58,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":284,\"sequenceNumber\":285,\"term\":1,\"timestamp\":1646688473691,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":140,\"contents\":{\"pos1\":59,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":285,\"sequenceNumber\":286,\"term\":1,\"timestamp\":1646688473728,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":60,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":286,\"sequenceNumber\":287,\"term\":1,\"timestamp\":1646688473758,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":142,\"contents\":{\"pos1\":61,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":287,\"sequenceNumber\":288,\"term\":1,\"timestamp\":1646688473792,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":62,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":288,\"sequenceNumber\":289,\"term\":1,\"timestamp\":1646688473817,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":144,\"contents\":{\"pos1\":63,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":289,\"sequenceNumber\":290,\"term\":1,\"timestamp\":1646688473855,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":64,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":290,\"sequenceNumber\":291,\"term\":1,\"timestamp\":1646688473879,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":146,\"contents\":{\"pos1\":65,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":291,\"sequenceNumber\":292,\"term\":1,\"timestamp\":1646688473913,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":66,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":292,\"sequenceNumber\":293,\"term\":1,\"timestamp\":1646688473944,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":148,\"contents\":{\"pos1\":67,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":293,\"sequenceNumber\":294,\"term\":1,\"timestamp\":1646688473991,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":68,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":294,\"sequenceNumber\":295,\"term\":1,\"timestamp\":1646688474023,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":150,\"contents\":{\"pos1\":69,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":295,\"sequenceNumber\":296,\"term\":1,\"timestamp\":1646688474054,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":70,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":296,\"sequenceNumber\":297,\"term\":1,\"timestamp\":1646688474086,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":152,\"contents\":{\"pos1\":71,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":297,\"sequenceNumber\":298,\"term\":1,\"timestamp\":1646688474119,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":72,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":298,\"sequenceNumber\":299,\"term\":1,\"timestamp\":1646688474147,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":154,\"contents\":{\"pos1\":73,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":299,\"sequenceNumber\":300,\"term\":1,\"timestamp\":1646688474178,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":74,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":300,\"sequenceNumber\":301,\"term\":1,\"timestamp\":1646688474214,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":156,\"contents\":{\"pos1\":75,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":301,\"sequenceNumber\":302,\"term\":1,\"timestamp\":1646688474242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":76,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":302,\"sequenceNumber\":303,\"term\":1,\"timestamp\":1646688474279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":158,\"contents\":{\"pos1\":77,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":303,\"sequenceNumber\":304,\"term\":1,\"timestamp\":1646688474306,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":78,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":304,\"sequenceNumber\":305,\"term\":1,\"timestamp\":1646688474355,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":160,\"contents\":{\"pos1\":79,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":305,\"sequenceNumber\":306,\"term\":1,\"timestamp\":1646688474388,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":80,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":306,\"sequenceNumber\":307,\"term\":1,\"timestamp\":1646688474415,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":162,\"contents\":{\"pos1\":81,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":307,\"sequenceNumber\":308,\"term\":1,\"timestamp\":1646688474449,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":163,\"contents\":{\"pos1\":82,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":308,\"sequenceNumber\":309,\"term\":1,\"timestamp\":1646688474482,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":164,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":309,\"sequenceNumber\":310,\"term\":1,\"timestamp\":1646688474514,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":165,\"contents\":{\"pos1\":84,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":310,\"sequenceNumber\":311,\"term\":1,\"timestamp\":1646688474559,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":166,\"contents\":{\"pos1\":85,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":311,\"sequenceNumber\":312,\"term\":1,\"timestamp\":1646688474576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":86,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":312,\"sequenceNumber\":313,\"term\":1,\"timestamp\":1646688474611,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":168,\"contents\":{\"pos1\":87,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":313,\"sequenceNumber\":314,\"term\":1,\"timestamp\":1646688474643,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":88,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":314,\"sequenceNumber\":315,\"term\":1,\"timestamp\":1646688474672,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":170,\"contents\":{\"pos1\":89,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":315,\"sequenceNumber\":316,\"term\":1,\"timestamp\":1646688474705,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":90,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":316,\"sequenceNumber\":317,\"term\":1,\"timestamp\":1646688474739,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":91,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":317,\"sequenceNumber\":318,\"term\":1,\"timestamp\":1646688474774,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":173,\"contents\":{\"pos1\":92,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":318,\"sequenceNumber\":319,\"term\":1,\"timestamp\":1646688474803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":93,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":319,\"sequenceNumber\":320,\"term\":1,\"timestamp\":1646688474860,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":175,\"contents\":{\"pos1\":94,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":320,\"sequenceNumber\":321,\"term\":1,\"timestamp\":1646688474882,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":176,\"contents\":{\"pos1\":95,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":321,\"sequenceNumber\":322,\"term\":1,\"timestamp\":1646688474914,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":177,\"contents\":{\"pos1\":96,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":322,\"sequenceNumber\":323,\"term\":1,\"timestamp\":1646688474945,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":97,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":323,\"sequenceNumber\":324,\"term\":1,\"timestamp\":1646688474977,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":179,\"contents\":{\"pos1\":98,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":324,\"sequenceNumber\":325,\"term\":1,\"timestamp\":1646688475012,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":99,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":325,\"sequenceNumber\":326,\"term\":1,\"timestamp\":1646688475042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":181,\"contents\":{\"pos1\":100,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":326,\"sequenceNumber\":327,\"term\":1,\"timestamp\":1646688475075,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":101,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":327,\"sequenceNumber\":328,\"term\":1,\"timestamp\":1646688475110,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":183,\"contents\":{\"pos1\":102,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":328,\"sequenceNumber\":329,\"term\":1,\"timestamp\":1646688475134,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":103,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":329,\"sequenceNumber\":330,\"term\":1,\"timestamp\":1646688475168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":185,\"contents\":{\"pos1\":104,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":330,\"sequenceNumber\":331,\"term\":1,\"timestamp\":1646688475213,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":105,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":331,\"sequenceNumber\":332,\"term\":1,\"timestamp\":1646688475244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":187,\"contents\":{\"pos1\":106,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":332,\"sequenceNumber\":333,\"term\":1,\"timestamp\":1646688475276,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":107,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":333,\"sequenceNumber\":334,\"term\":1,\"timestamp\":1646688475311,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":189,\"contents\":{\"pos1\":108,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":334,\"sequenceNumber\":335,\"term\":1,\"timestamp\":1646688475340,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":109,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":335,\"sequenceNumber\":336,\"term\":1,\"timestamp\":1646688475373,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":191,\"contents\":{\"pos1\":110,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":336,\"sequenceNumber\":337,\"term\":1,\"timestamp\":1646688475406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":192,\"contents\":{\"pos1\":111,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":337,\"sequenceNumber\":338,\"term\":1,\"timestamp\":1646688475435,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":193,\"contents\":{\"pos1\":112,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":338,\"sequenceNumber\":339,\"term\":1,\"timestamp\":1646688475467,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":113,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":339,\"sequenceNumber\":340,\"term\":1,\"timestamp\":1646688475498,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":195,\"contents\":{\"pos1\":114,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":340,\"sequenceNumber\":341,\"term\":1,\"timestamp\":1646688475529,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":196,\"contents\":{\"pos1\":115,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":341,\"sequenceNumber\":342,\"term\":1,\"timestamp\":1646688475576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":197,\"contents\":{\"pos1\":116,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":342,\"sequenceNumber\":343,\"term\":1,\"timestamp\":1646688475603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":198,\"contents\":{\"pos1\":117,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":343,\"sequenceNumber\":344,\"term\":1,\"timestamp\":1646688475635,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":199,\"contents\":{\"pos1\":118,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":344,\"sequenceNumber\":345,\"term\":1,\"timestamp\":1646688475667,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":200,\"contents\":{\"pos1\":119,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":345,\"sequenceNumber\":346,\"term\":1,\"timestamp\":1646688475709,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":201,\"contents\":{\"pos1\":120,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":346,\"sequenceNumber\":347,\"term\":1,\"timestamp\":1646688475730,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":202,\"contents\":{\"pos1\":121,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":347,\"sequenceNumber\":348,\"term\":1,\"timestamp\":1646688475762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":203,\"contents\":{\"pos1\":122,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":348,\"sequenceNumber\":349,\"term\":1,\"timestamp\":1646688475795,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":204,\"contents\":{\"pos1\":123,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":349,\"sequenceNumber\":350,\"term\":1,\"timestamp\":1646688475828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":205,\"contents\":{\"pos1\":124,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":350,\"sequenceNumber\":351,\"term\":1,\"timestamp\":1646688475859,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":206,\"contents\":{\"pos1\":125,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":351,\"sequenceNumber\":352,\"term\":1,\"timestamp\":1646688475906,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":207,\"contents\":{\"pos1\":126,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":352,\"sequenceNumber\":353,\"term\":1,\"timestamp\":1646688475939,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":208,\"contents\":{\"pos1\":127,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":353,\"sequenceNumber\":354,\"term\":1,\"timestamp\":1646688475969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":209,\"contents\":{\"pos1\":128,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":354,\"sequenceNumber\":355,\"term\":1,\"timestamp\":1646688475999,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":210,\"contents\":{\"pos1\":129,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":355,\"sequenceNumber\":356,\"term\":1,\"timestamp\":1646688476031,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":211,\"contents\":{\"pos1\":130,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":356,\"sequenceNumber\":357,\"term\":1,\"timestamp\":1646688476062,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":212,\"contents\":{\"pos1\":131,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":357,\"sequenceNumber\":358,\"term\":1,\"timestamp\":1646688476094,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":213,\"contents\":{\"pos1\":132,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":358,\"sequenceNumber\":359,\"term\":1,\"timestamp\":1646688476128,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":214,\"contents\":{\"pos1\":133,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":359,\"sequenceNumber\":360,\"term\":1,\"timestamp\":1646688476157,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":215,\"contents\":{\"pos1\":134,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":360,\"sequenceNumber\":361,\"term\":1,\"timestamp\":1646688476191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":216,\"contents\":{\"pos1\":135,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":361,\"sequenceNumber\":362,\"term\":1,\"timestamp\":1646688476240,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":217,\"contents\":{\"pos1\":136,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":362,\"sequenceNumber\":363,\"term\":1,\"timestamp\":1646688476269,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":137,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":363,\"sequenceNumber\":364,\"term\":1,\"timestamp\":1646688476301,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":219,\"contents\":{\"pos1\":138,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":364,\"sequenceNumber\":365,\"term\":1,\"timestamp\":1646688476335,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":139,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":365,\"sequenceNumber\":366,\"term\":1,\"timestamp\":1646688476363,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":221,\"contents\":{\"pos1\":140,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":366,\"sequenceNumber\":367,\"term\":1,\"timestamp\":1646688476398,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":222,\"contents\":{\"pos1\":141,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":367,\"sequenceNumber\":368,\"term\":1,\"timestamp\":1646688476428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":223,\"contents\":{\"pos1\":142,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":368,\"sequenceNumber\":369,\"term\":1,\"timestamp\":1646688476459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":224,\"contents\":{\"pos1\":143,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":369,\"sequenceNumber\":370,\"term\":1,\"timestamp\":1646688476491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":225,\"contents\":{\"pos1\":144,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":370,\"sequenceNumber\":371,\"term\":1,\"timestamp\":1646688476523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":226,\"contents\":{\"pos1\":145,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":371,\"sequenceNumber\":372,\"term\":1,\"timestamp\":1646688476562,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":227,\"contents\":{\"pos1\":146,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":372,\"sequenceNumber\":373,\"term\":1,\"timestamp\":1646688476592,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":228,\"contents\":{\"pos1\":147,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":373,\"sequenceNumber\":374,\"term\":1,\"timestamp\":1646688476628,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":229,\"contents\":{\"pos1\":148,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":374,\"sequenceNumber\":375,\"term\":1,\"timestamp\":1646688476666,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":230,\"contents\":{\"pos1\":149,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":375,\"sequenceNumber\":376,\"term\":1,\"timestamp\":1646688476697,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":231,\"contents\":{\"pos1\":150,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":376,\"sequenceNumber\":377,\"term\":1,\"timestamp\":1646688476732,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":232,\"contents\":{\"pos1\":151,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":377,\"sequenceNumber\":378,\"term\":1,\"timestamp\":1646688476766,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":233,\"contents\":{\"pos1\":152,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":378,\"sequenceNumber\":379,\"term\":1,\"timestamp\":1646688476793,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":234,\"contents\":{\"pos1\":153,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":379,\"sequenceNumber\":380,\"term\":1,\"timestamp\":1646688476828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":235,\"contents\":{\"pos1\":154,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":380,\"sequenceNumber\":381,\"term\":1,\"timestamp\":1646688476875,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":236,\"contents\":{\"pos1\":155,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":381,\"sequenceNumber\":382,\"term\":1,\"timestamp\":1646688476890,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":237,\"contents\":{\"pos1\":156,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":382,\"sequenceNumber\":383,\"term\":1,\"timestamp\":1646688476930,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":238,\"contents\":{\"pos1\":157,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":383,\"sequenceNumber\":384,\"term\":1,\"timestamp\":1646688476979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":239,\"contents\":{\"pos1\":158,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":384,\"sequenceNumber\":385,\"term\":1,\"timestamp\":1646688476984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":240,\"contents\":{\"pos1\":159,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":385,\"sequenceNumber\":386,\"term\":1,\"timestamp\":1646688477013,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":241,\"contents\":{\"pos1\":160,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":386,\"sequenceNumber\":387,\"term\":1,\"timestamp\":1646688477047,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":242,\"contents\":{\"pos1\":161,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":387,\"sequenceNumber\":388,\"term\":1,\"timestamp\":1646688477091,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":243,\"contents\":{\"pos1\":162,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":388,\"sequenceNumber\":389,\"term\":1,\"timestamp\":1646688477121,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":244,\"contents\":{\"pos1\":163,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":389,\"sequenceNumber\":390,\"term\":1,\"timestamp\":1646688477154,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":245,\"contents\":{\"pos1\":164,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":390,\"sequenceNumber\":391,\"term\":1,\"timestamp\":1646688477188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":246,\"contents\":{\"pos1\":165,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":391,\"sequenceNumber\":392,\"term\":1,\"timestamp\":1646688477217,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":166,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":392,\"sequenceNumber\":393,\"term\":1,\"timestamp\":1646688477249,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":248,\"contents\":{\"pos1\":167,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":393,\"sequenceNumber\":394,\"term\":1,\"timestamp\":1646688477279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":168,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":394,\"sequenceNumber\":395,\"term\":1,\"timestamp\":1646688477314,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":250,\"contents\":{\"pos1\":169,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":395,\"sequenceNumber\":396,\"term\":1,\"timestamp\":1646688477344,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":251,\"contents\":{\"pos1\":170,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":396,\"sequenceNumber\":397,\"term\":1,\"timestamp\":1646688477376,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":252,\"contents\":{\"pos1\":171,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":397,\"sequenceNumber\":398,\"term\":1,\"timestamp\":1646688477426,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":172,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":398,\"sequenceNumber\":399,\"term\":1,\"timestamp\":1646688477459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":254,\"contents\":{\"pos1\":173,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":399,\"sequenceNumber\":400,\"term\":1,\"timestamp\":1646688477488,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":255,\"contents\":{\"pos1\":174,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":400,\"sequenceNumber\":401,\"term\":1,\"timestamp\":1646688477524,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":256,\"contents\":{\"pos1\":175,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":401,\"sequenceNumber\":402,\"term\":1,\"timestamp\":1646688477552,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":257,\"contents\":{\"pos1\":176,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":402,\"sequenceNumber\":403,\"term\":1,\"timestamp\":1646688477584,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":258,\"contents\":{\"pos1\":177,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":403,\"sequenceNumber\":404,\"term\":1,\"timestamp\":1646688477613,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":259,\"contents\":{\"pos1\":178,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":404,\"sequenceNumber\":405,\"term\":1,\"timestamp\":1646688477652,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":260,\"contents\":{\"pos1\":179,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":405,\"sequenceNumber\":406,\"term\":1,\"timestamp\":1646688477688,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":261,\"contents\":{\"pos1\":180,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":406,\"sequenceNumber\":407,\"term\":1,\"timestamp\":1646688477712,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":262,\"contents\":{\"pos1\":181,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":407,\"sequenceNumber\":408,\"term\":1,\"timestamp\":1646688477749,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":263,\"contents\":{\"pos1\":182,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":408,\"sequenceNumber\":409,\"term\":1,\"timestamp\":1646688477776,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":264,\"contents\":{\"pos1\":183,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":409,\"sequenceNumber\":410,\"term\":1,\"timestamp\":1646688477820,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":265,\"contents\":{\"pos1\":184,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":410,\"sequenceNumber\":411,\"term\":1,\"timestamp\":1646688477852,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":266,\"contents\":{\"pos1\":185,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":411,\"sequenceNumber\":412,\"term\":1,\"timestamp\":1646688477883,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":267,\"contents\":{\"pos1\":186,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":412,\"sequenceNumber\":413,\"term\":1,\"timestamp\":1646688477916,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":268,\"contents\":{\"pos1\":187,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":413,\"sequenceNumber\":414,\"term\":1,\"timestamp\":1646688477948,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":269,\"contents\":{\"pos1\":188,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":414,\"sequenceNumber\":415,\"term\":1,\"timestamp\":1646688477979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":270,\"contents\":{\"pos1\":189,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":415,\"sequenceNumber\":416,\"term\":1,\"timestamp\":1646688478009,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":271,\"contents\":{\"pos1\":190,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":416,\"sequenceNumber\":417,\"term\":1,\"timestamp\":1646688478042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":273,\"contents\":{\"pos1\":191,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":417,\"sequenceNumber\":418,\"term\":1,\"timestamp\":1646688490596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":274,\"contents\":{\"pos1\":192,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":418,\"sequenceNumber\":419,\"term\":1,\"timestamp\":1646688491109,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":275,\"contents\":{\"pos1\":193,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":419,\"sequenceNumber\":420,\"term\":1,\"timestamp\":1646688491129,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":276,\"contents\":{\"pos1\":194,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":420,\"sequenceNumber\":421,\"term\":1,\"timestamp\":1646688491168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":277,\"contents\":{\"pos1\":195,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":421,\"sequenceNumber\":422,\"term\":1,\"timestamp\":1646688491188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":278,\"contents\":{\"pos1\":196,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":422,\"sequenceNumber\":423,\"term\":1,\"timestamp\":1646688491221,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":279,\"contents\":{\"pos1\":197,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":423,\"sequenceNumber\":424,\"term\":1,\"timestamp\":1646688491272,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":198,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":424,\"sequenceNumber\":425,\"term\":1,\"timestamp\":1646688491305,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":281,\"contents\":{\"pos1\":199,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":425,\"sequenceNumber\":426,\"term\":1,\"timestamp\":1646688491329,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":282,\"contents\":{\"pos1\":200,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":426,\"sequenceNumber\":427,\"term\":1,\"timestamp\":1646688491366,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":283,\"contents\":{\"pos1\":201,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":427,\"sequenceNumber\":428,\"term\":1,\"timestamp\":1646688491396,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":202,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":428,\"sequenceNumber\":429,\"term\":1,\"timestamp\":1646688491433,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":285,\"contents\":{\"pos1\":203,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":429,\"sequenceNumber\":430,\"term\":1,\"timestamp\":1646688491462,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":204,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":430,\"sequenceNumber\":431,\"term\":1,\"timestamp\":1646688491491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":287,\"contents\":{\"pos1\":205,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":431,\"sequenceNumber\":432,\"term\":1,\"timestamp\":1646688491523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":206,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":432,\"sequenceNumber\":433,\"term\":1,\"timestamp\":1646688491555,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":289,\"contents\":{\"pos1\":207,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":433,\"sequenceNumber\":434,\"term\":1,\"timestamp\":1646688491583,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":208,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":434,\"sequenceNumber\":435,\"term\":1,\"timestamp\":1646688491617,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":291,\"contents\":{\"pos1\":209,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":435,\"sequenceNumber\":436,\"term\":1,\"timestamp\":1646688491653,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":210,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":436,\"sequenceNumber\":437,\"term\":1,\"timestamp\":1646688491702,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":293,\"contents\":{\"pos1\":211,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":437,\"sequenceNumber\":438,\"term\":1,\"timestamp\":1646688491733,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":212,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":438,\"sequenceNumber\":439,\"term\":1,\"timestamp\":1646688491762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":295,\"contents\":{\"pos1\":213,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":439,\"sequenceNumber\":440,\"term\":1,\"timestamp\":1646688491796,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":296,\"contents\":{\"pos1\":214,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":440,\"sequenceNumber\":441,\"term\":1,\"timestamp\":1646688491823,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":297,\"contents\":{\"pos1\":215,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":441,\"sequenceNumber\":442,\"term\":1,\"timestamp\":1646688491868,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":216,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":442,\"sequenceNumber\":443,\"term\":1,\"timestamp\":1646688491892,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":299,\"contents\":{\"pos1\":217,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":443,\"sequenceNumber\":444,\"term\":1,\"timestamp\":1646688491922,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":300,\"contents\":{\"pos1\":218,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":444,\"sequenceNumber\":445,\"term\":1,\"timestamp\":1646688491956,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":301,\"contents\":{\"pos1\":219,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":445,\"sequenceNumber\":446,\"term\":1,\"timestamp\":1646688491984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":220,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":446,\"sequenceNumber\":447,\"term\":1,\"timestamp\":1646688492018,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":303,\"contents\":{\"pos1\":221,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":447,\"sequenceNumber\":448,\"term\":1,\"timestamp\":1646688492060,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":304,\"contents\":{\"pos1\":222,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":448,\"sequenceNumber\":449,\"term\":1,\"timestamp\":1646688492080,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":305,\"contents\":{\"pos1\":223,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":449,\"sequenceNumber\":450,\"term\":1,\"timestamp\":1646688492111,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":306,\"contents\":{\"pos1\":224,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":450,\"sequenceNumber\":451,\"term\":1,\"timestamp\":1646688492145,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":307,\"contents\":{\"pos1\":225,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":451,\"sequenceNumber\":452,\"term\":1,\"timestamp\":1646688492191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":308,\"contents\":{\"pos1\":226,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":452,\"sequenceNumber\":453,\"term\":1,\"timestamp\":1646688492223,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":309,\"contents\":{\"pos1\":227,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":453,\"sequenceNumber\":454,\"term\":1,\"timestamp\":1646688492256,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":310,\"contents\":{\"pos1\":228,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":454,\"sequenceNumber\":455,\"term\":1,\"timestamp\":1646688492288,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":311,\"contents\":{\"pos1\":229,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":455,\"sequenceNumber\":456,\"term\":1,\"timestamp\":1646688492319,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":313,\"contents\":{\"pos1\":230,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":456,\"sequenceNumber\":457,\"term\":1,\"timestamp\":1646688495162,\"type\":\"op\"}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":8,\"length\":8,\"segments\":[[1,4],{\"json\":[1,1],\"removedSeq\":225,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,2],\"removedSeq\":222,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,3],\"removedSeq\":216,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,5],\"removedSeq\":207,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,6],\"removedSeq\":204,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,7],\"removedSeq\":195,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,8],\"removedSeq\":192,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"}],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":457,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":8,\"totalSegmentCount\":8}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[9,0,0,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":457,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,{\"id\":\"0f163713-5ea0-40f3-b69e-390a358a7c22\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"}}},{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,{\"id\":\"cc4f51b2-938b-4f1d-969d-26bcbbb2aa28\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e\"}}},null,null,null,null,null,null,null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b4c1c436-d533-4d3c-abbc-c60e8ae1be95",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c25bf0d5-ff0a-42a0-9689-280eb09aac1c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":4,\"totalLengthChars\":4,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"ads\",\"Asd\",\"as\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"95f8d7e1-9024-4ddf-bc34-b114befa158c\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "48285434-9a83-41cc-8ae5-f5dcb49d8369",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5aa31e6a-3749-4ba2-9305-2aa0512ec5b0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"b4abc57c-1270-4a64-a1d1-803b9833dd45\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "471bc487-438e-4f95-b33d-f4b1d7f2aace",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46b84a10-53f7-469f-a849-04db1d8918b6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"242480b0-ae14-49ea-a545-3274183a1478\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "490e917c-9805-40b5-93d9-3b52c444f8c8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf847818-809d-41f4-9dc8-e9389d87b82d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"988e4338-27fb-4124-a330-63fc8d5cb818\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2f989fd2-bb56-4d76-809e-b672000fa9f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":7,\"totalLengthChars\":7,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdsad\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsad\",\"Assad\",\"assay\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7b1d9334-4447-41e9-8134-4090cb9352bd\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":7,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "af627ff8-30d1-4e89-8220-12c59b99016e",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d2dba981-eeb5-4fdc-aa91-8549d108f8bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":9,\"totalLengthChars\":9,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdasdsd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsads'd\",\"Sadsads\",\"Sadsads'\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"1fc7dbca-f11f-4693-872f-c63827533a35\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":9,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f3a00f9-e6ce-40c1-a206-1650c1280a86",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0f98d43-9e0c-41d1-9bee-e72fd5407d90",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"5ef1d1b7-ccb3-4f11-9e9f-1443cb3bceb4\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b194361b-3b4b-4623-b7b9-fe5857095751",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc03124d-5ee3-4a74-b3bc-fd2c5f93b954",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8859a370-84e1-4e01-914f-0e5a0553b3ee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":313,\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":456,\"sequenceNumber\":457,\"timestamp\":1646688495162,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688495162},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688495162},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"],\"unreferencedTimestampMs\":1646688495162},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688495162},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688495162},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\",\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\",\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\",\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\",\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"],\"unreferencedTimestampMs\":1646688495162},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_472_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_472_0.json
@@ -1,0 +1,3645 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":189,\"sequenceNumber\":472,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688384281,\"mode\":\"write\"},\"sequenceNumber\":131}],[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688401739,\"mode\":\"write\"},\"sequenceNumber\":154}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":2,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"nodeType\":\"Paragraph\",\"markerId\":\"be62d0e4-0791-4cd2-973c-012d813ec960\"}},\"type\":0},\"metadata\":{\"batch\":true},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":227,\"sequenceNumber\":228,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":2,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{\"batch\":false},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":228,\"sequenceNumber\":229,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":3,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":229,\"sequenceNumber\":230,\"term\":1,\"timestamp\":1646688471871,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":4,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":230,\"sequenceNumber\":231,\"term\":1,\"timestamp\":1646688471905,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":5,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":231,\"sequenceNumber\":232,\"term\":1,\"timestamp\":1646688471942,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":6,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":232,\"sequenceNumber\":233,\"term\":1,\"timestamp\":1646688471970,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":7,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":233,\"sequenceNumber\":234,\"term\":1,\"timestamp\":1646688471996,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":8,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":234,\"sequenceNumber\":235,\"term\":1,\"timestamp\":1646688472053,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":9,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":235,\"sequenceNumber\":236,\"term\":1,\"timestamp\":1646688472076,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":91,\"contents\":{\"pos1\":10,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":236,\"sequenceNumber\":237,\"term\":1,\"timestamp\":1646688472113,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":11,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":237,\"sequenceNumber\":238,\"term\":1,\"timestamp\":1646688472140,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":93,\"contents\":{\"pos1\":12,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":238,\"sequenceNumber\":239,\"term\":1,\"timestamp\":1646688472170,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":13,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":239,\"sequenceNumber\":240,\"term\":1,\"timestamp\":1646688472210,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":95,\"contents\":{\"pos1\":14,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":240,\"sequenceNumber\":241,\"term\":1,\"timestamp\":1646688472242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":15,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":241,\"sequenceNumber\":242,\"term\":1,\"timestamp\":1646688472265,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":97,\"contents\":{\"pos1\":16,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":242,\"sequenceNumber\":243,\"term\":1,\"timestamp\":1646688472299,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":17,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":243,\"sequenceNumber\":244,\"term\":1,\"timestamp\":1646688472332,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":99,\"contents\":{\"pos1\":18,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":244,\"sequenceNumber\":245,\"term\":1,\"timestamp\":1646688472382,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":19,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":245,\"sequenceNumber\":246,\"term\":1,\"timestamp\":1646688472406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":20,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":246,\"sequenceNumber\":247,\"term\":1,\"timestamp\":1646688472442,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":21,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":247,\"sequenceNumber\":248,\"term\":1,\"timestamp\":1646688472470,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":22,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":248,\"sequenceNumber\":249,\"term\":1,\"timestamp\":1646688472513,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":23,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":249,\"sequenceNumber\":250,\"term\":1,\"timestamp\":1646688472537,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":105,\"contents\":{\"pos1\":24,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":250,\"sequenceNumber\":251,\"term\":1,\"timestamp\":1646688472568,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":25,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":251,\"sequenceNumber\":252,\"term\":1,\"timestamp\":1646688472603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":107,\"contents\":{\"pos1\":26,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":252,\"sequenceNumber\":253,\"term\":1,\"timestamp\":1646688472630,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":27,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":253,\"sequenceNumber\":254,\"term\":1,\"timestamp\":1646688472661,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":109,\"contents\":{\"pos1\":28,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":254,\"sequenceNumber\":255,\"term\":1,\"timestamp\":1646688472692,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":110,\"contents\":{\"pos1\":29,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":255,\"sequenceNumber\":256,\"term\":1,\"timestamp\":1646688472727,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":30,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":256,\"sequenceNumber\":257,\"term\":1,\"timestamp\":1646688472756,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":112,\"contents\":{\"pos1\":31,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":257,\"sequenceNumber\":258,\"term\":1,\"timestamp\":1646688472803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":32,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":258,\"sequenceNumber\":259,\"term\":1,\"timestamp\":1646688472834,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":114,\"contents\":{\"pos1\":33,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":259,\"sequenceNumber\":260,\"term\":1,\"timestamp\":1646688472870,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":34,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":260,\"sequenceNumber\":261,\"term\":1,\"timestamp\":1646688472918,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":116,\"contents\":{\"pos1\":35,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":261,\"sequenceNumber\":262,\"term\":1,\"timestamp\":1646688472935,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":36,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":262,\"sequenceNumber\":263,\"term\":1,\"timestamp\":1646688472969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":37,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":263,\"sequenceNumber\":264,\"term\":1,\"timestamp\":1646688473006,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":119,\"contents\":{\"pos1\":38,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":264,\"sequenceNumber\":265,\"term\":1,\"timestamp\":1646688473030,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":39,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":265,\"sequenceNumber\":266,\"term\":1,\"timestamp\":1646688473063,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":121,\"contents\":{\"pos1\":40,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":266,\"sequenceNumber\":267,\"term\":1,\"timestamp\":1646688473093,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":41,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":267,\"sequenceNumber\":268,\"term\":1,\"timestamp\":1646688473120,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":123,\"contents\":{\"pos1\":42,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":268,\"sequenceNumber\":269,\"term\":1,\"timestamp\":1646688473168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":43,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":269,\"sequenceNumber\":270,\"term\":1,\"timestamp\":1646688473199,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":125,\"contents\":{\"pos1\":44,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":270,\"sequenceNumber\":271,\"term\":1,\"timestamp\":1646688473244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":45,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":271,\"sequenceNumber\":272,\"term\":1,\"timestamp\":1646688473264,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":127,\"contents\":{\"pos1\":46,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":272,\"sequenceNumber\":273,\"term\":1,\"timestamp\":1646688473294,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":47,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":273,\"sequenceNumber\":274,\"term\":1,\"timestamp\":1646688473326,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":129,\"contents\":{\"pos1\":48,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":274,\"sequenceNumber\":275,\"term\":1,\"timestamp\":1646688473360,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":49,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":275,\"sequenceNumber\":276,\"term\":1,\"timestamp\":1646688473399,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":50,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":276,\"sequenceNumber\":277,\"term\":1,\"timestamp\":1646688473428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":132,\"contents\":{\"pos1\":51,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":277,\"sequenceNumber\":278,\"term\":1,\"timestamp\":1646688473457,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":52,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":278,\"sequenceNumber\":279,\"term\":1,\"timestamp\":1646688473492,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":53,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":279,\"sequenceNumber\":280,\"term\":1,\"timestamp\":1646688473517,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":54,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":280,\"sequenceNumber\":281,\"term\":1,\"timestamp\":1646688473547,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":136,\"contents\":{\"pos1\":55,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":281,\"sequenceNumber\":282,\"term\":1,\"timestamp\":1646688473596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":56,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":282,\"sequenceNumber\":283,\"term\":1,\"timestamp\":1646688473634,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":138,\"contents\":{\"pos1\":57,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":283,\"sequenceNumber\":284,\"term\":1,\"timestamp\":1646688473662,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":58,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":284,\"sequenceNumber\":285,\"term\":1,\"timestamp\":1646688473691,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":140,\"contents\":{\"pos1\":59,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":285,\"sequenceNumber\":286,\"term\":1,\"timestamp\":1646688473728,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":60,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":286,\"sequenceNumber\":287,\"term\":1,\"timestamp\":1646688473758,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":142,\"contents\":{\"pos1\":61,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":287,\"sequenceNumber\":288,\"term\":1,\"timestamp\":1646688473792,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":62,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":288,\"sequenceNumber\":289,\"term\":1,\"timestamp\":1646688473817,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":144,\"contents\":{\"pos1\":63,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":289,\"sequenceNumber\":290,\"term\":1,\"timestamp\":1646688473855,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":64,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":290,\"sequenceNumber\":291,\"term\":1,\"timestamp\":1646688473879,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":146,\"contents\":{\"pos1\":65,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":291,\"sequenceNumber\":292,\"term\":1,\"timestamp\":1646688473913,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":66,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":292,\"sequenceNumber\":293,\"term\":1,\"timestamp\":1646688473944,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":148,\"contents\":{\"pos1\":67,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":293,\"sequenceNumber\":294,\"term\":1,\"timestamp\":1646688473991,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":68,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":294,\"sequenceNumber\":295,\"term\":1,\"timestamp\":1646688474023,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":150,\"contents\":{\"pos1\":69,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":295,\"sequenceNumber\":296,\"term\":1,\"timestamp\":1646688474054,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":70,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":296,\"sequenceNumber\":297,\"term\":1,\"timestamp\":1646688474086,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":152,\"contents\":{\"pos1\":71,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":297,\"sequenceNumber\":298,\"term\":1,\"timestamp\":1646688474119,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":72,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":298,\"sequenceNumber\":299,\"term\":1,\"timestamp\":1646688474147,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":154,\"contents\":{\"pos1\":73,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":299,\"sequenceNumber\":300,\"term\":1,\"timestamp\":1646688474178,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":74,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":300,\"sequenceNumber\":301,\"term\":1,\"timestamp\":1646688474214,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":156,\"contents\":{\"pos1\":75,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":301,\"sequenceNumber\":302,\"term\":1,\"timestamp\":1646688474242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":76,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":302,\"sequenceNumber\":303,\"term\":1,\"timestamp\":1646688474279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":158,\"contents\":{\"pos1\":77,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":303,\"sequenceNumber\":304,\"term\":1,\"timestamp\":1646688474306,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":78,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":304,\"sequenceNumber\":305,\"term\":1,\"timestamp\":1646688474355,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":160,\"contents\":{\"pos1\":79,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":305,\"sequenceNumber\":306,\"term\":1,\"timestamp\":1646688474388,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":80,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":306,\"sequenceNumber\":307,\"term\":1,\"timestamp\":1646688474415,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":162,\"contents\":{\"pos1\":81,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":307,\"sequenceNumber\":308,\"term\":1,\"timestamp\":1646688474449,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":163,\"contents\":{\"pos1\":82,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":308,\"sequenceNumber\":309,\"term\":1,\"timestamp\":1646688474482,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":164,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":309,\"sequenceNumber\":310,\"term\":1,\"timestamp\":1646688474514,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":165,\"contents\":{\"pos1\":84,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":310,\"sequenceNumber\":311,\"term\":1,\"timestamp\":1646688474559,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":166,\"contents\":{\"pos1\":85,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":311,\"sequenceNumber\":312,\"term\":1,\"timestamp\":1646688474576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":86,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":312,\"sequenceNumber\":313,\"term\":1,\"timestamp\":1646688474611,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":168,\"contents\":{\"pos1\":87,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":313,\"sequenceNumber\":314,\"term\":1,\"timestamp\":1646688474643,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":88,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":314,\"sequenceNumber\":315,\"term\":1,\"timestamp\":1646688474672,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":170,\"contents\":{\"pos1\":89,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":315,\"sequenceNumber\":316,\"term\":1,\"timestamp\":1646688474705,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":90,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":316,\"sequenceNumber\":317,\"term\":1,\"timestamp\":1646688474739,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":91,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":317,\"sequenceNumber\":318,\"term\":1,\"timestamp\":1646688474774,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":173,\"contents\":{\"pos1\":92,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":318,\"sequenceNumber\":319,\"term\":1,\"timestamp\":1646688474803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":93,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":319,\"sequenceNumber\":320,\"term\":1,\"timestamp\":1646688474860,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":175,\"contents\":{\"pos1\":94,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":320,\"sequenceNumber\":321,\"term\":1,\"timestamp\":1646688474882,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":176,\"contents\":{\"pos1\":95,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":321,\"sequenceNumber\":322,\"term\":1,\"timestamp\":1646688474914,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":177,\"contents\":{\"pos1\":96,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":322,\"sequenceNumber\":323,\"term\":1,\"timestamp\":1646688474945,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":97,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":323,\"sequenceNumber\":324,\"term\":1,\"timestamp\":1646688474977,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":179,\"contents\":{\"pos1\":98,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":324,\"sequenceNumber\":325,\"term\":1,\"timestamp\":1646688475012,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":99,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":325,\"sequenceNumber\":326,\"term\":1,\"timestamp\":1646688475042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":181,\"contents\":{\"pos1\":100,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":326,\"sequenceNumber\":327,\"term\":1,\"timestamp\":1646688475075,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":101,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":327,\"sequenceNumber\":328,\"term\":1,\"timestamp\":1646688475110,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":183,\"contents\":{\"pos1\":102,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":328,\"sequenceNumber\":329,\"term\":1,\"timestamp\":1646688475134,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":103,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":329,\"sequenceNumber\":330,\"term\":1,\"timestamp\":1646688475168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":185,\"contents\":{\"pos1\":104,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":330,\"sequenceNumber\":331,\"term\":1,\"timestamp\":1646688475213,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":105,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":331,\"sequenceNumber\":332,\"term\":1,\"timestamp\":1646688475244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":187,\"contents\":{\"pos1\":106,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":332,\"sequenceNumber\":333,\"term\":1,\"timestamp\":1646688475276,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":107,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":333,\"sequenceNumber\":334,\"term\":1,\"timestamp\":1646688475311,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":189,\"contents\":{\"pos1\":108,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":334,\"sequenceNumber\":335,\"term\":1,\"timestamp\":1646688475340,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":109,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":335,\"sequenceNumber\":336,\"term\":1,\"timestamp\":1646688475373,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":191,\"contents\":{\"pos1\":110,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":336,\"sequenceNumber\":337,\"term\":1,\"timestamp\":1646688475406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":192,\"contents\":{\"pos1\":111,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":337,\"sequenceNumber\":338,\"term\":1,\"timestamp\":1646688475435,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":193,\"contents\":{\"pos1\":112,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":338,\"sequenceNumber\":339,\"term\":1,\"timestamp\":1646688475467,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":113,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":339,\"sequenceNumber\":340,\"term\":1,\"timestamp\":1646688475498,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":195,\"contents\":{\"pos1\":114,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":340,\"sequenceNumber\":341,\"term\":1,\"timestamp\":1646688475529,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":196,\"contents\":{\"pos1\":115,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":341,\"sequenceNumber\":342,\"term\":1,\"timestamp\":1646688475576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":197,\"contents\":{\"pos1\":116,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":342,\"sequenceNumber\":343,\"term\":1,\"timestamp\":1646688475603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":198,\"contents\":{\"pos1\":117,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":343,\"sequenceNumber\":344,\"term\":1,\"timestamp\":1646688475635,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":199,\"contents\":{\"pos1\":118,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":344,\"sequenceNumber\":345,\"term\":1,\"timestamp\":1646688475667,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":200,\"contents\":{\"pos1\":119,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":345,\"sequenceNumber\":346,\"term\":1,\"timestamp\":1646688475709,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":201,\"contents\":{\"pos1\":120,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":346,\"sequenceNumber\":347,\"term\":1,\"timestamp\":1646688475730,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":202,\"contents\":{\"pos1\":121,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":347,\"sequenceNumber\":348,\"term\":1,\"timestamp\":1646688475762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":203,\"contents\":{\"pos1\":122,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":348,\"sequenceNumber\":349,\"term\":1,\"timestamp\":1646688475795,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":204,\"contents\":{\"pos1\":123,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":349,\"sequenceNumber\":350,\"term\":1,\"timestamp\":1646688475828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":205,\"contents\":{\"pos1\":124,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":350,\"sequenceNumber\":351,\"term\":1,\"timestamp\":1646688475859,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":206,\"contents\":{\"pos1\":125,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":351,\"sequenceNumber\":352,\"term\":1,\"timestamp\":1646688475906,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":207,\"contents\":{\"pos1\":126,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":352,\"sequenceNumber\":353,\"term\":1,\"timestamp\":1646688475939,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":208,\"contents\":{\"pos1\":127,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":353,\"sequenceNumber\":354,\"term\":1,\"timestamp\":1646688475969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":209,\"contents\":{\"pos1\":128,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":354,\"sequenceNumber\":355,\"term\":1,\"timestamp\":1646688475999,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":210,\"contents\":{\"pos1\":129,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":355,\"sequenceNumber\":356,\"term\":1,\"timestamp\":1646688476031,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":211,\"contents\":{\"pos1\":130,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":356,\"sequenceNumber\":357,\"term\":1,\"timestamp\":1646688476062,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":212,\"contents\":{\"pos1\":131,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":357,\"sequenceNumber\":358,\"term\":1,\"timestamp\":1646688476094,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":213,\"contents\":{\"pos1\":132,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":358,\"sequenceNumber\":359,\"term\":1,\"timestamp\":1646688476128,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":214,\"contents\":{\"pos1\":133,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":359,\"sequenceNumber\":360,\"term\":1,\"timestamp\":1646688476157,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":215,\"contents\":{\"pos1\":134,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":360,\"sequenceNumber\":361,\"term\":1,\"timestamp\":1646688476191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":216,\"contents\":{\"pos1\":135,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":361,\"sequenceNumber\":362,\"term\":1,\"timestamp\":1646688476240,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":217,\"contents\":{\"pos1\":136,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":362,\"sequenceNumber\":363,\"term\":1,\"timestamp\":1646688476269,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":137,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":363,\"sequenceNumber\":364,\"term\":1,\"timestamp\":1646688476301,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":219,\"contents\":{\"pos1\":138,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":364,\"sequenceNumber\":365,\"term\":1,\"timestamp\":1646688476335,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":139,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":365,\"sequenceNumber\":366,\"term\":1,\"timestamp\":1646688476363,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":221,\"contents\":{\"pos1\":140,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":366,\"sequenceNumber\":367,\"term\":1,\"timestamp\":1646688476398,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":222,\"contents\":{\"pos1\":141,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":367,\"sequenceNumber\":368,\"term\":1,\"timestamp\":1646688476428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":223,\"contents\":{\"pos1\":142,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":368,\"sequenceNumber\":369,\"term\":1,\"timestamp\":1646688476459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":224,\"contents\":{\"pos1\":143,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":369,\"sequenceNumber\":370,\"term\":1,\"timestamp\":1646688476491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":225,\"contents\":{\"pos1\":144,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":370,\"sequenceNumber\":371,\"term\":1,\"timestamp\":1646688476523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":226,\"contents\":{\"pos1\":145,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":371,\"sequenceNumber\":372,\"term\":1,\"timestamp\":1646688476562,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":227,\"contents\":{\"pos1\":146,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":372,\"sequenceNumber\":373,\"term\":1,\"timestamp\":1646688476592,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":228,\"contents\":{\"pos1\":147,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":373,\"sequenceNumber\":374,\"term\":1,\"timestamp\":1646688476628,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":229,\"contents\":{\"pos1\":148,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":374,\"sequenceNumber\":375,\"term\":1,\"timestamp\":1646688476666,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":230,\"contents\":{\"pos1\":149,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":375,\"sequenceNumber\":376,\"term\":1,\"timestamp\":1646688476697,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":231,\"contents\":{\"pos1\":150,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":376,\"sequenceNumber\":377,\"term\":1,\"timestamp\":1646688476732,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":232,\"contents\":{\"pos1\":151,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":377,\"sequenceNumber\":378,\"term\":1,\"timestamp\":1646688476766,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":233,\"contents\":{\"pos1\":152,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":378,\"sequenceNumber\":379,\"term\":1,\"timestamp\":1646688476793,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":234,\"contents\":{\"pos1\":153,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":379,\"sequenceNumber\":380,\"term\":1,\"timestamp\":1646688476828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":235,\"contents\":{\"pos1\":154,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":380,\"sequenceNumber\":381,\"term\":1,\"timestamp\":1646688476875,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":236,\"contents\":{\"pos1\":155,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":381,\"sequenceNumber\":382,\"term\":1,\"timestamp\":1646688476890,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":237,\"contents\":{\"pos1\":156,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":382,\"sequenceNumber\":383,\"term\":1,\"timestamp\":1646688476930,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":238,\"contents\":{\"pos1\":157,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":383,\"sequenceNumber\":384,\"term\":1,\"timestamp\":1646688476979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":239,\"contents\":{\"pos1\":158,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":384,\"sequenceNumber\":385,\"term\":1,\"timestamp\":1646688476984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":240,\"contents\":{\"pos1\":159,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":385,\"sequenceNumber\":386,\"term\":1,\"timestamp\":1646688477013,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":241,\"contents\":{\"pos1\":160,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":386,\"sequenceNumber\":387,\"term\":1,\"timestamp\":1646688477047,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":242,\"contents\":{\"pos1\":161,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":387,\"sequenceNumber\":388,\"term\":1,\"timestamp\":1646688477091,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":243,\"contents\":{\"pos1\":162,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":388,\"sequenceNumber\":389,\"term\":1,\"timestamp\":1646688477121,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":244,\"contents\":{\"pos1\":163,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":389,\"sequenceNumber\":390,\"term\":1,\"timestamp\":1646688477154,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":245,\"contents\":{\"pos1\":164,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":390,\"sequenceNumber\":391,\"term\":1,\"timestamp\":1646688477188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":246,\"contents\":{\"pos1\":165,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":391,\"sequenceNumber\":392,\"term\":1,\"timestamp\":1646688477217,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":166,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":392,\"sequenceNumber\":393,\"term\":1,\"timestamp\":1646688477249,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":248,\"contents\":{\"pos1\":167,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":393,\"sequenceNumber\":394,\"term\":1,\"timestamp\":1646688477279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":168,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":394,\"sequenceNumber\":395,\"term\":1,\"timestamp\":1646688477314,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":250,\"contents\":{\"pos1\":169,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":395,\"sequenceNumber\":396,\"term\":1,\"timestamp\":1646688477344,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":251,\"contents\":{\"pos1\":170,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":396,\"sequenceNumber\":397,\"term\":1,\"timestamp\":1646688477376,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":252,\"contents\":{\"pos1\":171,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":397,\"sequenceNumber\":398,\"term\":1,\"timestamp\":1646688477426,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":172,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":398,\"sequenceNumber\":399,\"term\":1,\"timestamp\":1646688477459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":254,\"contents\":{\"pos1\":173,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":399,\"sequenceNumber\":400,\"term\":1,\"timestamp\":1646688477488,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":255,\"contents\":{\"pos1\":174,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":400,\"sequenceNumber\":401,\"term\":1,\"timestamp\":1646688477524,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":256,\"contents\":{\"pos1\":175,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":401,\"sequenceNumber\":402,\"term\":1,\"timestamp\":1646688477552,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":257,\"contents\":{\"pos1\":176,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":402,\"sequenceNumber\":403,\"term\":1,\"timestamp\":1646688477584,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":258,\"contents\":{\"pos1\":177,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":403,\"sequenceNumber\":404,\"term\":1,\"timestamp\":1646688477613,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":259,\"contents\":{\"pos1\":178,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":404,\"sequenceNumber\":405,\"term\":1,\"timestamp\":1646688477652,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":260,\"contents\":{\"pos1\":179,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":405,\"sequenceNumber\":406,\"term\":1,\"timestamp\":1646688477688,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":261,\"contents\":{\"pos1\":180,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":406,\"sequenceNumber\":407,\"term\":1,\"timestamp\":1646688477712,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":262,\"contents\":{\"pos1\":181,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":407,\"sequenceNumber\":408,\"term\":1,\"timestamp\":1646688477749,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":263,\"contents\":{\"pos1\":182,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":408,\"sequenceNumber\":409,\"term\":1,\"timestamp\":1646688477776,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":264,\"contents\":{\"pos1\":183,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":409,\"sequenceNumber\":410,\"term\":1,\"timestamp\":1646688477820,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":265,\"contents\":{\"pos1\":184,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":410,\"sequenceNumber\":411,\"term\":1,\"timestamp\":1646688477852,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":266,\"contents\":{\"pos1\":185,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":411,\"sequenceNumber\":412,\"term\":1,\"timestamp\":1646688477883,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":267,\"contents\":{\"pos1\":186,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":412,\"sequenceNumber\":413,\"term\":1,\"timestamp\":1646688477916,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":268,\"contents\":{\"pos1\":187,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":413,\"sequenceNumber\":414,\"term\":1,\"timestamp\":1646688477948,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":269,\"contents\":{\"pos1\":188,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":414,\"sequenceNumber\":415,\"term\":1,\"timestamp\":1646688477979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":270,\"contents\":{\"pos1\":189,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":415,\"sequenceNumber\":416,\"term\":1,\"timestamp\":1646688478009,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":271,\"contents\":{\"pos1\":190,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":416,\"sequenceNumber\":417,\"term\":1,\"timestamp\":1646688478042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":273,\"contents\":{\"pos1\":191,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":417,\"sequenceNumber\":418,\"term\":1,\"timestamp\":1646688490596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":274,\"contents\":{\"pos1\":192,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":418,\"sequenceNumber\":419,\"term\":1,\"timestamp\":1646688491109,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":275,\"contents\":{\"pos1\":193,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":419,\"sequenceNumber\":420,\"term\":1,\"timestamp\":1646688491129,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":276,\"contents\":{\"pos1\":194,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":420,\"sequenceNumber\":421,\"term\":1,\"timestamp\":1646688491168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":277,\"contents\":{\"pos1\":195,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":421,\"sequenceNumber\":422,\"term\":1,\"timestamp\":1646688491188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":278,\"contents\":{\"pos1\":196,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":422,\"sequenceNumber\":423,\"term\":1,\"timestamp\":1646688491221,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":279,\"contents\":{\"pos1\":197,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":423,\"sequenceNumber\":424,\"term\":1,\"timestamp\":1646688491272,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":198,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":424,\"sequenceNumber\":425,\"term\":1,\"timestamp\":1646688491305,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":281,\"contents\":{\"pos1\":199,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":425,\"sequenceNumber\":426,\"term\":1,\"timestamp\":1646688491329,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":282,\"contents\":{\"pos1\":200,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":426,\"sequenceNumber\":427,\"term\":1,\"timestamp\":1646688491366,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":283,\"contents\":{\"pos1\":201,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":427,\"sequenceNumber\":428,\"term\":1,\"timestamp\":1646688491396,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":202,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":428,\"sequenceNumber\":429,\"term\":1,\"timestamp\":1646688491433,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":285,\"contents\":{\"pos1\":203,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":429,\"sequenceNumber\":430,\"term\":1,\"timestamp\":1646688491462,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":204,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":430,\"sequenceNumber\":431,\"term\":1,\"timestamp\":1646688491491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":287,\"contents\":{\"pos1\":205,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":431,\"sequenceNumber\":432,\"term\":1,\"timestamp\":1646688491523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":206,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":432,\"sequenceNumber\":433,\"term\":1,\"timestamp\":1646688491555,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":289,\"contents\":{\"pos1\":207,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":433,\"sequenceNumber\":434,\"term\":1,\"timestamp\":1646688491583,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":208,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":434,\"sequenceNumber\":435,\"term\":1,\"timestamp\":1646688491617,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":291,\"contents\":{\"pos1\":209,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":435,\"sequenceNumber\":436,\"term\":1,\"timestamp\":1646688491653,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":210,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":436,\"sequenceNumber\":437,\"term\":1,\"timestamp\":1646688491702,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":293,\"contents\":{\"pos1\":211,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":437,\"sequenceNumber\":438,\"term\":1,\"timestamp\":1646688491733,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":212,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":438,\"sequenceNumber\":439,\"term\":1,\"timestamp\":1646688491762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":295,\"contents\":{\"pos1\":213,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":439,\"sequenceNumber\":440,\"term\":1,\"timestamp\":1646688491796,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":296,\"contents\":{\"pos1\":214,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":440,\"sequenceNumber\":441,\"term\":1,\"timestamp\":1646688491823,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":297,\"contents\":{\"pos1\":215,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":441,\"sequenceNumber\":442,\"term\":1,\"timestamp\":1646688491868,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":216,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":442,\"sequenceNumber\":443,\"term\":1,\"timestamp\":1646688491892,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":299,\"contents\":{\"pos1\":217,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":443,\"sequenceNumber\":444,\"term\":1,\"timestamp\":1646688491922,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":300,\"contents\":{\"pos1\":218,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":444,\"sequenceNumber\":445,\"term\":1,\"timestamp\":1646688491956,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":301,\"contents\":{\"pos1\":219,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":445,\"sequenceNumber\":446,\"term\":1,\"timestamp\":1646688491984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":220,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":446,\"sequenceNumber\":447,\"term\":1,\"timestamp\":1646688492018,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":303,\"contents\":{\"pos1\":221,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":447,\"sequenceNumber\":448,\"term\":1,\"timestamp\":1646688492060,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":304,\"contents\":{\"pos1\":222,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":448,\"sequenceNumber\":449,\"term\":1,\"timestamp\":1646688492080,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":305,\"contents\":{\"pos1\":223,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":449,\"sequenceNumber\":450,\"term\":1,\"timestamp\":1646688492111,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":306,\"contents\":{\"pos1\":224,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":450,\"sequenceNumber\":451,\"term\":1,\"timestamp\":1646688492145,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":307,\"contents\":{\"pos1\":225,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":451,\"sequenceNumber\":452,\"term\":1,\"timestamp\":1646688492191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":308,\"contents\":{\"pos1\":226,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":452,\"sequenceNumber\":453,\"term\":1,\"timestamp\":1646688492223,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":309,\"contents\":{\"pos1\":227,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":453,\"sequenceNumber\":454,\"term\":1,\"timestamp\":1646688492256,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":310,\"contents\":{\"pos1\":228,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":454,\"sequenceNumber\":455,\"term\":1,\"timestamp\":1646688492288,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":311,\"contents\":{\"pos1\":229,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":455,\"sequenceNumber\":456,\"term\":1,\"timestamp\":1646688492319,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":313,\"contents\":{\"pos1\":230,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":456,\"sequenceNumber\":457,\"term\":1,\"timestamp\":1646688495162,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":314,\"contents\":{\"pos1\":231,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":457,\"sequenceNumber\":458,\"term\":1,\"timestamp\":1646688495663,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":315,\"contents\":{\"pos1\":232,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":458,\"sequenceNumber\":459,\"term\":1,\"timestamp\":1646688495694,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":316,\"contents\":{\"pos1\":233,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":459,\"sequenceNumber\":460,\"term\":1,\"timestamp\":1646688495724,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":317,\"contents\":{\"pos1\":234,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":460,\"sequenceNumber\":461,\"term\":1,\"timestamp\":1646688495774,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":318,\"contents\":{\"pos1\":235,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":461,\"sequenceNumber\":462,\"term\":1,\"timestamp\":1646688495790,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":319,\"contents\":{\"pos1\":236,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":462,\"sequenceNumber\":463,\"term\":1,\"timestamp\":1646688495836,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":320,\"contents\":{\"pos1\":237,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":463,\"sequenceNumber\":464,\"term\":1,\"timestamp\":1646688495870,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":321,\"contents\":{\"pos1\":238,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":464,\"sequenceNumber\":465,\"term\":1,\"timestamp\":1646688495902,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":322,\"contents\":{\"pos1\":239,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":465,\"sequenceNumber\":466,\"term\":1,\"timestamp\":1646688495931,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":323,\"contents\":{\"pos1\":240,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":466,\"sequenceNumber\":467,\"term\":1,\"timestamp\":1646688495971,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":324,\"contents\":{\"pos1\":241,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":467,\"sequenceNumber\":468,\"term\":1,\"timestamp\":1646688495996,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":325,\"contents\":{\"pos1\":242,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":468,\"sequenceNumber\":469,\"term\":1,\"timestamp\":1646688496025,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":326,\"contents\":{\"pos1\":243,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":469,\"sequenceNumber\":470,\"term\":1,\"timestamp\":1646688496058,\"type\":\"op\"}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":8,\"length\":8,\"segments\":[[1,4],{\"json\":[1,1],\"removedSeq\":225,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,2],\"removedSeq\":222,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,3],\"removedSeq\":216,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,5],\"removedSeq\":207,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,6],\"removedSeq\":204,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"},{\"json\":[1,7],\"removedSeq\":195,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"},{\"json\":[1,8],\"removedSeq\":192,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"}],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":472,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":8,\"totalSegmentCount\":8}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[9,0,0,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":472,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,{\"id\":\"0f163713-5ea0-40f3-b69e-390a358a7c22\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"}}},{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,{\"id\":\"cc4f51b2-938b-4f1d-969d-26bcbbb2aa28\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e\"}}},null,null,null,null,null,null,null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b4c1c436-d533-4d3c-abbc-c60e8ae1be95",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c25bf0d5-ff0a-42a0-9689-280eb09aac1c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":4,\"totalLengthChars\":4,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"ads\",\"Asd\",\"as\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"95f8d7e1-9024-4ddf-bc34-b114befa158c\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "48285434-9a83-41cc-8ae5-f5dcb49d8369",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5aa31e6a-3749-4ba2-9305-2aa0512ec5b0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"b4abc57c-1270-4a64-a1d1-803b9833dd45\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "471bc487-438e-4f95-b33d-f4b1d7f2aace",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46b84a10-53f7-469f-a849-04db1d8918b6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"242480b0-ae14-49ea-a545-3274183a1478\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "490e917c-9805-40b5-93d9-3b52c444f8c8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf847818-809d-41f4-9dc8-e9389d87b82d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"988e4338-27fb-4124-a330-63fc8d5cb818\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2f989fd2-bb56-4d76-809e-b672000fa9f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":7,\"totalLengthChars\":7,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdsad\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsad\",\"Assad\",\"assay\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7b1d9334-4447-41e9-8134-4090cb9352bd\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":7,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "af627ff8-30d1-4e89-8220-12c59b99016e",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d2dba981-eeb5-4fdc-aa91-8549d108f8bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":9,\"totalLengthChars\":9,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdasdsd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsads'd\",\"Sadsads\",\"Sadsads'\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"1fc7dbca-f11f-4693-872f-c63827533a35\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":9,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f3a00f9-e6ce-40c1-a206-1650c1280a86",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0f98d43-9e0c-41d1-9bee-e72fd5407d90",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"5ef1d1b7-ccb3-4f11-9e9f-1443cb3bceb4\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b194361b-3b4b-4623-b7b9-fe5857095751",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc03124d-5ee3-4a74-b3bc-fd2c5f93b954",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8859a370-84e1-4e01-914f-0e5a0553b3ee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":-1,\"sequenceNumber\":472,\"timestamp\":1646688497092,\"type\":\"summaryAck\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688495162},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688495162},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688495162},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688495162},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688495162},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688495162},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688495162},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688495162},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688495162},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688495162},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688495162},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688495162},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688495162},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"],\"unreferencedTimestampMs\":1646688495162},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688495162},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688495162},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688495162},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688495162},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688495162},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688495162},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688495162},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688495162},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688495162},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688495162},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688495162},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688495162},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688495162},\"/490e917c-9805-40b5-93d9-3b52c444f8c8\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688495162},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\",\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688495162},\"/af627ff8-30d1-4e89-8220-12c59b99016e\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\",\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688495162},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\",\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688495162},\"/b194361b-3b4b-4623-b7b9-fe5857095751\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\",\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"],\"unreferencedTimestampMs\":1646688495162},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_473_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_473_0.json
@@ -1,0 +1,3645 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":189,\"sequenceNumber\":473,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688384281,\"mode\":\"write\"},\"sequenceNumber\":131}],[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688401739,\"mode\":\"write\"},\"sequenceNumber\":154}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":2,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"nodeType\":\"Paragraph\",\"markerId\":\"be62d0e4-0791-4cd2-973c-012d813ec960\"}},\"type\":0},\"metadata\":{\"batch\":true},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":227,\"sequenceNumber\":228,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":83,\"contents\":{\"pos1\":2,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{\"batch\":false},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":228,\"sequenceNumber\":229,\"term\":1,\"timestamp\":1646688471368,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":3,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":229,\"sequenceNumber\":230,\"term\":1,\"timestamp\":1646688471871,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":85,\"contents\":{\"pos1\":4,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":230,\"sequenceNumber\":231,\"term\":1,\"timestamp\":1646688471905,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":5,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":231,\"sequenceNumber\":232,\"term\":1,\"timestamp\":1646688471942,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":6,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":232,\"sequenceNumber\":233,\"term\":1,\"timestamp\":1646688471970,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":7,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":233,\"sequenceNumber\":234,\"term\":1,\"timestamp\":1646688471996,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":8,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":234,\"sequenceNumber\":235,\"term\":1,\"timestamp\":1646688472053,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":9,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":235,\"sequenceNumber\":236,\"term\":1,\"timestamp\":1646688472076,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":91,\"contents\":{\"pos1\":10,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":236,\"sequenceNumber\":237,\"term\":1,\"timestamp\":1646688472113,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":11,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":237,\"sequenceNumber\":238,\"term\":1,\"timestamp\":1646688472140,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":93,\"contents\":{\"pos1\":12,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":238,\"sequenceNumber\":239,\"term\":1,\"timestamp\":1646688472170,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":13,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":239,\"sequenceNumber\":240,\"term\":1,\"timestamp\":1646688472210,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":95,\"contents\":{\"pos1\":14,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":240,\"sequenceNumber\":241,\"term\":1,\"timestamp\":1646688472242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":15,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":241,\"sequenceNumber\":242,\"term\":1,\"timestamp\":1646688472265,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":97,\"contents\":{\"pos1\":16,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":242,\"sequenceNumber\":243,\"term\":1,\"timestamp\":1646688472299,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":17,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":243,\"sequenceNumber\":244,\"term\":1,\"timestamp\":1646688472332,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":99,\"contents\":{\"pos1\":18,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":244,\"sequenceNumber\":245,\"term\":1,\"timestamp\":1646688472382,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":19,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":245,\"sequenceNumber\":246,\"term\":1,\"timestamp\":1646688472406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":20,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":246,\"sequenceNumber\":247,\"term\":1,\"timestamp\":1646688472442,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":21,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":247,\"sequenceNumber\":248,\"term\":1,\"timestamp\":1646688472470,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":22,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":248,\"sequenceNumber\":249,\"term\":1,\"timestamp\":1646688472513,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":23,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":249,\"sequenceNumber\":250,\"term\":1,\"timestamp\":1646688472537,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":105,\"contents\":{\"pos1\":24,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":250,\"sequenceNumber\":251,\"term\":1,\"timestamp\":1646688472568,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":25,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":251,\"sequenceNumber\":252,\"term\":1,\"timestamp\":1646688472603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":107,\"contents\":{\"pos1\":26,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":252,\"sequenceNumber\":253,\"term\":1,\"timestamp\":1646688472630,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":27,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":253,\"sequenceNumber\":254,\"term\":1,\"timestamp\":1646688472661,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":109,\"contents\":{\"pos1\":28,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":254,\"sequenceNumber\":255,\"term\":1,\"timestamp\":1646688472692,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":110,\"contents\":{\"pos1\":29,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":255,\"sequenceNumber\":256,\"term\":1,\"timestamp\":1646688472727,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":30,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":256,\"sequenceNumber\":257,\"term\":1,\"timestamp\":1646688472756,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":112,\"contents\":{\"pos1\":31,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":257,\"sequenceNumber\":258,\"term\":1,\"timestamp\":1646688472803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":32,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":258,\"sequenceNumber\":259,\"term\":1,\"timestamp\":1646688472834,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":114,\"contents\":{\"pos1\":33,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":259,\"sequenceNumber\":260,\"term\":1,\"timestamp\":1646688472870,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":34,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":260,\"sequenceNumber\":261,\"term\":1,\"timestamp\":1646688472918,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":116,\"contents\":{\"pos1\":35,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":261,\"sequenceNumber\":262,\"term\":1,\"timestamp\":1646688472935,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":36,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":262,\"sequenceNumber\":263,\"term\":1,\"timestamp\":1646688472969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":37,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":263,\"sequenceNumber\":264,\"term\":1,\"timestamp\":1646688473006,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":119,\"contents\":{\"pos1\":38,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":264,\"sequenceNumber\":265,\"term\":1,\"timestamp\":1646688473030,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":39,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":265,\"sequenceNumber\":266,\"term\":1,\"timestamp\":1646688473063,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":121,\"contents\":{\"pos1\":40,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":266,\"sequenceNumber\":267,\"term\":1,\"timestamp\":1646688473093,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":41,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":267,\"sequenceNumber\":268,\"term\":1,\"timestamp\":1646688473120,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":123,\"contents\":{\"pos1\":42,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":268,\"sequenceNumber\":269,\"term\":1,\"timestamp\":1646688473168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":43,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":269,\"sequenceNumber\":270,\"term\":1,\"timestamp\":1646688473199,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":125,\"contents\":{\"pos1\":44,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":270,\"sequenceNumber\":271,\"term\":1,\"timestamp\":1646688473244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":45,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":271,\"sequenceNumber\":272,\"term\":1,\"timestamp\":1646688473264,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":127,\"contents\":{\"pos1\":46,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":272,\"sequenceNumber\":273,\"term\":1,\"timestamp\":1646688473294,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":47,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":273,\"sequenceNumber\":274,\"term\":1,\"timestamp\":1646688473326,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":129,\"contents\":{\"pos1\":48,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":274,\"sequenceNumber\":275,\"term\":1,\"timestamp\":1646688473360,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":49,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":275,\"sequenceNumber\":276,\"term\":1,\"timestamp\":1646688473399,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":50,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":276,\"sequenceNumber\":277,\"term\":1,\"timestamp\":1646688473428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":132,\"contents\":{\"pos1\":51,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":277,\"sequenceNumber\":278,\"term\":1,\"timestamp\":1646688473457,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":52,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":278,\"sequenceNumber\":279,\"term\":1,\"timestamp\":1646688473492,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":53,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":279,\"sequenceNumber\":280,\"term\":1,\"timestamp\":1646688473517,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":54,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":280,\"sequenceNumber\":281,\"term\":1,\"timestamp\":1646688473547,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":136,\"contents\":{\"pos1\":55,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":281,\"sequenceNumber\":282,\"term\":1,\"timestamp\":1646688473596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":56,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":282,\"sequenceNumber\":283,\"term\":1,\"timestamp\":1646688473634,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":138,\"contents\":{\"pos1\":57,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":283,\"sequenceNumber\":284,\"term\":1,\"timestamp\":1646688473662,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":58,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":284,\"sequenceNumber\":285,\"term\":1,\"timestamp\":1646688473691,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":140,\"contents\":{\"pos1\":59,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":285,\"sequenceNumber\":286,\"term\":1,\"timestamp\":1646688473728,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":60,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":286,\"sequenceNumber\":287,\"term\":1,\"timestamp\":1646688473758,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":142,\"contents\":{\"pos1\":61,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":287,\"sequenceNumber\":288,\"term\":1,\"timestamp\":1646688473792,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":62,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":288,\"sequenceNumber\":289,\"term\":1,\"timestamp\":1646688473817,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":144,\"contents\":{\"pos1\":63,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":289,\"sequenceNumber\":290,\"term\":1,\"timestamp\":1646688473855,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":64,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":290,\"sequenceNumber\":291,\"term\":1,\"timestamp\":1646688473879,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":146,\"contents\":{\"pos1\":65,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":291,\"sequenceNumber\":292,\"term\":1,\"timestamp\":1646688473913,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":66,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":292,\"sequenceNumber\":293,\"term\":1,\"timestamp\":1646688473944,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":148,\"contents\":{\"pos1\":67,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":293,\"sequenceNumber\":294,\"term\":1,\"timestamp\":1646688473991,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":68,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":294,\"sequenceNumber\":295,\"term\":1,\"timestamp\":1646688474023,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":150,\"contents\":{\"pos1\":69,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":295,\"sequenceNumber\":296,\"term\":1,\"timestamp\":1646688474054,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":70,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":296,\"sequenceNumber\":297,\"term\":1,\"timestamp\":1646688474086,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":152,\"contents\":{\"pos1\":71,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":297,\"sequenceNumber\":298,\"term\":1,\"timestamp\":1646688474119,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":72,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":298,\"sequenceNumber\":299,\"term\":1,\"timestamp\":1646688474147,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":154,\"contents\":{\"pos1\":73,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":299,\"sequenceNumber\":300,\"term\":1,\"timestamp\":1646688474178,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":74,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":300,\"sequenceNumber\":301,\"term\":1,\"timestamp\":1646688474214,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":156,\"contents\":{\"pos1\":75,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":301,\"sequenceNumber\":302,\"term\":1,\"timestamp\":1646688474242,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":76,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":302,\"sequenceNumber\":303,\"term\":1,\"timestamp\":1646688474279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":158,\"contents\":{\"pos1\":77,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":303,\"sequenceNumber\":304,\"term\":1,\"timestamp\":1646688474306,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":78,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":304,\"sequenceNumber\":305,\"term\":1,\"timestamp\":1646688474355,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":160,\"contents\":{\"pos1\":79,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":305,\"sequenceNumber\":306,\"term\":1,\"timestamp\":1646688474388,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":80,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":306,\"sequenceNumber\":307,\"term\":1,\"timestamp\":1646688474415,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":162,\"contents\":{\"pos1\":81,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":307,\"sequenceNumber\":308,\"term\":1,\"timestamp\":1646688474449,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":163,\"contents\":{\"pos1\":82,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":308,\"sequenceNumber\":309,\"term\":1,\"timestamp\":1646688474482,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":164,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":309,\"sequenceNumber\":310,\"term\":1,\"timestamp\":1646688474514,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":165,\"contents\":{\"pos1\":84,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":310,\"sequenceNumber\":311,\"term\":1,\"timestamp\":1646688474559,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":166,\"contents\":{\"pos1\":85,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":311,\"sequenceNumber\":312,\"term\":1,\"timestamp\":1646688474576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":86,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":312,\"sequenceNumber\":313,\"term\":1,\"timestamp\":1646688474611,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":168,\"contents\":{\"pos1\":87,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":313,\"sequenceNumber\":314,\"term\":1,\"timestamp\":1646688474643,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":88,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":314,\"sequenceNumber\":315,\"term\":1,\"timestamp\":1646688474672,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":170,\"contents\":{\"pos1\":89,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":315,\"sequenceNumber\":316,\"term\":1,\"timestamp\":1646688474705,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":90,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":316,\"sequenceNumber\":317,\"term\":1,\"timestamp\":1646688474739,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":91,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":317,\"sequenceNumber\":318,\"term\":1,\"timestamp\":1646688474774,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":173,\"contents\":{\"pos1\":92,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":318,\"sequenceNumber\":319,\"term\":1,\"timestamp\":1646688474803,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":93,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":319,\"sequenceNumber\":320,\"term\":1,\"timestamp\":1646688474860,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":175,\"contents\":{\"pos1\":94,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":320,\"sequenceNumber\":321,\"term\":1,\"timestamp\":1646688474882,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":176,\"contents\":{\"pos1\":95,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":321,\"sequenceNumber\":322,\"term\":1,\"timestamp\":1646688474914,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":177,\"contents\":{\"pos1\":96,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":322,\"sequenceNumber\":323,\"term\":1,\"timestamp\":1646688474945,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":97,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":323,\"sequenceNumber\":324,\"term\":1,\"timestamp\":1646688474977,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":179,\"contents\":{\"pos1\":98,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":324,\"sequenceNumber\":325,\"term\":1,\"timestamp\":1646688475012,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":99,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":325,\"sequenceNumber\":326,\"term\":1,\"timestamp\":1646688475042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":181,\"contents\":{\"pos1\":100,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":326,\"sequenceNumber\":327,\"term\":1,\"timestamp\":1646688475075,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":101,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":327,\"sequenceNumber\":328,\"term\":1,\"timestamp\":1646688475110,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":183,\"contents\":{\"pos1\":102,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":328,\"sequenceNumber\":329,\"term\":1,\"timestamp\":1646688475134,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":103,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":329,\"sequenceNumber\":330,\"term\":1,\"timestamp\":1646688475168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":185,\"contents\":{\"pos1\":104,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":330,\"sequenceNumber\":331,\"term\":1,\"timestamp\":1646688475213,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":105,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":331,\"sequenceNumber\":332,\"term\":1,\"timestamp\":1646688475244,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":187,\"contents\":{\"pos1\":106,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":332,\"sequenceNumber\":333,\"term\":1,\"timestamp\":1646688475276,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":107,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":333,\"sequenceNumber\":334,\"term\":1,\"timestamp\":1646688475311,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":189,\"contents\":{\"pos1\":108,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":334,\"sequenceNumber\":335,\"term\":1,\"timestamp\":1646688475340,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":109,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":335,\"sequenceNumber\":336,\"term\":1,\"timestamp\":1646688475373,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":191,\"contents\":{\"pos1\":110,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":336,\"sequenceNumber\":337,\"term\":1,\"timestamp\":1646688475406,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":192,\"contents\":{\"pos1\":111,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":337,\"sequenceNumber\":338,\"term\":1,\"timestamp\":1646688475435,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":193,\"contents\":{\"pos1\":112,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":338,\"sequenceNumber\":339,\"term\":1,\"timestamp\":1646688475467,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":113,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":339,\"sequenceNumber\":340,\"term\":1,\"timestamp\":1646688475498,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":195,\"contents\":{\"pos1\":114,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":340,\"sequenceNumber\":341,\"term\":1,\"timestamp\":1646688475529,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":196,\"contents\":{\"pos1\":115,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":341,\"sequenceNumber\":342,\"term\":1,\"timestamp\":1646688475576,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":197,\"contents\":{\"pos1\":116,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":342,\"sequenceNumber\":343,\"term\":1,\"timestamp\":1646688475603,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":198,\"contents\":{\"pos1\":117,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":343,\"sequenceNumber\":344,\"term\":1,\"timestamp\":1646688475635,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":199,\"contents\":{\"pos1\":118,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":344,\"sequenceNumber\":345,\"term\":1,\"timestamp\":1646688475667,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":200,\"contents\":{\"pos1\":119,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":345,\"sequenceNumber\":346,\"term\":1,\"timestamp\":1646688475709,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":201,\"contents\":{\"pos1\":120,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":346,\"sequenceNumber\":347,\"term\":1,\"timestamp\":1646688475730,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":202,\"contents\":{\"pos1\":121,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":347,\"sequenceNumber\":348,\"term\":1,\"timestamp\":1646688475762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":203,\"contents\":{\"pos1\":122,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":348,\"sequenceNumber\":349,\"term\":1,\"timestamp\":1646688475795,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":204,\"contents\":{\"pos1\":123,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":349,\"sequenceNumber\":350,\"term\":1,\"timestamp\":1646688475828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":205,\"contents\":{\"pos1\":124,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":350,\"sequenceNumber\":351,\"term\":1,\"timestamp\":1646688475859,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":206,\"contents\":{\"pos1\":125,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":351,\"sequenceNumber\":352,\"term\":1,\"timestamp\":1646688475906,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":207,\"contents\":{\"pos1\":126,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":352,\"sequenceNumber\":353,\"term\":1,\"timestamp\":1646688475939,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":208,\"contents\":{\"pos1\":127,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":353,\"sequenceNumber\":354,\"term\":1,\"timestamp\":1646688475969,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":209,\"contents\":{\"pos1\":128,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":354,\"sequenceNumber\":355,\"term\":1,\"timestamp\":1646688475999,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":210,\"contents\":{\"pos1\":129,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":355,\"sequenceNumber\":356,\"term\":1,\"timestamp\":1646688476031,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":211,\"contents\":{\"pos1\":130,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":356,\"sequenceNumber\":357,\"term\":1,\"timestamp\":1646688476062,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":212,\"contents\":{\"pos1\":131,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":357,\"sequenceNumber\":358,\"term\":1,\"timestamp\":1646688476094,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":213,\"contents\":{\"pos1\":132,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":358,\"sequenceNumber\":359,\"term\":1,\"timestamp\":1646688476128,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":214,\"contents\":{\"pos1\":133,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":359,\"sequenceNumber\":360,\"term\":1,\"timestamp\":1646688476157,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":215,\"contents\":{\"pos1\":134,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":360,\"sequenceNumber\":361,\"term\":1,\"timestamp\":1646688476191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":216,\"contents\":{\"pos1\":135,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":361,\"sequenceNumber\":362,\"term\":1,\"timestamp\":1646688476240,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":217,\"contents\":{\"pos1\":136,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":362,\"sequenceNumber\":363,\"term\":1,\"timestamp\":1646688476269,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":137,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":363,\"sequenceNumber\":364,\"term\":1,\"timestamp\":1646688476301,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":219,\"contents\":{\"pos1\":138,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":364,\"sequenceNumber\":365,\"term\":1,\"timestamp\":1646688476335,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":139,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":365,\"sequenceNumber\":366,\"term\":1,\"timestamp\":1646688476363,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":221,\"contents\":{\"pos1\":140,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":366,\"sequenceNumber\":367,\"term\":1,\"timestamp\":1646688476398,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":222,\"contents\":{\"pos1\":141,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":367,\"sequenceNumber\":368,\"term\":1,\"timestamp\":1646688476428,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":223,\"contents\":{\"pos1\":142,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":368,\"sequenceNumber\":369,\"term\":1,\"timestamp\":1646688476459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":224,\"contents\":{\"pos1\":143,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":369,\"sequenceNumber\":370,\"term\":1,\"timestamp\":1646688476491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":225,\"contents\":{\"pos1\":144,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":370,\"sequenceNumber\":371,\"term\":1,\"timestamp\":1646688476523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":226,\"contents\":{\"pos1\":145,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":371,\"sequenceNumber\":372,\"term\":1,\"timestamp\":1646688476562,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":227,\"contents\":{\"pos1\":146,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":372,\"sequenceNumber\":373,\"term\":1,\"timestamp\":1646688476592,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":228,\"contents\":{\"pos1\":147,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":373,\"sequenceNumber\":374,\"term\":1,\"timestamp\":1646688476628,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":229,\"contents\":{\"pos1\":148,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":374,\"sequenceNumber\":375,\"term\":1,\"timestamp\":1646688476666,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":230,\"contents\":{\"pos1\":149,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":375,\"sequenceNumber\":376,\"term\":1,\"timestamp\":1646688476697,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":231,\"contents\":{\"pos1\":150,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":376,\"sequenceNumber\":377,\"term\":1,\"timestamp\":1646688476732,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":232,\"contents\":{\"pos1\":151,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":377,\"sequenceNumber\":378,\"term\":1,\"timestamp\":1646688476766,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":233,\"contents\":{\"pos1\":152,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":378,\"sequenceNumber\":379,\"term\":1,\"timestamp\":1646688476793,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":234,\"contents\":{\"pos1\":153,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":379,\"sequenceNumber\":380,\"term\":1,\"timestamp\":1646688476828,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":235,\"contents\":{\"pos1\":154,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":380,\"sequenceNumber\":381,\"term\":1,\"timestamp\":1646688476875,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":236,\"contents\":{\"pos1\":155,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":381,\"sequenceNumber\":382,\"term\":1,\"timestamp\":1646688476890,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":237,\"contents\":{\"pos1\":156,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":382,\"sequenceNumber\":383,\"term\":1,\"timestamp\":1646688476930,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":238,\"contents\":{\"pos1\":157,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":383,\"sequenceNumber\":384,\"term\":1,\"timestamp\":1646688476979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":239,\"contents\":{\"pos1\":158,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":384,\"sequenceNumber\":385,\"term\":1,\"timestamp\":1646688476984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":240,\"contents\":{\"pos1\":159,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":385,\"sequenceNumber\":386,\"term\":1,\"timestamp\":1646688477013,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":241,\"contents\":{\"pos1\":160,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":386,\"sequenceNumber\":387,\"term\":1,\"timestamp\":1646688477047,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":242,\"contents\":{\"pos1\":161,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":387,\"sequenceNumber\":388,\"term\":1,\"timestamp\":1646688477091,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":243,\"contents\":{\"pos1\":162,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":388,\"sequenceNumber\":389,\"term\":1,\"timestamp\":1646688477121,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":244,\"contents\":{\"pos1\":163,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":389,\"sequenceNumber\":390,\"term\":1,\"timestamp\":1646688477154,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":245,\"contents\":{\"pos1\":164,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":390,\"sequenceNumber\":391,\"term\":1,\"timestamp\":1646688477188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":246,\"contents\":{\"pos1\":165,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":391,\"sequenceNumber\":392,\"term\":1,\"timestamp\":1646688477217,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":166,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":392,\"sequenceNumber\":393,\"term\":1,\"timestamp\":1646688477249,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":248,\"contents\":{\"pos1\":167,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":393,\"sequenceNumber\":394,\"term\":1,\"timestamp\":1646688477279,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":168,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":394,\"sequenceNumber\":395,\"term\":1,\"timestamp\":1646688477314,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":250,\"contents\":{\"pos1\":169,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":395,\"sequenceNumber\":396,\"term\":1,\"timestamp\":1646688477344,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":251,\"contents\":{\"pos1\":170,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":396,\"sequenceNumber\":397,\"term\":1,\"timestamp\":1646688477376,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":252,\"contents\":{\"pos1\":171,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":397,\"sequenceNumber\":398,\"term\":1,\"timestamp\":1646688477426,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":172,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":398,\"sequenceNumber\":399,\"term\":1,\"timestamp\":1646688477459,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":254,\"contents\":{\"pos1\":173,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":399,\"sequenceNumber\":400,\"term\":1,\"timestamp\":1646688477488,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":255,\"contents\":{\"pos1\":174,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":400,\"sequenceNumber\":401,\"term\":1,\"timestamp\":1646688477524,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":256,\"contents\":{\"pos1\":175,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":401,\"sequenceNumber\":402,\"term\":1,\"timestamp\":1646688477552,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":257,\"contents\":{\"pos1\":176,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":402,\"sequenceNumber\":403,\"term\":1,\"timestamp\":1646688477584,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":258,\"contents\":{\"pos1\":177,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":403,\"sequenceNumber\":404,\"term\":1,\"timestamp\":1646688477613,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":259,\"contents\":{\"pos1\":178,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":404,\"sequenceNumber\":405,\"term\":1,\"timestamp\":1646688477652,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":260,\"contents\":{\"pos1\":179,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":405,\"sequenceNumber\":406,\"term\":1,\"timestamp\":1646688477688,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":261,\"contents\":{\"pos1\":180,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":406,\"sequenceNumber\":407,\"term\":1,\"timestamp\":1646688477712,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":262,\"contents\":{\"pos1\":181,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":407,\"sequenceNumber\":408,\"term\":1,\"timestamp\":1646688477749,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":263,\"contents\":{\"pos1\":182,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":408,\"sequenceNumber\":409,\"term\":1,\"timestamp\":1646688477776,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":264,\"contents\":{\"pos1\":183,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":409,\"sequenceNumber\":410,\"term\":1,\"timestamp\":1646688477820,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":265,\"contents\":{\"pos1\":184,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":410,\"sequenceNumber\":411,\"term\":1,\"timestamp\":1646688477852,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":266,\"contents\":{\"pos1\":185,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":411,\"sequenceNumber\":412,\"term\":1,\"timestamp\":1646688477883,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":267,\"contents\":{\"pos1\":186,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":412,\"sequenceNumber\":413,\"term\":1,\"timestamp\":1646688477916,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":268,\"contents\":{\"pos1\":187,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":413,\"sequenceNumber\":414,\"term\":1,\"timestamp\":1646688477948,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":269,\"contents\":{\"pos1\":188,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":414,\"sequenceNumber\":415,\"term\":1,\"timestamp\":1646688477979,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":270,\"contents\":{\"pos1\":189,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":415,\"sequenceNumber\":416,\"term\":1,\"timestamp\":1646688478009,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":271,\"contents\":{\"pos1\":190,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":416,\"sequenceNumber\":417,\"term\":1,\"timestamp\":1646688478042,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":273,\"contents\":{\"pos1\":191,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":417,\"sequenceNumber\":418,\"term\":1,\"timestamp\":1646688490596,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":274,\"contents\":{\"pos1\":192,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":418,\"sequenceNumber\":419,\"term\":1,\"timestamp\":1646688491109,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":275,\"contents\":{\"pos1\":193,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":419,\"sequenceNumber\":420,\"term\":1,\"timestamp\":1646688491129,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":276,\"contents\":{\"pos1\":194,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":420,\"sequenceNumber\":421,\"term\":1,\"timestamp\":1646688491168,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":277,\"contents\":{\"pos1\":195,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":421,\"sequenceNumber\":422,\"term\":1,\"timestamp\":1646688491188,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":278,\"contents\":{\"pos1\":196,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":422,\"sequenceNumber\":423,\"term\":1,\"timestamp\":1646688491221,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":279,\"contents\":{\"pos1\":197,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":423,\"sequenceNumber\":424,\"term\":1,\"timestamp\":1646688491272,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":198,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":424,\"sequenceNumber\":425,\"term\":1,\"timestamp\":1646688491305,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":281,\"contents\":{\"pos1\":199,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":425,\"sequenceNumber\":426,\"term\":1,\"timestamp\":1646688491329,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":282,\"contents\":{\"pos1\":200,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":426,\"sequenceNumber\":427,\"term\":1,\"timestamp\":1646688491366,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":283,\"contents\":{\"pos1\":201,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":427,\"sequenceNumber\":428,\"term\":1,\"timestamp\":1646688491396,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":202,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":428,\"sequenceNumber\":429,\"term\":1,\"timestamp\":1646688491433,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":285,\"contents\":{\"pos1\":203,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":429,\"sequenceNumber\":430,\"term\":1,\"timestamp\":1646688491462,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":204,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":430,\"sequenceNumber\":431,\"term\":1,\"timestamp\":1646688491491,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":287,\"contents\":{\"pos1\":205,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":431,\"sequenceNumber\":432,\"term\":1,\"timestamp\":1646688491523,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":206,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":432,\"sequenceNumber\":433,\"term\":1,\"timestamp\":1646688491555,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":289,\"contents\":{\"pos1\":207,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":433,\"sequenceNumber\":434,\"term\":1,\"timestamp\":1646688491583,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":208,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":434,\"sequenceNumber\":435,\"term\":1,\"timestamp\":1646688491617,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":291,\"contents\":{\"pos1\":209,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":435,\"sequenceNumber\":436,\"term\":1,\"timestamp\":1646688491653,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":210,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":436,\"sequenceNumber\":437,\"term\":1,\"timestamp\":1646688491702,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":293,\"contents\":{\"pos1\":211,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":437,\"sequenceNumber\":438,\"term\":1,\"timestamp\":1646688491733,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":212,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":438,\"sequenceNumber\":439,\"term\":1,\"timestamp\":1646688491762,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":295,\"contents\":{\"pos1\":213,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":439,\"sequenceNumber\":440,\"term\":1,\"timestamp\":1646688491796,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":296,\"contents\":{\"pos1\":214,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":440,\"sequenceNumber\":441,\"term\":1,\"timestamp\":1646688491823,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":297,\"contents\":{\"pos1\":215,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":441,\"sequenceNumber\":442,\"term\":1,\"timestamp\":1646688491868,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":216,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":442,\"sequenceNumber\":443,\"term\":1,\"timestamp\":1646688491892,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":299,\"contents\":{\"pos1\":217,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":443,\"sequenceNumber\":444,\"term\":1,\"timestamp\":1646688491922,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":300,\"contents\":{\"pos1\":218,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":444,\"sequenceNumber\":445,\"term\":1,\"timestamp\":1646688491956,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":301,\"contents\":{\"pos1\":219,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":445,\"sequenceNumber\":446,\"term\":1,\"timestamp\":1646688491984,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":220,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":446,\"sequenceNumber\":447,\"term\":1,\"timestamp\":1646688492018,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":303,\"contents\":{\"pos1\":221,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":447,\"sequenceNumber\":448,\"term\":1,\"timestamp\":1646688492060,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":304,\"contents\":{\"pos1\":222,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":448,\"sequenceNumber\":449,\"term\":1,\"timestamp\":1646688492080,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":305,\"contents\":{\"pos1\":223,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":449,\"sequenceNumber\":450,\"term\":1,\"timestamp\":1646688492111,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":306,\"contents\":{\"pos1\":224,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":450,\"sequenceNumber\":451,\"term\":1,\"timestamp\":1646688492145,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":307,\"contents\":{\"pos1\":225,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":451,\"sequenceNumber\":452,\"term\":1,\"timestamp\":1646688492191,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":308,\"contents\":{\"pos1\":226,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":452,\"sequenceNumber\":453,\"term\":1,\"timestamp\":1646688492223,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":309,\"contents\":{\"pos1\":227,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":453,\"sequenceNumber\":454,\"term\":1,\"timestamp\":1646688492256,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":310,\"contents\":{\"pos1\":228,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":454,\"sequenceNumber\":455,\"term\":1,\"timestamp\":1646688492288,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":311,\"contents\":{\"pos1\":229,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":455,\"sequenceNumber\":456,\"term\":1,\"timestamp\":1646688492319,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":313,\"contents\":{\"pos1\":230,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":456,\"sequenceNumber\":457,\"term\":1,\"timestamp\":1646688495162,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":314,\"contents\":{\"pos1\":231,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":457,\"sequenceNumber\":458,\"term\":1,\"timestamp\":1646688495663,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":315,\"contents\":{\"pos1\":232,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":458,\"sequenceNumber\":459,\"term\":1,\"timestamp\":1646688495694,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":316,\"contents\":{\"pos1\":233,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":459,\"sequenceNumber\":460,\"term\":1,\"timestamp\":1646688495724,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":317,\"contents\":{\"pos1\":234,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":460,\"sequenceNumber\":461,\"term\":1,\"timestamp\":1646688495774,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":318,\"contents\":{\"pos1\":235,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":461,\"sequenceNumber\":462,\"term\":1,\"timestamp\":1646688495790,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":319,\"contents\":{\"pos1\":236,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":462,\"sequenceNumber\":463,\"term\":1,\"timestamp\":1646688495836,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":320,\"contents\":{\"pos1\":237,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":463,\"sequenceNumber\":464,\"term\":1,\"timestamp\":1646688495870,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":321,\"contents\":{\"pos1\":238,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":464,\"sequenceNumber\":465,\"term\":1,\"timestamp\":1646688495902,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":322,\"contents\":{\"pos1\":239,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":465,\"sequenceNumber\":466,\"term\":1,\"timestamp\":1646688495931,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":323,\"contents\":{\"pos1\":240,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":466,\"sequenceNumber\":467,\"term\":1,\"timestamp\":1646688495971,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":324,\"contents\":{\"pos1\":241,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":467,\"sequenceNumber\":468,\"term\":1,\"timestamp\":1646688495996,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":325,\"contents\":{\"pos1\":242,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":468,\"sequenceNumber\":469,\"term\":1,\"timestamp\":1646688496025,\"type\":\"op\"},{\"clientId\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",\"clientSequenceNumber\":326,\"contents\":{\"pos1\":243,\"seg\":{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},\"type\":0},\"metadata\":{},\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":469,\"sequenceNumber\":470,\"term\":1,\"timestamp\":1646688496058,\"type\":\"op\"}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":8,\"length\":8,\"segments\":[[1,4],{\"json\":[1,1],\"removedSeq\":225,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"removedClientIds\":[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"]},{\"json\":[1,2],\"removedSeq\":222,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"removedClientIds\":[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"]},{\"json\":[1,3],\"removedSeq\":216,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"removedClientIds\":[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"]},{\"json\":[1,5],\"removedSeq\":207,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"removedClientIds\":[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"]},{\"json\":[1,6],\"removedSeq\":204,\"removedClient\":\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"removedClientIds\":[\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\",\"5f9c6a07-e72b-4176-95c2-2683be590ee2\"]},{\"json\":[1,7],\"removedSeq\":195,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"removedClientIds\":[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"]},{\"json\":[1,8],\"removedSeq\":192,\"removedClient\":\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"removedClientIds\":[\"5f9c6a07-e72b-4176-95c2-2683be590ee2\",\"cec2de69-45a7-4a6b-9baf-c0ef0c3f0860\"]}],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":473,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":8,\"totalSegmentCount\":8}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[9,0,0,0,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":189,\"sequenceNumber\":473,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,{\"id\":\"bd21828d-2143-4248-956e-87e3f8bbd035\"},null,{\"id\":\"0f163713-5ea0-40f3-b69e-390a358a7c22\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"}}},{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,{\"id\":\"cc4f51b2-938b-4f1d-969d-26bcbbb2aa28\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e\"}}},null,null,null,null,null,null,null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f6d586f1-caf4-4f8a-b0f8-9554c5863f9b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"9f39fee6-2201-472f-a21a-32f76d9fbe7b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "cb5595a0-11be-4f9c-8e9a-b0403699732b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1b47e67d-3fe4-4ede-96d4-e0f545136748",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"75e10a5d-47e4-48d2-b155-06f68b0ba935\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "173d26b6-f5c1-4a85-8015-e878bba48a9d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "78507950-28f2-441b-9351-3fbac44763b9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"478c5f8c-5a98-45ca-8cbf-10aeec4769b7\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "01337eeb-1889-4949-8e82-fd3893c2207c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "065a487f-6ccf-4448-abd4-14190325db31",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"72755d84-bebf-43c1-9787-788ef0e62675\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b4c1c436-d533-4d3c-abbc-c60e8ae1be95",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c25bf0d5-ff0a-42a0-9689-280eb09aac1c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":4,\"totalLengthChars\":4,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"ads\",\"Asd\",\"as\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"95f8d7e1-9024-4ddf-bc34-b114befa158c\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "48285434-9a83-41cc-8ae5-f5dcb49d8369",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "5aa31e6a-3749-4ba2-9305-2aa0512ec5b0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"b4abc57c-1270-4a64-a1d1-803b9833dd45\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "471bc487-438e-4f95-b33d-f4b1d7f2aace",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46b84a10-53f7-469f-a849-04db1d8918b6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"242480b0-ae14-49ea-a545-3274183a1478\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "490e917c-9805-40b5-93d9-3b52c444f8c8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf847818-809d-41f4-9dc8-e9389d87b82d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"988e4338-27fb-4124-a330-63fc8d5cb818\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2f989fd2-bb56-4d76-809e-b672000fa9f7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":7,\"totalLengthChars\":7,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdsad\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsad\",\"Assad\",\"assay\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7b1d9334-4447-41e9-8134-4090cb9352bd\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":7,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "af627ff8-30d1-4e89-8220-12c59b99016e",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d2dba981-eeb5-4fdc-aa91-8549d108f8bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":9,\"totalLengthChars\":9,\"totalSegmentCount\":2,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"text\":\"asdasdsd\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688300000},\"proofing!spellingError\":[\"Sadsads'd\",\"Sadsads\",\"Sadsads'\"]}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"1fc7dbca-f11f-4693-872f-c63827533a35\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":9,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "1f3a00f9-e6ce-40c1-a206-1650c1280a86",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a0f98d43-9e0c-41d1-9bee-e72fd5407d90",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"5ef1d1b7-ccb3-4f11-9e9f-1443cb3bceb4\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b194361b-3b4b-4623-b7b9-fe5857095751",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bc03124d-5ee3-4a74-b3bc-fd2c5f93b954",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":189,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8859a370-84e1-4e01-914f-0e5a0553b3ee\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":189,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ],
+                "unreferenced": true
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",\"clientSequenceNumber\":42,\"minimumSequenceNumber\":189,\"referenceSequenceNumber\":472,\"sequenceNumber\":473,\"timestamp\":1646688512878,\"type\":\"summarize\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688512878},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"],\"unreferencedTimestampMs\":1646688512878},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"],\"unreferencedTimestampMs\":1646688512878},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688512878},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"],\"unreferencedTimestampMs\":1646688512878},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"],\"unreferencedTimestampMs\":1646688512878},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688512878},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"],\"unreferencedTimestampMs\":1646688512878},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"],\"unreferencedTimestampMs\":1646688512878},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688512878},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"],\"unreferencedTimestampMs\":1646688512878},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"],\"unreferencedTimestampMs\":1646688512878},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688512878},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"],\"unreferencedTimestampMs\":1646688512878},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"],\"unreferencedTimestampMs\":1646688512878},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688512878},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"],\"unreferencedTimestampMs\":1646688512878},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"],\"unreferencedTimestampMs\":1646688512878},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688512878},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"],\"unreferencedTimestampMs\":1646688512878},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"],\"unreferencedTimestampMs\":1646688512878},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688512878},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"],\"unreferencedTimestampMs\":1646688512878},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"],\"unreferencedTimestampMs\":1646688512878},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688512878},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"],\"unreferencedTimestampMs\":1646688512878},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"],\"unreferencedTimestampMs\":1646688512878},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688512878},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"],\"unreferencedTimestampMs\":1646688512878},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"],\"unreferencedTimestampMs\":1646688512878},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688512878},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"],\"unreferencedTimestampMs\":1646688512878},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"],\"unreferencedTimestampMs\":1646688512878},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688512878},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"],\"unreferencedTimestampMs\":1646688512878},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"],\"unreferencedTimestampMs\":1646688512878},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688512878},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"],\"unreferencedTimestampMs\":1646688512878},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"],\"unreferencedTimestampMs\":1646688512878},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688512878},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"],\"unreferencedTimestampMs\":1646688512878},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"],\"unreferencedTimestampMs\":1646688512878},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688512878},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"],\"unreferencedTimestampMs\":1646688512878},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"],\"unreferencedTimestampMs\":1646688512878},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688512878},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"],\"unreferencedTimestampMs\":1646688512878},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"],\"unreferencedTimestampMs\":1646688512878},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688512878},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\"],\"unreferencedTimestampMs\":1646688512878},\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b\":{\"outboundRoutes\":[\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/root\",\"/f6d586f1-caf4-4f8a-b0f8-9554c5863f9b/e165c0b1-0ab3-44fd-adcf-7fc402fcdf9b\"],\"unreferencedTimestampMs\":1646688512878},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688512878},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\"],\"unreferencedTimestampMs\":1646688512878},\"/cb5595a0-11be-4f9c-8e9a-b0403699732b\":{\"outboundRoutes\":[\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/root\",\"/cb5595a0-11be-4f9c-8e9a-b0403699732b/1b47e67d-3fe4-4ede-96d4-e0f545136748\"],\"unreferencedTimestampMs\":1646688512878},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688512878},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\"],\"unreferencedTimestampMs\":1646688512878},\"/173d26b6-f5c1-4a85-8015-e878bba48a9d\":{\"outboundRoutes\":[\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/root\",\"/173d26b6-f5c1-4a85-8015-e878bba48a9d/78507950-28f2-441b-9351-3fbac44763b9\"],\"unreferencedTimestampMs\":1646688512878},\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\",\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688512878},\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c\"],\"unreferencedTimestampMs\":1646688512878},\"/01337eeb-1889-4949-8e82-fd3893c2207c\":{\"outboundRoutes\":[\"/01337eeb-1889-4949-8e82-fd3893c2207c/root\",\"/01337eeb-1889-4949-8e82-fd3893c2207c/065a487f-6ccf-4448-abd4-14190325db31\"],\"unreferencedTimestampMs\":1646688512878},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688512878},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\"],\"unreferencedTimestampMs\":1646688512878},\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95\":{\"outboundRoutes\":[\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/root\",\"/b4c1c436-d533-4d3c-abbc-c60e8ae1be95/c25bf0d5-ff0a-42a0-9689-280eb09aac1c\"],\"unreferencedTimestampMs\":1646688512878},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688512878},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\"],\"unreferencedTimestampMs\":1646688512878},\"/48285434-9a83-41cc-8ae5-f5dcb49d8369\":{\"outboundRoutes\":[\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/root\",\"/48285434-9a83-41cc-8ae5-f5dcb49d8369/5aa31e6a-3749-4ba2-9305-2aa0512ec5b0\"],\"unreferencedTimestampMs\":1646688512878},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688512878},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\"],\"unreferencedTimestampMs\":1646688512878},\"/471bc487-438e-4f95-b33d-f4b1d7f2aace\":{\"outboundRoutes\":[\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/root\",\"/471bc487-438e-4f95-b33d-f4b1d7f2aace/46b84a10-53f7-469f-a849-04db1d8918b6\"],\"unreferencedTimestampMs\":1646688512878},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688512878},\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8\"],\"unreferencedTimestampMs\":1646688512878},\"/490e917c-9805-40b5-93d9-3b52c444f8c8\":{\"outboundRoutes\":[\"/490e917c-9805-40b5-93d9-3b52c444f8c8/root\",\"/490e917c-9805-40b5-93d9-3b52c444f8c8/cf847818-809d-41f4-9dc8-e9389d87b82d\"],\"unreferencedTimestampMs\":1646688512878},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688512878},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\"],\"unreferencedTimestampMs\":1646688512878},\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b\":{\"outboundRoutes\":[\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/root\",\"/1f926fd7-6a2f-4b9b-b00f-ac06c4958b6b/2f989fd2-bb56-4d76-809e-b672000fa9f7\"],\"unreferencedTimestampMs\":1646688512878},\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\",\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688512878},\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e\"],\"unreferencedTimestampMs\":1646688512878},\"/af627ff8-30d1-4e89-8220-12c59b99016e\":{\"outboundRoutes\":[\"/af627ff8-30d1-4e89-8220-12c59b99016e/root\",\"/af627ff8-30d1-4e89-8220-12c59b99016e/d2dba981-eeb5-4fdc-aa91-8549d108f8bd\"],\"unreferencedTimestampMs\":1646688512878},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688512878},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\"],\"unreferencedTimestampMs\":1646688512878},\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86\":{\"outboundRoutes\":[\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/root\",\"/1f3a00f9-e6ce-40c1-a206-1650c1280a86/a0f98d43-9e0c-41d1-9bee-e72fd5407d90\"],\"unreferencedTimestampMs\":1646688512878},\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\",\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688512878},\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751\"],\"unreferencedTimestampMs\":1646688512878},\"/b194361b-3b4b-4623-b7b9-fe5857095751\":{\"outboundRoutes\":[\"/b194361b-3b4b-4623-b7b9-fe5857095751/root\",\"/b194361b-3b4b-4623-b7b9-fe5857095751/bc03124d-5ee3-4a74-b3bc-fd2c5f93b954\"],\"unreferencedTimestampMs\":1646688512878},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_63_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_63_0.json
@@ -1,0 +1,2168 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":62,\"sequenceNumber\":63,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":62,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":62,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":2,\"length\":4,\"segments\":[[1,4],[3,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":62,\"sequenceNumber\":63,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[5,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":62,\"sequenceNumber\":63,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,null,{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},null,null,null,null,null,null,null,null,null,null,{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",\"clientSequenceNumber\":6,\"minimumSequenceNumber\":62,\"referenceSequenceNumber\":62,\"sequenceNumber\":63,\"timestamp\":1646688197647,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_75_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_75_0.json
@@ -1,0 +1,2168 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":73,\"sequenceNumber\":75,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":73,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":73,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":2,\"length\":4,\"segments\":[[1,4],[3,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":73,\"sequenceNumber\":75,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":4,\"totalSegmentCount\":2}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[5,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":73,\"sequenceNumber\":75,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,null,{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},null,null,null,null,null,null,null,null,null,null,{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":73,\"referenceSequenceNumber\":-1,\"sequenceNumber\":75,\"timestamp\":1646688238577,\"type\":\"leave\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_99_0.json
+++ b/snapshotTestContent/SharedMatrixDeletes/src_snapshots/0.59.3000/snapshot_99_0.json
@@ -1,0 +1,2528 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":97,\"sequenceNumber\":99,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"0c200397-abdc-47ca-905d-ab3ef7329c8f\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688161581,\"mode\":\"write\"},\"sequenceNumber\":1}],[\"49522d62-8131-448f-bcd6-c5ce9bff5d59\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\",\"summary:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":false},\"type\":\"summarizer\",\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688166844,\"mode\":\"write\"},\"sequenceNumber\":7}],[\"2043528d-03b2-4eac-afd4-6f05ed83d1ac\",{\"client\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"scopes\":[\"doc:read\",\"doc:write\"],\"permission\":[],\"details\":{\"capabilities\":{\"interactive\":true},\"environment\":\"; loaderVersion:0.55.4\"},\"timestamp\":1646688274807,\"mode\":\"write\"},\"sequenceNumber\":78}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":5,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":4,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20220303004\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.05151478ba716cec7672.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.bbfe12ec621d7dc80d28.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "bb6b1aaa-ed9b-4679-b654-dc414501670a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}},\"versions\":[{\"sequenceNumber\":3,\"value\":{\"type\":\"Plain\",\"value\":\"0c200397-abdc-47ca-905d-ab3ef7329c8f\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "3330095c-a43b-4518-8222-9dad8f7b1f46",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"oid\":\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"},\"timestamp\":1646688161717}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "38cb8e29-292c-4994-9833-24b30eb821ea",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "69d4f850-127d-4415-ae0e-20848df3a163",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "18477e11-3bf4-4885-9e4c-7f4d8142922d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"component!renderOptions\":\"{ \\\"hideTitle\\\": true}\",\"component!display\":\"block\",\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000},\"nodeType\":\"FluidComponent\",\"markerId\":\"268ced7c-ed33-4ec0-9587-34fcedb9a49e\",\"component!url\":{\"type\":\"__fluid_handle__\",\"url\":\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"},\"content!locale\":\"en-us\"}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"d13919f4-e515-4b00-8322-c9629a6aeeac\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a26dafb-fe0b-4c53-8a30-56c3a467eb02",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a5f5d59d-b938-4755-bb77-43f05ba09c43",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"a\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"8f3120f9-8ca9-4169-855a-e03c90d407fe\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "56bfeaff-2842-4c98-a1a2-14206e928ddf",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"b\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a88251c5-814e-42c6-a229-0496a8bd4a74\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "83168cfa-bc66-4156-968d-8bdf2c84bfbe",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "e4ef90cd-7842-4aa4-ad69-956e1a833ddb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"c\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"cd3eb727-fa75-43d2-b150-b5985dea410e\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "07bb1f75-ddb6-472d-aaf8-96245ca8c278",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"d\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ce83bbd5-a5cc-4172-a1f5-8bc385392666\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f84b3c4c-7daf-4d7a-8a55-844d0339c52d",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "15413f4e-28c9-4d69-ab07-85f7a3b862cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2307f9a4-952b-427c-9ab7-e298595c5371\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f347b0de-2617-40f7-a964-01163fb3e7af",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "dc7effd0-c753-4e5c-aa9d-f0f5f599d4df",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"375dcea4-7051-4617-a119-24c25012634b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7ea167fc-0b98-4183-bafa-d56848d20803\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4085f3d8-0c61-4667-91e8-bda35ef591d9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"83d2717e-a1da-4977-b09f-405de4466517\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bf4216e0-9fc0-48fd-a17a-772b5200989c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "660c330b-c129-4fb9-953a-9011cd72b5e0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"ba36d979-380a-4dc0-ae85-71d59a525eb9\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f08e03d6-4305-46a3-9d20-67f8da5ab970",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cc20d76a-704c-47fd-84f2-abc3c63d7aaa",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"5\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a81b37b7-0b66-46f5-a5d7-39b5dc168129\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "bde77ebe-9970-4c1e-857d-d2926f9bc7a5",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "7bdee5f1-4d8f-4567-bf87-323f91cb53dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"6\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"50c439c7-c312-4e5d-961d-f9ffb700ebc8\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "579306e5-bb64-4f3a-a1ec-62a5b63e4ad0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b8fd4d00-980b-4f28-af3a-8d4306292074",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"7\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"0fbbe644-b1f7-40a5-8e3f-0f2d69b13b2f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "42425ac3-0629-4ef4-9c01-c0a0b50307c6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "f588d2f6-5a15-43c8-a0f2-8f2a852c1856",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"7d1b48ec-76f7-42eb-8c28-51095e007b06\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c23e0a70-1c9b-4f8d-a926-24b5d2224ae6",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48932546-243f-42b0-b95c-dd64aece154d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"55042d8d-4965-46d8-82e8-c18a8529e5fb\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "2d73328f-4993-4642-904b-8657735570a0",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1f66174e-6672-4307-9059-11555da1ccb3",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"02deaf0a-57e9-4a73-916d-98b81f86c433\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "663e6819-d035-4b2a-850f-7bff14454b0f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a804b04-bee2-4590-8ead-c85c7d8e07bb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"97a607bb-93d0-4ef6-90fc-4622e8883c41\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "47b85e14-d60d-4543-8e3e-cfe15c8a97e3",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"matrixIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "matrixId-95efe124-a593-464f-872d-5052f804e76e",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "rows",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":3,\"length\":5,\"segments\":[[1,4],[3,1],[1,5]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":97,\"sequenceNumber\":99,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":3}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "cols",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "040000",
+                                      "path": "segments",
+                                      "type": "Tree",
+                                      "value": {
+                                        "entries": [
+                                          {
+                                            "mode": "100644",
+                                            "path": "header",
+                                            "type": "Blob",
+                                            "value": {
+                                              "contents": "{\"version\":\"1\",\"segmentCount\":1,\"length\":5,\"segments\":[[5,1]],\"startIndex\":0,\"headerMetadata\":{\"minSequenceNumber\":97,\"sequenceNumber\":99,\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"totalLength\":5,\"totalSegmentCount\":1}}",
+                                              "encoding": "utf-8"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "handleTable",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[6,0,0,0,0,0]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": "cells",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "[[[[[[null,null,null,{\"id\":\"initialRow-0\"},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f347b0de-2617-40f7-a964-01163fb3e7af\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,{\"id\":\"initialRow-1\"},null,{\"id\":\"initialRow-2\"},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/2d73328f-4993-4642-904b-8657735570a0\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/663e6819-d035-4b2a-850f-7bff14454b0f\"}},\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\"}},null,null,null,null,null,null,null,{\"id\":\"8690c68a-2e7c-4396-8515-7194bd94de0c\"},{\"id\":\"initialColumn-0\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-1\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018\"}}},null,null,null,null,null,null,null,null,{\"id\":\"initialColumn-2\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"id\":\"initialColumn-3\",\"type\":\"IRichTextData\",\"title\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"}},\"titleType\":\"IRichTextData\",\"dataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}},\"titleDataTypeProps\":{\"initialConfig\":{\"isTextBoxMode\":true,\"disableGuestComponents\":true,\"richTextServicesConfiguration\":{\"presetName\":\"RichTextCell\"}}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"}}},{\"value\":{\"componentHandle\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"}}},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]],[null]]",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/sharedmatrix\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\",\\\"@ms/tablero/TableDataModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "0442acda-dc4a-4858-9465-c9cd0a949b06",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"tableroDocumentId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"}},\"rowSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\"}},\"colSequenceKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\"}},\"sharedSignalKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\"}},\"viewDataPropertyBagKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"}},\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"columnTitleType\":{\"type\":\"Plain\",\"value\":\"IRichTextData\"},\"sortedColumn\":{\"type\":\"Plain\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/SharedArray\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/signal\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.25.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"subdirectories\":{\"tableViewDataPropertyBag\":{\"storage\":{\"contentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"}},\"subdirectories\":{\"tableFormattingOptionPropertyBag\":{\"storage\":{\"isRTL\":{\"type\":\"Plain\",\"value\":false}}}}},\"columnViewDataPropertyBag\":{\"subdirectories\":{\"initialColumn-0\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-1\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-2\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}},\"initialColumn-3\":{\"storage\":{\"width\":{\"type\":\"Plain\",\"value\":170},\"minWidth\":{\"type\":\"Plain\",\"value\":56},\"widthRatio\":{\"type\":\"Plain\",\"value\":1}}}}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"@ms/tablero/TableViewModel\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "151634f5-cf9a-4c97-aee7-1afdde0acae1",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"componentConfigurationType\":{\"type\":\"Plain\",\"value\":\"richTextTablero\"},\"tableViewModelIdKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "298b0a35-a5e4-4623-b0ed-8ae2501a255b",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "826296df-37df-48d8-b419-c5920d0d7d4a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"1\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"361bff7f-db2f-4b2f-a9c0-b0401cbf2ad3\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "570f508d-007d-4502-8213-c8cb1c51f018",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4a4c7b2d-7e85-492e-8019-9b1eb7353508",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"2\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"15ad673b-375f-4ec1-9006-9eb8af57b99b\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "cf5a56e4-126d-45db-825d-853ef77583c9",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"3\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"a2509056-49f1-45e7-aff8-283a20fe9817\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "5a93bca1-25ba-45bc-87bc-3968fc0ac1cf",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"configuration\":{\"type\":\"Plain\",\"value\":{\"presetName\":\"RichTextCell\"}},\"isTextBoxMode\":{\"type\":\"Plain\",\"value\":true},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "eabd23dd-a259-4a40-ad8d-bf8078be7a84",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":2,\"totalLengthChars\":2,\"totalSegmentCount\":2,\"chunkSequenceNumber\":97,\"segmentTexts\":[{\"text\":\"4\",\"props\":{\"attribution\":{\"id\":\"UnknownPerson@example.com\",\"name\":\"UnknownPerson\",\"email\":\"UnknownPerson@example.com\",\"timestamp\":1646688000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"2176c681-d805-4b40-825f-815401bce04f\",\"nodeType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":97,\"totalLength\":2,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.56.6\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/tablero/TableroView\\\",\\\"IRichTextData\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.56.6\",\"createContainerTimestamp\":1646688156435,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":\"2043528d-03b2-4eac-afd4-6f05ed83d1ac\",\"clientSequenceNumber\":18,\"minimumSequenceNumber\":97,\"referenceSequenceNumber\":98,\"sequenceNumber\":99,\"timestamp\":1646688280365,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\",\"/_scheduler\"]},\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/bb6b1aaa-ed9b-4679-b654-dc414501670a\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\",\"/69d4f850-127d-4415-ae0e-20848df3a163\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46\"]},\"/3330095c-a43b-4518-8222-9dad8f7b1f46\":{\"outboundRoutes\":[\"/3330095c-a43b-4518-8222-9dad8f7b1f46/root\",\"/3330095c-a43b-4518-8222-9dad8f7b1f46/38cb8e29-292c-4994-9833-24b30eb821ea\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/root\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\",\"/69d4f850-127d-4415-ae0e-20848df3a163\"]},\"/69d4f850-127d-4415-ae0e-20848df3a163\":{\"outboundRoutes\":[\"/69d4f850-127d-4415-ae0e-20848df3a163/root\",\"/69d4f850-127d-4415-ae0e-20848df3a163/18477e11-3bf4-4885-9e4c-7f4d8142922d\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\"]},\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/root\",\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02/a5f5d59d-b938-4755-bb77-43f05ba09c43\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\"]},\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\":{\"outboundRoutes\":[\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/root\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f/56bfeaff-2842-4c98-a1a2-14206e928ddf\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\"]},\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\":{\"outboundRoutes\":[\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/root\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe/e4ef90cd-7842-4aa4-ad69-956e1a833ddb\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\"]},\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\":{\"outboundRoutes\":[\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/root\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278/94d5a85a-a3b6-4550-8d4f-e2a623b9e1ae\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\"]},\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\":{\"outboundRoutes\":[\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/root\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d/15413f4e-28c9-4d69-ab07-85f7a3b862cc\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af\"]},\"/f347b0de-2617-40f7-a964-01163fb3e7af\":{\"outboundRoutes\":[\"/f347b0de-2617-40f7-a964-01163fb3e7af/root\",\"/f347b0de-2617-40f7-a964-01163fb3e7af/dc7effd0-c753-4e5c-aa9d-f0f5f599d4df\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\"]},\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\":{\"outboundRoutes\":[\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/root\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a/6901dfef-fdcc-4ab4-b23a-a6ffdf1708d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\"]},\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\":{\"outboundRoutes\":[\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/root\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1/4085f3d8-0c61-4667-91e8-bda35ef591d9\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\"]},\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\":{\"outboundRoutes\":[\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/root\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c/660c330b-c129-4fb9-953a-9011cd72b5e0\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\"]},\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\":{\"outboundRoutes\":[\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/root\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970/cc20d76a-704c-47fd-84f2-abc3c63d7aaa\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\"]},\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\":{\"outboundRoutes\":[\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/root\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5/7bdee5f1-4d8f-4567-bf87-323f91cb53dc\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\"]},\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\":{\"outboundRoutes\":[\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/root\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0/b8fd4d00-980b-4f28-af3a-8d4306292074\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\"]},\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\":{\"outboundRoutes\":[\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/root\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6/f588d2f6-5a15-43c8-a0f2-8f2a852c1856\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\"]},\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\":{\"outboundRoutes\":[\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/root\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6/48932546-243f-42b0-b95c-dd64aece154d\"]},\"/2d73328f-4993-4642-904b-8657735570a0/root\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\",\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0\"]},\"/2d73328f-4993-4642-904b-8657735570a0\":{\"outboundRoutes\":[\"/2d73328f-4993-4642-904b-8657735570a0/root\",\"/2d73328f-4993-4642-904b-8657735570a0/1f66174e-6672-4307-9059-11555da1ccb3\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f\"]},\"/663e6819-d035-4b2a-850f-7bff14454b0f\":{\"outboundRoutes\":[\"/663e6819-d035-4b2a-850f-7bff14454b0f/root\",\"/663e6819-d035-4b2a-850f-7bff14454b0f/4a804b04-bee2-4590-8ead-c85c7d8e07bb\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\":{\"outboundRoutes\":[\"/5a26dafb-fe0b-4c53-8a30-56c3a467eb02\",\"/c9d51e0b-09f0-4b95-a884-ed39fbd1ef8f\",\"/83168cfa-bc66-4156-968d-8bdf2c84bfbe\",\"/07bb1f75-ddb6-472d-aaf8-96245ca8c278\",\"/f84b3c4c-7daf-4d7a-8a55-844d0339c52d\",\"/f347b0de-2617-40f7-a964-01163fb3e7af\",\"/06e1c3bd-6ce1-4362-8f1a-40b5e0782c7a\",\"/307bf7c6-fa1e-474b-b79e-ac8f7b77c3d1\",\"/bf4216e0-9fc0-48fd-a17a-772b5200989c\",\"/f08e03d6-4305-46a3-9d20-67f8da5ab970\",\"/bde77ebe-9970-4c1e-857d-d2926f9bc7a5\",\"/579306e5-bb64-4f3a-a1ec-62a5b63e4ad0\",\"/42425ac3-0629-4ef4-9c01-c0a0b50307c6\",\"/c23e0a70-1c9b-4f8d-a926-24b5d2224ae6\",\"/2d73328f-4993-4642-904b-8657735570a0\",\"/663e6819-d035-4b2a-850f-7bff14454b0f\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\",\"/570f508d-007d-4502-8213-c8cb1c51f018\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\"]},\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/root\",\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3/matrixId-95efe124-a593-464f-872d-5052f804e76e\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\":{\"outboundRoutes\":[\"/47b85e14-d60d-4543-8e3e-cfe15c8a97e3\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\"]},\"/0442acda-dc4a-4858-9465-c9cd0a949b06\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06/root\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/rowSequence-0954ad8a-f059-4e57-8794-1e315fcbd899\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/colSequence-8ed6a702-906a-432e-9a88-8adcf3e04c0d\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/sharedSignal-45d35084-5687-4ee4-9bf9-7ee5db08b42c\",\"/0442acda-dc4a-4858-9465-c9cd0a949b06/viewDataPropertyBag-21a7bb41-c415-4fdc-8d0d-6bad7e72dbff\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\":{\"outboundRoutes\":[\"/0442acda-dc4a-4858-9465-c9cd0a949b06\",\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\"]},\"/151634f5-cf9a-4c97-aee7-1afdde0acae1\":{\"outboundRoutes\":[\"/151634f5-cf9a-4c97-aee7-1afdde0acae1/root\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\"]},\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b\":{\"outboundRoutes\":[\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/root\",\"/298b0a35-a5e4-4623-b0ed-8ae2501a255b/826296df-37df-48d8-b419-c5920d0d7d4a\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/root\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\",\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018\"]},\"/570f508d-007d-4502-8213-c8cb1c51f018\":{\"outboundRoutes\":[\"/570f508d-007d-4502-8213-c8cb1c51f018/root\",\"/570f508d-007d-4502-8213-c8cb1c51f018/4a4c7b2d-7e85-492e-8019-9b1eb7353508\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\"]},\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c\":{\"outboundRoutes\":[\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/root\",\"/f27adfc1-63ae-4ec7-a9db-ec3c3d7cb78c/cf5a56e4-126d-45db-825d-853ef77583c9\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\"]},\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf\":{\"outboundRoutes\":[\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/root\",\"/5a93bca1-25ba-45bc-87bc-3968fc0ac1cf/eabd23dd-a259-4a40-ad8d-bf8078be7a84\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,791 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":998,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c27f7136-f696-4d16-a987-b016864acfc9\",{\"client\":{\"user\":{\"id\":\"rlqq1vbpg@example.com}\",\"name\":\"psy14blb7khms1s\",\"email\":\"7mdyla6qj@example.com}\"}},\"sequenceNumber\":1}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "9acfdfc3-b8f2-4751-b19c-bba930d124ff",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "d622a7ed-880a-482b-a1e8-1be09dedbae8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "b929106b-7f80-416b-8e5d-31f08f02c92d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/b929106b-7f80-416b-8e5d-31f08f02c92d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2c617c0f-273d-49f4-b696-54bd3695c891\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/70bc151c-4854-418a-a546-77a287e0138d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4c136b66-63df-44d5-9163-08d0979a7471\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c27f7136-f696-4d16-a987-b016864acfc9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":368,\"refSeqNumber\":997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2c617c0f-273d-49f4-b696-54bd3695c891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d7ed3734-e287-44e1-8383-efa71bdebfd4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4c136b66-63df-44d5-9163-08d0979a7471",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a925583d-5608-4590-9000-6b94783a9552\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/011575d0-afb9-444c-8328-95ad09b750c6\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/81501816-9a9b-4df2-880a-f5d94562b3e8\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/11b84fb1-ae15-487f-bd4c-ba53d6a617c1\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1daf2d51-820a-4857-b3f1-6356639bf0bd\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec31b865-0ed5-41de-88f3-cbe1ccc76431\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6fbb365-b827-4386-9428-3785195090ad\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a925583d-5608-4590-9000-6b94783a9552",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "011575d0-afb9-444c-8328-95ad09b750c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "81501816-9a9b-4df2-880a-f5d94562b3e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "11b84fb1-ae15-487f-bd4c-ba53d6a617c1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1daf2d51-820a-4857-b3f1-6356639bf0bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec31b865-0ed5-41de-88f3-cbe1ccc76431",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6fbb365-b827-4386-9428-3785195090ad",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "70bc151c-4854-418a-a546-77a287e0138d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d7ed3734-e287-44e1-8383-efa71bdebfd4\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":22,\"chunkLengthChars\":369,\"totalLengthChars\":369,\"totalSegmentCount\":22,\"chunkSequenceNumber\":998,\"segmentTexts\":[{\"text\":\"vdka\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10860101-8e42-4af0-abbb-77ef0af29395\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"usmha\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"f6j801r2mdd8rhcpyprxihazs9bxq6x6gdklupgn9e4h6mdayvqwg2qdv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dd6c671b-f2a5-43a2-84c4-66f39a170d0c\",\"ItemType\":\"Paragraph\"}},\"4tq505ca6gp2hvz2dhu0nqr4a8j4ue2uwsory9mxk5nclyaeoieuz1z8iy8795pb14gxnwdwke58\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a5177859-5d16-4401-846c-492973b53882\",\"ItemType\":\"Paragraph\"}},\"70ag092j6cjxstrfzhe9hpcx0e4glu6r4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"de981134-5576-48c5-a290-1ad5eb536f47\",\"ItemType\":\"Paragraph\"}},\"j7y1hunvr7vc6s92ppc2mkdrvw5xeazwzqhz0kxpkf0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c9195aeb-fb15-484e-ab78-f48a3116dc82\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7aafa2b-b8d2-4e41-8589-3de7ef9e0915\",\"ItemType\":\"Paragraph\"}},\"yadkg7q7k7brzog2qmjrccycjyuho43e5p3r3yktkbpds\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1a9316e-68f3-435c-be01-63383f7b39ba\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6679e71-df50-4c8b-92f6-571cd1c67014\",\"ItemType\":\"Paragraph\"}},\"wy96h1omeam90u0h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bb5b57b4-f4c3-47bb-b739-4643020f650d\",\"ItemType\":\"Paragraph\"}},\"seupt9z6zxub95951237zhqnuzn0almf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d4727240-8a83-4b98-82ad-da6efd2c32bc\",\"ItemType\":\"Paragraph\"}},\"1ajeeks8uxn3q083vho7v6eby4xrnlcgy95wsq6528vnjn\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d67e6cba-fa53-4df6-8135-35260250002b\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1b6b3653-ded7-4ee1-9993-82fe71bf3cdd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":998,\"totalLength\":369,\"totalSegmentCount\":22}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1063,\"contents\":{\"pos1\":367,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1564523538482,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1064,\"minimumSequenceNumber\":998,\"referenceSequenceNumber\":998,\"sequenceNumber\":1000,\"timestamp\":1564523538482,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,791 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1780,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c27f7136-f696-4d16-a987-b016864acfc9\",{\"client\":{\"user\":{\"id\":\"rlqq1vbpg@example.com}\",\"name\":\"psy14blb7khms1s\",\"email\":\"7mdyla6qj@example.com}\"}},\"sequenceNumber\":1}],[\"8d0286e5-3783-4637-ac92-df2980eb7fd2\",{\"client\":{\"user\":{\"id\":\"w99asouc8@example.com}\",\"name\":\"j5ojebbsmc8bu6i\",\"email\":\"9pyc6r7op@example.com}\"}},\"sequenceNumber\":1685}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/b929106b-7f80-416b-8e5d-31f08f02c92d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b929106b-7f80-416b-8e5d-31f08f02c92d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2c617c0f-273d-49f4-b696-54bd3695c891\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/70bc151c-4854-418a-a546-77a287e0138d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4c136b66-63df-44d5-9163-08d0979a7471\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c27f7136-f696-4d16-a987-b016864acfc9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":649,\"refSeqNumber\":1999}},\"9708c2fb-40fd-44d1-aed1-f237c99bcdcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1406}},\"8d0286e5-3783-4637-ac92-df2980eb7fd2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1682}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2c617c0f-273d-49f4-b696-54bd3695c891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d7ed3734-e287-44e1-8383-efa71bdebfd4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "70bc151c-4854-418a-a546-77a287e0138d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d7ed3734-e287-44e1-8383-efa71bdebfd4\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":43,\"chunkLengthChars\":672,\"totalLengthChars\":672,\"totalSegmentCount\":43,\"chunkSequenceNumber\":1780,\"segmentTexts\":[{\"text\":\"vdka\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10860101-8e42-4af0-abbb-77ef0af29395\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"usmha\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"f6j801r2mdd8rhcpyprxihazs9bxq6x6gdklupgn9e4h6mdayvqwg2qdv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dd6c671b-f2a5-43a2-84c4-66f39a170d0c\",\"ItemType\":\"Paragraph\"}},\"4tq505ca6gp2hvz2dhu0nqr4a8j4ue2uwsory9mxk5nclyaeoieuz1z8iy8795pb14gxnwdwke58\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a5177859-5d16-4401-846c-492973b53882\",\"ItemType\":\"Paragraph\"}},\"70ag092j6cjxstrfzhe9hpcx0e4glu6r4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"de981134-5576-48c5-a290-1ad5eb536f47\",\"ItemType\":\"Paragraph\"}},\"j7y1hunvr7vc6s92ppc2mkdrvw5xeazwzqhz0kxpkf0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c9195aeb-fb15-484e-ab78-f48a3116dc82\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7aafa2b-b8d2-4e41-8589-3de7ef9e0915\",\"ItemType\":\"Paragraph\"}},\"yadkg7q7k7brzog2qmjrccycjyuho43e5p3r3yktkbpds\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1a9316e-68f3-435c-be01-63383f7b39ba\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6679e71-df50-4c8b-92f6-571cd1c67014\",\"ItemType\":\"Paragraph\"}},\"wy96h1omeam90u0h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bb5b57b4-f4c3-47bb-b739-4643020f650d\",\"ItemType\":\"Paragraph\"}},\"seupt9z6zxub95951237zhqnuzn0almf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d4727240-8a83-4b98-82ad-da6efd2c32bc\",\"ItemType\":\"Paragraph\"}},\"1ajeeks8uxn3q083vho7v6eby4xrnlcgy95wsq6528vnjnq7f4pqneufsp06ubo624av7elhz87f430\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d67e6cba-fa53-4df6-8135-35260250002b\",\"ItemType\":\"Paragraph\"}},\"jgsk\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4f2bf87a-3957-4024-a665-be82a63fca1d\",\"ItemType\":\"Paragraph\"}},\"s4aohyl2k0lvufvv3yjljhab887v2vs7jnvqj2gtp1x1cdptr12tfs7u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"959c2c58-ba46-4381-8cb2-82655da01bf3\",\"ItemType\":\"Paragraph\"}},\"mftmqsudg4y03zljaesabof9csq4kec9pg3ei\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a071a996-44eb-483f-8c18-29a3832bd20a\",\"ItemType\":\"Paragraph\"}},\"rxnjfhc7xu5yailc56zu013hfu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a0b4d656-c34f-4e8d-8afb-0efe830667be\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b6fd517d-e32f-4051-ba58-f4893223bbef\",\"ItemType\":\"Paragraph\"}},\"i08w6tvby4ax2otjpq8iolky2r0x3mofn3d0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef9dd758-8b13-4a84-9946-2e18b6a325e2\",\"ItemType\":\"Paragraph\"}},\"jwr0n3il2d7eh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"99d5e345-523c-4628-93ad-25d955b87062\",\"ItemType\":\"Paragraph\"}},\"zyoukaa7dz3nfl8hthyw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ece59010-002f-4dbc-94d6-0c338e7c1e95\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"df79278c-6b1e-4af4-87c5-6b1ad4ea9f47\",\"ItemType\":\"Paragraph\"}},\"8w88ww8hh1l28ha2aks1hfatuznhpp4jmxs5ih\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3c7eba98-1e71-4fb1-8140-8ffcd5295d15\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ff13e8ee-e03c-427f-a649-051351ced0e7\",\"ItemType\":\"Paragraph\"}},\"n9xzi1otwapbg71xtqffv85s4rkz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8bf94f6b-160a-48cd-9d4a-a2737cc13c46\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1b6b3653-ded7-4ee1-9993-82fe71bf3cdd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1780,\"totalLength\":672,\"totalSegmentCount\":43}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1886,\"contents\":{\"pos1\":640,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1780,\"sequenceNumber\":1781,\"timestamp\":1564524473519,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1889,\"contents\":{\"pos1\":641,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1782,\"sequenceNumber\":1783,\"timestamp\":1564524474019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1892,\"contents\":{\"pos1\":642,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1784,\"sequenceNumber\":1785,\"timestamp\":1564524474519,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1894,\"contents\":{\"pos1\":643,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1786,\"sequenceNumber\":1787,\"timestamp\":1564524474660,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1896,\"contents\":{\"pos1\":644,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1788,\"sequenceNumber\":1789,\"timestamp\":1564524474910,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1900,\"contents\":{\"pos1\":644,\"pos2\":645,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1791,\"sequenceNumber\":1792,\"timestamp\":1564524475269,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1902,\"contents\":{\"pos1\":643,\"pos2\":644,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1793,\"sequenceNumber\":1794,\"timestamp\":1564524475394,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1904,\"contents\":{\"pos1\":642,\"pos2\":643,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1795,\"sequenceNumber\":1796,\"timestamp\":1564524475503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1906,\"contents\":{\"pos1\":642,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1796,\"sequenceNumber\":1797,\"timestamp\":1564524475927,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1908,\"contents\":{\"pos1\":643,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1798,\"sequenceNumber\":1799,\"timestamp\":1564524476021,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1910,\"contents\":{\"pos1\":644,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1800,\"sequenceNumber\":1801,\"timestamp\":1564524476115,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1912,\"contents\":{\"pos1\":645,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1802,\"sequenceNumber\":1803,\"timestamp\":1564524476209,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1914,\"contents\":{\"pos1\":646,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1804,\"sequenceNumber\":1805,\"timestamp\":1564524476334,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1916,\"contents\":{\"pos1\":647,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1806,\"sequenceNumber\":1807,\"timestamp\":1564524476443,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1918,\"contents\":{\"pos1\":648,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1808,\"sequenceNumber\":1809,\"timestamp\":1564524476600,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1920,\"contents\":{\"pos1\":649,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1810,\"sequenceNumber\":1811,\"timestamp\":1564524476771,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1922,\"contents\":{\"pos1\":650,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1812,\"sequenceNumber\":1813,\"timestamp\":1564524476834,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1924,\"contents\":{\"pos1\":651,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1814,\"sequenceNumber\":1815,\"timestamp\":1564524477022,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1926,\"contents\":{\"pos1\":652,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1816,\"sequenceNumber\":1817,\"timestamp\":1564524477131,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1928,\"contents\":{\"pos1\":653,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1818,\"sequenceNumber\":1819,\"timestamp\":1564524477397,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1930,\"contents\":{\"pos1\":654,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1820,\"sequenceNumber\":1821,\"timestamp\":1564524477507,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1932,\"contents\":{\"pos1\":655,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1822,\"sequenceNumber\":1823,\"timestamp\":1564524477727,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1934,\"contents\":{\"pos1\":656,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1824,\"sequenceNumber\":1825,\"timestamp\":1564524477868,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1936,\"contents\":{\"pos1\":657,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1826,\"sequenceNumber\":1827,\"timestamp\":1564524478087,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1938,\"contents\":{\"pos1\":658,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1828,\"sequenceNumber\":1829,\"timestamp\":1564524478243,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1940,\"contents\":{\"pos1\":659,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1830,\"sequenceNumber\":1831,\"timestamp\":1564524478430,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1942,\"contents\":{\"pos1\":660,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1832,\"sequenceNumber\":1833,\"timestamp\":1564524478540,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1946,\"contents\":{\"pos1\":661,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1834,\"sequenceNumber\":1835,\"timestamp\":1564524479463,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1949,\"contents\":{\"pos1\":662,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1836,\"sequenceNumber\":1837,\"timestamp\":1564524479807,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1951,\"contents\":{\"pos1\":663,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1838,\"sequenceNumber\":1839,\"timestamp\":1564524479885,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1954,\"contents\":{\"pos1\":664,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1840,\"sequenceNumber\":1841,\"timestamp\":1564524480151,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1956,\"contents\":{\"pos1\":665,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1842,\"sequenceNumber\":1843,\"timestamp\":1564524480291,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1959,\"contents\":{\"pos1\":666,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1844,\"sequenceNumber\":1845,\"timestamp\":1564524480791,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1962,\"contents\":{\"pos1\":667,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1846,\"sequenceNumber\":1847,\"timestamp\":1564524481324,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1964,\"contents\":{\"pos1\":668,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1848,\"sequenceNumber\":1849,\"timestamp\":1564524481418,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1966,\"contents\":{\"pos1\":669,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1850,\"sequenceNumber\":1851,\"timestamp\":1564524481480,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1969,\"contents\":{\"pos1\":670,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1852,\"sequenceNumber\":1853,\"timestamp\":1564524481746,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1971,\"contents\":{\"pos1\":671,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1854,\"sequenceNumber\":1855,\"timestamp\":1564524481965,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1976,\"contents\":{\"pos1\":602,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78bbe823-dc67-4c5f-a3d6-e758b1547ad7\",\"ItemType\":\"Paragraph\"}},\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1857,\"sequenceNumber\":1858,\"timestamp\":1564524482965,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1979,\"contents\":{\"pos1\":602,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1859,\"sequenceNumber\":1860,\"timestamp\":1564524483387,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1981,\"contents\":{\"pos1\":603,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1861,\"sequenceNumber\":1862,\"timestamp\":1564524483544,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1983,\"contents\":{\"pos1\":604,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1863,\"sequenceNumber\":1864,\"timestamp\":1564524483653,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1986,\"contents\":{\"pos1\":605,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1865,\"sequenceNumber\":1866,\"timestamp\":1564524484090,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1989,\"contents\":{\"pos1\":606,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1867,\"sequenceNumber\":1868,\"timestamp\":1564524484689,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1991,\"contents\":{\"pos1\":607,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1869,\"sequenceNumber\":1870,\"timestamp\":1564524485002,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1993,\"contents\":{\"pos1\":608,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1871,\"sequenceNumber\":1872,\"timestamp\":1564524485236,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1995,\"contents\":{\"pos1\":609,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1873,\"sequenceNumber\":1874,\"timestamp\":1564524485346,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":1997,\"contents\":{\"pos1\":610,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1875,\"sequenceNumber\":1876,\"timestamp\":1564524485471,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2000,\"contents\":{\"pos1\":611,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1877,\"sequenceNumber\":1878,\"timestamp\":1564524486252,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2002,\"contents\":{\"pos1\":612,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1879,\"sequenceNumber\":1880,\"timestamp\":1564524486346,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2004,\"contents\":{\"pos1\":613,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1881,\"sequenceNumber\":1882,\"timestamp\":1564524486424,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2006,\"contents\":{\"pos1\":614,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1883,\"sequenceNumber\":1884,\"timestamp\":1564524486533,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2008,\"contents\":{\"pos1\":615,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1885,\"sequenceNumber\":1886,\"timestamp\":1564524486736,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2010,\"contents\":{\"pos1\":616,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1887,\"sequenceNumber\":1888,\"timestamp\":1564524487002,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2014,\"contents\":{\"pos1\":616,\"pos2\":617,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1890,\"sequenceNumber\":1891,\"timestamp\":1564524487392,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2016,\"contents\":{\"pos1\":616,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1891,\"sequenceNumber\":1892,\"timestamp\":1564524488019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2018,\"contents\":{\"pos1\":617,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1893,\"sequenceNumber\":1894,\"timestamp\":1564524488270,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2020,\"contents\":{\"pos1\":618,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1895,\"sequenceNumber\":1896,\"timestamp\":1564524488363,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2022,\"contents\":{\"pos1\":619,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1897,\"sequenceNumber\":1898,\"timestamp\":1564524488582,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2025,\"contents\":{\"pos1\":620,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1899,\"sequenceNumber\":1900,\"timestamp\":1564524489379,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2029,\"contents\":{\"pos1\":620,\"pos2\":621,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1902,\"sequenceNumber\":1903,\"timestamp\":1564524490420,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2031,\"contents\":{\"pos1\":620,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1903,\"sequenceNumber\":1904,\"timestamp\":1564524491030,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2033,\"contents\":{\"pos1\":621,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1905,\"sequenceNumber\":1906,\"timestamp\":1564524491264,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2035,\"contents\":{\"pos1\":622,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1907,\"sequenceNumber\":1908,\"timestamp\":1564524491436,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2037,\"contents\":{\"pos1\":623,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1909,\"sequenceNumber\":1910,\"timestamp\":1564524491561,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2039,\"contents\":{\"pos1\":624,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1911,\"sequenceNumber\":1912,\"timestamp\":1564524491639,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2041,\"contents\":{\"pos1\":625,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1913,\"sequenceNumber\":1914,\"timestamp\":1564524491702,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2043,\"contents\":{\"pos1\":626,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1915,\"sequenceNumber\":1916,\"timestamp\":1564524491842,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2046,\"contents\":{\"pos1\":627,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1917,\"sequenceNumber\":1918,\"timestamp\":1564524492845,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2048,\"contents\":{\"pos1\":628,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1919,\"sequenceNumber\":1920,\"timestamp\":1564524493063,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2050,\"contents\":{\"pos1\":629,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1921,\"sequenceNumber\":1922,\"timestamp\":1564524493235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2052,\"contents\":{\"pos1\":630,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1923,\"sequenceNumber\":1924,\"timestamp\":1564524493470,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2054,\"contents\":{\"pos1\":631,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1925,\"sequenceNumber\":1926,\"timestamp\":1564524493548,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2057,\"contents\":{\"pos1\":632,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1927,\"sequenceNumber\":1928,\"timestamp\":1564524494563,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2059,\"contents\":{\"pos1\":633,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1929,\"sequenceNumber\":1930,\"timestamp\":1564524494720,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2061,\"contents\":{\"pos1\":634,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1931,\"sequenceNumber\":1932,\"timestamp\":1564524494829,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2063,\"contents\":{\"pos1\":635,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1933,\"sequenceNumber\":1934,\"timestamp\":1564524494970,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2065,\"contents\":{\"pos1\":636,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1935,\"sequenceNumber\":1936,\"timestamp\":1564524495095,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2067,\"contents\":{\"pos1\":637,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1937,\"sequenceNumber\":1938,\"timestamp\":1564524495329,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2069,\"contents\":{\"pos1\":638,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1939,\"sequenceNumber\":1940,\"timestamp\":1564524495423,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2073,\"contents\":{\"pos1\":638,\"pos2\":639,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1942,\"sequenceNumber\":1943,\"timestamp\":1564524495798,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2075,\"contents\":{\"pos1\":637,\"pos2\":638,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1944,\"sequenceNumber\":1945,\"timestamp\":1564524495938,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2077,\"contents\":{\"pos1\":636,\"pos2\":637,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1946,\"sequenceNumber\":1947,\"timestamp\":1564524496063,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2079,\"contents\":{\"pos1\":635,\"pos2\":636,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1948,\"sequenceNumber\":1949,\"timestamp\":1564524496235,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2081,\"contents\":{\"pos1\":634,\"pos2\":635,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1950,\"sequenceNumber\":1951,\"timestamp\":1564524496360,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2083,\"contents\":{\"pos1\":633,\"pos2\":634,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1952,\"sequenceNumber\":1953,\"timestamp\":1564524496501,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2085,\"contents\":{\"pos1\":633,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1953,\"sequenceNumber\":1954,\"timestamp\":1564524497157,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2087,\"contents\":{\"pos1\":634,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1955,\"sequenceNumber\":1956,\"timestamp\":1564524497282,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2089,\"contents\":{\"pos1\":635,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1957,\"sequenceNumber\":1958,\"timestamp\":1564524497376,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2092,\"contents\":{\"pos1\":636,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1959,\"sequenceNumber\":1960,\"timestamp\":1564524497688,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2094,\"contents\":{\"pos1\":637,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1961,\"sequenceNumber\":1962,\"timestamp\":1564524497923,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2096,\"contents\":{\"pos1\":638,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1963,\"sequenceNumber\":1964,\"timestamp\":1564524498048,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2099,\"contents\":{\"pos1\":639,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1965,\"sequenceNumber\":1966,\"timestamp\":1564524498251,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2101,\"contents\":{\"pos1\":640,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1967,\"sequenceNumber\":1968,\"timestamp\":1564524498424,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2103,\"contents\":{\"pos1\":641,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1969,\"sequenceNumber\":1970,\"timestamp\":1564524498580,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2106,\"contents\":{\"pos1\":642,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1971,\"sequenceNumber\":1972,\"timestamp\":1564524499221,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2108,\"contents\":{\"pos1\":643,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1973,\"sequenceNumber\":1974,\"timestamp\":1564524499377,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2110,\"contents\":{\"pos1\":644,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1975,\"sequenceNumber\":1976,\"timestamp\":1564524499533,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2112,\"contents\":{\"pos1\":645,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1977,\"sequenceNumber\":1978,\"timestamp\":1564524499705,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2114,\"contents\":{\"pos1\":646,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1979,\"sequenceNumber\":1980,\"timestamp\":1564524499799,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2116,\"contents\":{\"pos1\":647,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1981,\"sequenceNumber\":1982,\"timestamp\":1564524499939,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2118,\"contents\":{\"pos1\":648,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1983,\"sequenceNumber\":1984,\"timestamp\":1564524500127,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2120,\"contents\":{\"pos1\":649,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1985,\"sequenceNumber\":1986,\"timestamp\":1564524500252,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2122,\"contents\":{\"pos1\":650,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1987,\"sequenceNumber\":1988,\"timestamp\":1564524500471,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2125,\"contents\":{\"pos1\":651,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1989,\"sequenceNumber\":1990,\"timestamp\":1564524501033,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2127,\"contents\":{\"pos1\":652,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1991,\"sequenceNumber\":1992,\"timestamp\":1564524501267,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2131,\"contents\":{\"pos1\":652,\"pos2\":653,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1994,\"sequenceNumber\":1995,\"timestamp\":1564524501877,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2133,\"contents\":{\"pos1\":651,\"pos2\":652,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1996,\"sequenceNumber\":1997,\"timestamp\":1564524502017,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2136,\"contents\":{\"pos1\":650,\"pos2\":651,\"type\":1},\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1998,\"sequenceNumber\":1999,\"timestamp\":1564524502517,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4c136b66-63df-44d5-9163-08d0979a7471",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a925583d-5608-4590-9000-6b94783a9552\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/011575d0-afb9-444c-8328-95ad09b750c6\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/81501816-9a9b-4df2-880a-f5d94562b3e8\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/11b84fb1-ae15-487f-bd4c-ba53d6a617c1\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1daf2d51-820a-4857-b3f1-6356639bf0bd\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec31b865-0ed5-41de-88f3-cbe1ccc76431\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6fbb365-b827-4386-9428-3785195090ad\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a925583d-5608-4590-9000-6b94783a9552",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "011575d0-afb9-444c-8328-95ad09b750c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "81501816-9a9b-4df2-880a-f5d94562b3e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "11b84fb1-ae15-487f-bd4c-ba53d6a617c1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1daf2d51-820a-4857-b3f1-6356639bf0bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec31b865-0ed5-41de-88f3-cbe1ccc76431",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6fbb365-b827-4386-9428-3785195090ad",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "9acfdfc3-b8f2-4751-b19c-bba930d124ff",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "d622a7ed-880a-482b-a1e8-1be09dedbae8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":2137,\"minimumSequenceNumber\":1780,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1564524502674,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,845 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2919,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c27f7136-f696-4d16-a987-b016864acfc9\",{\"client\":{\"user\":{\"id\":\"rlqq1vbpg@example.com}\",\"name\":\"psy14blb7khms1s\",\"email\":\"7mdyla6qj@example.com}\"}},\"sequenceNumber\":1}],[\"093dbf1f-c7c7-43cc-bc8f-4cfc83b23cb0\",{\"client\":{\"user\":{\"id\":\"0dgvwuh2m@example.com}\",\"name\":\"cbfd3xq13skpv0v\",\"email\":\"od7mqkpf1@example.com}\"}},\"sequenceNumber\":2905}],[\"42f5db03-9fc0-498f-9309-8e96fc11df00\",{\"client\":{\"user\":{\"id\":\"5o7r28dye@example.com}\",\"name\":\"yz5dlhgy2e2r1ck\",\"email\":\"jv7hglkb9@example.com}\"}},\"sequenceNumber\":2913}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/b929106b-7f80-416b-8e5d-31f08f02c92d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b929106b-7f80-416b-8e5d-31f08f02c92d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}},\"versions\":[{\"sequenceNumber\":6,\"value\":{\"type\":\"Plain\",\"value\":\"c27f7136-f696-4d16-a987-b016864acfc9\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2c617c0f-273d-49f4-b696-54bd3695c891\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/70bc151c-4854-418a-a546-77a287e0138d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4c136b66-63df-44d5-9163-08d0979a7471\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c27f7136-f696-4d16-a987-b016864acfc9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1101,\"refSeqNumber\":2997}},\"9708c2fb-40fd-44d1-aed1-f237c99bcdcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1406}},\"5822164b-d8ae-43da-bdd6-b19a3e60b942\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2598}},\"4f08983f-c1fe-4d48-b9b1-6c54fc4e812f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2616}},\"0027343d-f535-43b0-8508-1d75722ef457\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2616}},\"24dcef44-39cd-479f-a268-8758eb5b2c7d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2895}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2c617c0f-273d-49f4-b696-54bd3695c891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d7ed3734-e287-44e1-8383-efa71bdebfd4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "70bc151c-4854-418a-a546-77a287e0138d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d7ed3734-e287-44e1-8383-efa71bdebfd4\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":56,\"chunkLengthChars\":1073,\"totalLengthChars\":1073,\"totalSegmentCount\":56,\"chunkSequenceNumber\":2919,\"segmentTexts\":[{\"text\":\"vdka\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10860101-8e42-4af0-abbb-77ef0af29395\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"usmha\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"f6j801r2mdd8rhcpyprxihazs9bxq6x6gdklupgn9e4h6mdayvqwg2qdv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dd6c671b-f2a5-43a2-84c4-66f39a170d0c\",\"ItemType\":\"Paragraph\"}},\"4tq505ca6gp2hvz2dhu0nqr4a8j4ue2uwsory9mxk5nclyaeoieuz1z8iy8795pb14gxnwdwke58\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a5177859-5d16-4401-846c-492973b53882\",\"ItemType\":\"Paragraph\"}},\"70ag092j6cjxstrfzhe9hpcx0e4glu6r4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"de981134-5576-48c5-a290-1ad5eb536f47\",\"ItemType\":\"Paragraph\"}},\"j7y1hunvr7vc6s92ppc2mkdrvw5xeazwzqhz0kxpkf0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c9195aeb-fb15-484e-ab78-f48a3116dc82\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7aafa2b-b8d2-4e41-8589-3de7ef9e0915\",\"ItemType\":\"Paragraph\"}},\"yadkg7q7k7brzog2qmjrccycjyuho43e5p3r3yktkbpds\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1a9316e-68f3-435c-be01-63383f7b39ba\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6679e71-df50-4c8b-92f6-571cd1c67014\",\"ItemType\":\"Paragraph\"}},\"wy96h1omeam90u0h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bb5b57b4-f4c3-47bb-b739-4643020f650d\",\"ItemType\":\"Paragraph\"}},\"seupt9z6zxub95951237zhqnuzn0almf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d4727240-8a83-4b98-82ad-da6efd2c32bc\",\"ItemType\":\"Paragraph\"}},\"1ajeeks8uxn3q083vho7v6eby4xrnlcgy95wsq6528vnjnq7f4pqneufsp06ubo624av7elhz87f430\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d67e6cba-fa53-4df6-8135-35260250002b\",\"ItemType\":\"Paragraph\"}},\"t5mdt34fhehda8ayzi5uh8b64bbic7vtwq08atbf1uaqqopsan34ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"118376af-89a6-431a-9732-539f439a8927\",\"ItemType\":\"Paragraph\"}},\"jgsk\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4f2bf87a-3957-4024-a665-be82a63fca1d\",\"ItemType\":\"Paragraph\"}},\"s4aohyl2k0lvufvv3yjljhab887v2vs7jnvqj2gtp1x1cdptr12tfs7u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"959c2c58-ba46-4381-8cb2-82655da01bf3\",\"ItemType\":\"Paragraph\"}},\"mftmqsudg4y03zljaesabof9csq4kec9pg3ei\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a071a996-44eb-483f-8c18-29a3832bd20a\",\"ItemType\":\"Paragraph\"}},\"rxnjfhc7xu5yailc56zu013hfu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a0b4d656-c34f-4e8d-8afb-0efe830667be\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b6fd517d-e32f-4051-ba58-f4893223bbef\",\"ItemType\":\"Paragraph\"}},\"i08w6tvby4ax2otjpq8iolky2r0x3mofn3d0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef9dd758-8b13-4a84-9946-2e18b6a325e2\",\"ItemType\":\"Paragraph\"}},\"jwr0n3il2d7eh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"99d5e345-523c-4628-93ad-25d955b87062\",\"ItemType\":\"Paragraph\"}},\"zyoukaa7dz3nfl8hthyw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ece59010-002f-4dbc-94d6-0c338e7c1e95\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"df79278c-6b1e-4af4-87c5-6b1ad4ea9f47\",\"ItemType\":\"Paragraph\"}},\"mmphyjqf0vsup3xgcocccnlhxdyfol3bc26n7hhtaew6ji5buzbty9f2w24m5sro3m8oa6osd0b8s\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78bbe823-dc67-4c5f-a3d6-e758b1547ad7\",\"ItemType\":\"Paragraph\"}},\"8w88ww8hh1l28ha2aks1hfatuznhpp4jmxs5ihtdgd738ufrqeprunmiyjjlriz6kpgh8r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3c7eba98-1e71-4fb1-8140-8ffcd5295d15\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca3a4bda-0ab5-44c2-9062-cd51447e734d\",\"ItemType\":\"Paragraph\"}},\"c2tscwbnwb6u7lgcp16w0za4yy4j03z0lp0og5jvizfnrvzkltsjplvndnwrm3y3i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c88c789c-e0d4-45f4-856a-f09d1c763ddb\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d5f12b5-7f00-411e-ab90-84a85caae946\",\"ItemType\":\"Paragraph\"}},\"c272ym1gkrvd79kms4lbk11a39y6zcm1drp9ictzyryz0754719bc3yo2amgvupu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e5097ad6-e053-459a-bdc1-5ec28e406bf3\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ff13e8ee-e03c-427f-a649-051351ced0e7\",\"ItemType\":\"Paragraph\"}},\"n9xzi1otwapbg71xtqffv85s4rkz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8bf94f6b-160a-48cd-9d4a-a2737cc13c46\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b7758137-42da-4338-90d2-468c583d8a62\",\"ItemType\":\"Paragraph\"}},\"is8n7ku30t6vfn8t6ze2sqn4t5sbdmb4po7qscjykjatv9b8c5q1hsvvox4exqneoqzj6g2p50ladyqcwdj8ffh1c1cg4m33e8jdt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"715e4e1c-067e-4efb-a88a-a848d51a67ea\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1b6b3653-ded7-4ee1-9993-82fe71bf3cdd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2919,\"totalLength\":1073,\"totalSegmentCount\":56}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3097,\"contents\":{\"pos1\":1072,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8b04930b-26d8-426e-985b-83fc7ade666f\",\"ItemType\":\"Paragraph\"}},\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2920,\"sequenceNumber\":2921,\"timestamp\":1564525585349,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3099,\"contents\":{\"pos1\":1073,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"783f5822-7dc8-40c4-b1da-f3b654d0c61d\",\"ItemType\":\"Paragraph\"}},\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2922,\"sequenceNumber\":2923,\"timestamp\":1564525585474,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3102,\"contents\":{\"pos1\":1073,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2924,\"sequenceNumber\":2925,\"timestamp\":1564525586224,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3104,\"contents\":{\"pos1\":1074,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2926,\"sequenceNumber\":2927,\"timestamp\":1564525586364,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3106,\"contents\":{\"pos1\":1075,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2928,\"sequenceNumber\":2929,\"timestamp\":1564525586599,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3108,\"contents\":{\"pos1\":1076,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2930,\"sequenceNumber\":2931,\"timestamp\":1564525586802,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3112,\"contents\":{\"pos1\":1076,\"pos2\":1077,\"type\":1},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2933,\"sequenceNumber\":2934,\"timestamp\":1564525587224,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3114,\"contents\":{\"pos1\":1075,\"pos2\":1076,\"type\":1},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2935,\"sequenceNumber\":2936,\"timestamp\":1564525587349,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3116,\"contents\":{\"pos1\":1074,\"pos2\":1075,\"type\":1},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2937,\"sequenceNumber\":2938,\"timestamp\":1564525587490,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3118,\"contents\":{\"pos1\":1073,\"pos2\":1074,\"type\":1},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2939,\"sequenceNumber\":2940,\"timestamp\":1564525587787,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3120,\"contents\":{\"pos1\":1073,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2940,\"sequenceNumber\":2941,\"timestamp\":1564525588365,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3122,\"contents\":{\"pos1\":1074,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2942,\"sequenceNumber\":2943,\"timestamp\":1564525588475,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3124,\"contents\":{\"pos1\":1075,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2944,\"sequenceNumber\":2945,\"timestamp\":1564525588600,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3127,\"contents\":{\"pos1\":1076,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2946,\"sequenceNumber\":2947,\"timestamp\":1564525588944,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3129,\"contents\":{\"pos1\":1077,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2948,\"sequenceNumber\":2949,\"timestamp\":1564525589194,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3131,\"contents\":{\"pos1\":1078,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2950,\"sequenceNumber\":2951,\"timestamp\":1564525589366,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3133,\"contents\":{\"pos1\":1079,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2952,\"sequenceNumber\":2953,\"timestamp\":1564525589506,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3135,\"contents\":{\"pos1\":1080,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2954,\"sequenceNumber\":2955,\"timestamp\":1564525589619,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3137,\"contents\":{\"pos1\":1081,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2956,\"sequenceNumber\":2957,\"timestamp\":1564525589916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3139,\"contents\":{\"pos1\":1082,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2958,\"sequenceNumber\":2959,\"timestamp\":1564525589963,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3141,\"contents\":{\"pos1\":1083,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2960,\"sequenceNumber\":2961,\"timestamp\":1564525590025,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3144,\"contents\":{\"pos1\":1084,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2962,\"sequenceNumber\":2963,\"timestamp\":1564525590432,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3146,\"contents\":{\"pos1\":1085,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2964,\"sequenceNumber\":2965,\"timestamp\":1564525590666,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3148,\"contents\":{\"pos1\":1086,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2966,\"sequenceNumber\":2967,\"timestamp\":1564525590916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3151,\"contents\":{\"pos1\":1087,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2968,\"sequenceNumber\":2969,\"timestamp\":1564525591682,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3153,\"contents\":{\"pos1\":1088,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2970,\"sequenceNumber\":2971,\"timestamp\":1564525591916,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3155,\"contents\":{\"pos1\":1089,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2972,\"sequenceNumber\":2973,\"timestamp\":1564525591979,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3157,\"contents\":{\"pos1\":1090,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2974,\"sequenceNumber\":2975,\"timestamp\":1564525592119,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3160,\"contents\":{\"pos1\":1091,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2976,\"sequenceNumber\":2977,\"timestamp\":1564525592557,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3164,\"contents\":{\"pos1\":1091,\"pos2\":1092,\"type\":1},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2979,\"sequenceNumber\":2980,\"timestamp\":1564525593604,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3166,\"contents\":{\"pos1\":1091,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2980,\"sequenceNumber\":2981,\"timestamp\":1564525594417,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3168,\"contents\":{\"pos1\":1092,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2982,\"sequenceNumber\":2983,\"timestamp\":1564525594636,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3171,\"contents\":{\"pos1\":1093,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2984,\"sequenceNumber\":2985,\"timestamp\":1564525595073,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3173,\"contents\":{\"pos1\":1094,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2986,\"sequenceNumber\":2987,\"timestamp\":1564525595167,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3175,\"contents\":{\"pos1\":1095,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2988,\"sequenceNumber\":2989,\"timestamp\":1564525595167,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3177,\"contents\":{\"pos1\":1096,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2990,\"sequenceNumber\":2991,\"timestamp\":1564525595308,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3179,\"contents\":{\"pos1\":1097,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2992,\"sequenceNumber\":2993,\"timestamp\":1564525595370,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3182,\"contents\":{\"pos1\":1098,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2994,\"sequenceNumber\":2995,\"timestamp\":1564525595870,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3185,\"contents\":{\"pos1\":1099,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2996,\"sequenceNumber\":2997,\"timestamp\":1564525596200,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3187,\"contents\":{\"pos1\":1100,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2998,\"sequenceNumber\":2999,\"timestamp\":1564525596482,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4c136b66-63df-44d5-9163-08d0979a7471",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a925583d-5608-4590-9000-6b94783a9552\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/011575d0-afb9-444c-8328-95ad09b750c6\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/81501816-9a9b-4df2-880a-f5d94562b3e8\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/11b84fb1-ae15-487f-bd4c-ba53d6a617c1\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1daf2d51-820a-4857-b3f1-6356639bf0bd\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec31b865-0ed5-41de-88f3-cbe1ccc76431\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6fbb365-b827-4386-9428-3785195090ad\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a925583d-5608-4590-9000-6b94783a9552",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "011575d0-afb9-444c-8328-95ad09b750c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "81501816-9a9b-4df2-880a-f5d94562b3e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "11b84fb1-ae15-487f-bd4c-ba53d6a617c1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1daf2d51-820a-4857-b3f1-6356639bf0bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec31b865-0ed5-41de-88f3-cbe1ccc76431",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6fbb365-b827-4386-9428-3785195090ad",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "9acfdfc3-b8f2-4751-b19c-bba930d124ff",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "d622a7ed-880a-482b-a1e8-1be09dedbae8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b2b27fcb-c3a5-4873-8091-86cf15f4e706",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c27f7136-f696-4d16-a987-b016864acfc9\",\"clientSequenceNumber\":3188,\"minimumSequenceNumber\":2919,\"referenceSequenceNumber\":2998,\"sequenceNumber\":3000,\"timestamp\":1564525596482,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_3425_0.json
+++ b/snapshotTestContent/Undo/src_snapshots/0.59.3000/snapshot_3425_0.json
@@ -1,0 +1,836 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3424,\"sequenceNumber\":3425,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"9ef704bb-cdbe-4759-81f9-366ffda04b2d\",{\"client\":{\"user\":{\"id\":\"14ibwrut4@example.com}\",\"name\":\"o6ecpu1k5qmj28c\",\"email\":\"fsk870blp@example.com}\"}},\"sequenceNumber\":3313}],[\"a5ad1986-5423-45f6-9ec4-2b1ab895a5c5\",{\"client\":{\"user\":{\"id\":\"7bomljv8h@example.com}\",\"name\":\"jkktlpsg1phrjp0\",\"email\":\"98k23lvf5@example.com}\"}},\"sequenceNumber\":3363}],[\"b4ff1ce1-c2bd-44d7-89ae-cc0fd845a781\",{\"client\":{\"user\":{\"id\":\"lbp6lceyl@example.com}\",\"name\":\"jtme4icq9fpa6sm\",\"email\":\"2a9u7h6qn@example.com}\"}},\"sequenceNumber\":3366}],[\"f22e3316-6078-48a2-b7da-0b85e1a7a59b\",{\"client\":{\"user\":{\"id\":\"4k1v4xmth@example.com}\",\"name\":\"gqifhr33fui6c38\",\"email\":\"hgk6cs4d2@example.com}\"}},\"sequenceNumber\":3396}],[\"6f5658ed-c413-42d6-a8bd-8fd838bf4d40\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"g5fbufe06@example.com}\",\"name\":\"cun9fh2afmulc0k\",\"email\":\"pv13vyjnh@example.com}\"}},\"sequenceNumber\":3425}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-fluid-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/b929106b-7f80-416b-8e5d-31f08f02c92d\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b929106b-7f80-416b-8e5d-31f08f02c92d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":3402,\"value\":{\"type\":\"Plain\",\"value\":\"f22e3316-6078-48a2-b7da-0b85e1a7a59b\"}},\"versions\":[{\"sequenceNumber\":3402,\"value\":{\"type\":\"Plain\",\"value\":\"f22e3316-6078-48a2-b7da-0b85e1a7a59b\"}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2c617c0f-273d-49f4-b696-54bd3695c891\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/70bc151c-4854-418a-a546-77a287e0138d\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4c136b66-63df-44d5-9163-08d0979a7471\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3eba4d0d-2b3b-4ba8-87ee-bd1213e5edd6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c27f7136-f696-4d16-a987-b016864acfc9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1216,\"refSeqNumber\":3249}},\"9708c2fb-40fd-44d1-aed1-f237c99bcdcb\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":1406}},\"5822164b-d8ae-43da-bdd6-b19a3e60b942\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2598}},\"4f08983f-c1fe-4d48-b9b1-6c54fc4e812f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2616}},\"0027343d-f535-43b0-8508-1d75722ef457\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2616}},\"24dcef44-39cd-479f-a268-8758eb5b2c7d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":2895}},\"77351d9c-8048-4a83-9cf5-a8da9daaab88\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3251}},\"cc9656f8-511a-4025-bab7-df3fe1eea3c4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3281}},\"121ec271-17af-43ce-ad10-ce4b23ca92e3\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":517,\"refSeqNumber\":3290}},\"26ead75d-b715-415c-b719-0b02ddeb96b4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3301}},\"f187fe10-806f-4ca9-8e44-9fff9f93ff6a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3312}},\"9dc26562-79dc-46d1-889d-32034ba60cd9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":320,\"refSeqNumber\":3320}},\"8c849af5-fba8-4602-bb2a-32ecc6d77db6\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3333}},\"c971947e-a319-4ebc-afa0-d50d2fad30c5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3342}},\"657737e7-a9bf-4eb9-9d6c-45a643b3e53f\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3351}},\"3ce4624a-d7bc-4b17-ba9e-a1e933c9b506\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3360}},\"24f7d247-0c6c-49d9-b9b2-be2894ec32b7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3360}},\"5ba296e6-d0a0-4929-b4c2-acb9de4a88f8\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":999,\"refSeqNumber\":3384}},\"f22e3316-6078-48a2-b7da-0b85e1a7a59b\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3393}},\"0a682141-1813-4aa9-b123-218ca3b15079\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":270,\"refSeqNumber\":3402}},\"5222e4ca-8060-4081-b363-a7eb6b612d1d\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3405}},\"7f5cde67-3ca8-4108-94be-ace2cad19bb7\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":3413}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2c617c0f-273d-49f4-b696-54bd3695c891",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d7ed3734-e287-44e1-8383-efa71bdebfd4",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "70bc151c-4854-418a-a546-77a287e0138d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d7ed3734-e287-44e1-8383-efa71bdebfd4\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":59,\"chunkLengthChars\":1218,\"totalLengthChars\":1218,\"totalSegmentCount\":59,\"chunkSequenceNumber\":3424,\"segmentTexts\":[{\"text\":\"vdka\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10860101-8e42-4af0-abbb-77ef0af29395\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"usmha\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true}},\"f6j801r2mdd8rhcpyprxihazs9bxq6x6gdklupgn9e4h6mdayvqwg2qdv\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"dd6c671b-f2a5-43a2-84c4-66f39a170d0c\",\"ItemType\":\"Paragraph\"}},\"4tq505ca6gp2hvz2dhu0nqr4a8j4ue2uwsory9mxk5nclyaeoieuz1z8iy8795pb14gxnwdwke58\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a5177859-5d16-4401-846c-492973b53882\",\"ItemType\":\"Paragraph\"}},\"70ag092j6cjxstrfzhe9hpcx0e4glu6r4\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"de981134-5576-48c5-a290-1ad5eb536f47\",\"ItemType\":\"Paragraph\"}},\"j7y1hunvr7vc6s92ppc2mkdrvw5xeazwzqhz0kxpkf0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c9195aeb-fb15-484e-ab78-f48a3116dc82\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f7aafa2b-b8d2-4e41-8589-3de7ef9e0915\",\"ItemType\":\"Paragraph\"}},\"yadkg7q7k7brzog2qmjrccycjyuho43e5p3r3yktkbpds\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1a9316e-68f3-435c-be01-63383f7b39ba\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c6679e71-df50-4c8b-92f6-571cd1c67014\",\"ItemType\":\"Paragraph\"}},\"wy96h1omeam90u0h\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bb5b57b4-f4c3-47bb-b739-4643020f650d\",\"ItemType\":\"Paragraph\"}},\"seupt9z6zxub95951237zhqnuzn0almf\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d4727240-8a83-4b98-82ad-da6efd2c32bc\",\"ItemType\":\"Paragraph\"}},\"1ajeeks8uxn3q083vho7v6eby4xrnlcgy95wsq6528vnjnq7f4pqneufsp06ubo624av7elhz87f430\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d67e6cba-fa53-4df6-8135-35260250002b\",\"ItemType\":\"Paragraph\"}},\"t5mdt34fhehda8ayzi5uh8b64bbic7vtwq08atbf1uaqqopsan34ev\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"118376af-89a6-431a-9732-539f439a8927\",\"ItemType\":\"Paragraph\"}},\"jgsk\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4f2bf87a-3957-4024-a665-be82a63fca1d\",\"ItemType\":\"Paragraph\"}},\"s4aohyl2k0lvufvv3yjljhab887v2vs7jnvqj2gtp1x1cdptr12tfs7u\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"959c2c58-ba46-4381-8cb2-82655da01bf3\",\"ItemType\":\"Paragraph\"}},\"mftmqsudg4y03zljaesabof9csq4kec9pg3ei\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a071a996-44eb-483f-8c18-29a3832bd20a\",\"ItemType\":\"Paragraph\"}},\"rxnjfhc7xu5yailc56zu013hfu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a0b4d656-c34f-4e8d-8afb-0efe830667be\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b6fd517d-e32f-4051-ba58-f4893223bbef\",\"ItemType\":\"Paragraph\"}},\"i08w6tvby4ax2otjpq8iolky2r0x3mofn3d0\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ef9dd758-8b13-4a84-9946-2e18b6a325e2\",\"ItemType\":\"Paragraph\"}},\"jwr0n3il2d7eh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"99d5e345-523c-4628-93ad-25d955b87062\",\"ItemType\":\"Paragraph\"}},\"zyoukaa7dz3nfl8hthyw\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ece59010-002f-4dbc-94d6-0c338e7c1e95\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"df79278c-6b1e-4af4-87c5-6b1ad4ea9f47\",\"ItemType\":\"Paragraph\"}},\"mmphyjqf0vsup3xgcocccnlhxdyfol3bc26n7hhtaew6ji5buzbty9f2w24m5sro3m8oa6osd0b8s\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"78bbe823-dc67-4c5f-a3d6-e758b1547ad7\",\"ItemType\":\"Paragraph\"}},\"8w88ww8hh1l28ha2aks1hfatuznhpp4jmxs5ihtdgd738ufrqeprunmiyjjlriz6kpgh8r\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3c7eba98-1e71-4fb1-8140-8ffcd5295d15\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ca3a4bda-0ab5-44c2-9062-cd51447e734d\",\"ItemType\":\"Paragraph\"}},\"c2tscwbnwb6u7lgcp16w0za4yy4j03z0lp0og5jvizfnrvzkltsjplvndnwrm3y3i\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c88c789c-e0d4-45f4-856a-f09d1c763ddb\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d5f12b5-7f00-411e-ab90-84a85caae946\",\"ItemType\":\"Paragraph\"}},\"c272ym1gkrvd79kms4lbk11a39y6zcm1drp9ictzyryz0754719bc3yo2amgvupu\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e5097ad6-e053-459a-bdc1-5ec28e406bf3\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ff13e8ee-e03c-427f-a649-051351ced0e7\",\"ItemType\":\"Paragraph\"}},\"n9xzi1otwapbg71xtqffv85s4rkz\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8bf94f6b-160a-48cd-9d4a-a2737cc13c46\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b7758137-42da-4338-90d2-468c583d8a62\",\"ItemType\":\"Paragraph\"}},\"is8n7ku30t6vfn8t6ze2sqn4t5sbdmb4po7qscjykjatv9b8c5q1hsvvox4exqneoqzj6g2p50ladyqcwdj8ffh1c1cg4m33e8jdt\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"715e4e1c-067e-4efb-a88a-a848d51a67ea\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8b04930b-26d8-426e-985b-83fc7ade666f\",\"ItemType\":\"Paragraph\"}},\"6epavoxx0wf4n9a4ppqe8uig9w7voo1qxyjkbffa67dz17ypyuglugffawpovhpvyus85dtcj2hzcia3x61okbvyezmi7hf2a5n5n4dv95qw8lewqj7hbv8gnrwq68g40uoczidmpsyjave\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"783f5822-7dc8-40c4-b1da-f3b654d0c61d\",\"ItemType\":\"Paragraph\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1b6b3653-ded7-4ee1-9993-82fe71bf3cdd\",\"ItemType\":\"Paragraph\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3424,\"totalLength\":1218,\"totalSegmentCount\":59}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4c136b66-63df-44d5-9163-08d0979a7471",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a925583d-5608-4590-9000-6b94783a9552\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/011575d0-afb9-444c-8328-95ad09b750c6\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/81501816-9a9b-4df2-880a-f5d94562b3e8\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/11b84fb1-ae15-487f-bd4c-ba53d6a617c1\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1daf2d51-820a-4857-b3f1-6356639bf0bd\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ec31b865-0ed5-41de-88f3-cbe1ccc76431\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c6fbb365-b827-4386-9428-3785195090ad\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a925583d-5608-4590-9000-6b94783a9552",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "011575d0-afb9-444c-8328-95ad09b750c6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"},\"propertiestabIndex\":{\"type\":\"Plain\",\"value\":-1},\"propertiesoutline\":{\"type\":\"Plain\",\"value\":\"none\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "81501816-9a9b-4df2-880a-f5d94562b3e8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "11b84fb1-ae15-487f-bd4c-ba53d6a617c1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1daf2d51-820a-4857-b3f1-6356639bf0bd",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ec31b865-0ed5-41de-88f3-cbe1ccc76431",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c6fbb365-b827-4386-9428-3785195090ad",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "9acfdfc3-b8f2-4751-b19c-bba930d124ff",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "d622a7ed-880a-482b-a1e8-1be09dedbae8",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "b2b27fcb-c3a5-4873-8091-86cf15f4e706",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":3424,\"referenceSequenceNumber\":-1,\"sequenceNumber\":3425,\"timestamp\":1564688595957,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_1000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_1000_0.json
@@ -1,0 +1,764 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":885,\"sequenceNumber\":1000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c08d27ca-3b63-4b75-b323-02ae349d838c\",{\"client\":{\"user\":{\"id\":\"jhxl0xnae@example.com}\",\"name\":\"mppqkyqs108g0km\",\"email\":\"papty7coq@example.com}\"}},\"sequenceNumber\":1}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":7235,\"refSeqNumber\":648}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":1,\"chunkLengthChars\":1,\"totalLengthChars\":1,\"totalSegmentCount\":1,\"chunkSequenceNumber\":885,\"segmentTexts\":[{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":885,\"totalLength\":1,\"totalSegmentCount\":1}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":885,\"contents\":{\"pos1\":0,\"seg\":{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":885,\"sequenceNumber\":886,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":886,\"contents\":{\"pos1\":50,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":886,\"sequenceNumber\":887,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":887,\"contents\":{\"pos1\":51,\"seg\":{\"text\":\"nsgmqrewogh5mtvhhsffou7594dtzboy2opzz1nv8htbvbfdh8faa425bocno\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":887,\"sequenceNumber\":888,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":888,\"contents\":{\"pos1\":112,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":888,\"sequenceNumber\":889,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":889,\"contents\":{\"pos1\":113,\"seg\":{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":889,\"sequenceNumber\":890,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":890,\"contents\":{\"pos1\":133,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":890,\"sequenceNumber\":891,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":891,\"contents\":{\"pos1\":134,\"seg\":{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":891,\"sequenceNumber\":892,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":892,\"contents\":{\"pos1\":183,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":892,\"sequenceNumber\":893,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":893,\"contents\":{\"pos1\":184,\"seg\":{\"text\":\"ptj0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":893,\"sequenceNumber\":894,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":894,\"contents\":{\"pos1\":240,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":894,\"sequenceNumber\":895,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":895,\"contents\":{\"pos1\":241,\"seg\":{\"text\":\"c17yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":895,\"sequenceNumber\":896,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":896,\"contents\":{\"pos1\":253,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":896,\"sequenceNumber\":897,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":897,\"contents\":{\"pos1\":254,\"seg\":{\"text\":\"zcgp\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":897,\"sequenceNumber\":898,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":898,\"contents\":{\"pos1\":258,\"seg\":{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":898,\"sequenceNumber\":899,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":899,\"contents\":{\"pos1\":276,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":899,\"sequenceNumber\":900,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":900,\"contents\":{\"pos1\":277,\"seg\":{\"text\":\"8pus0oy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":900,\"sequenceNumber\":901,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":901,\"contents\":{\"pos1\":284,\"seg\":{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":901,\"sequenceNumber\":902,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":902,\"contents\":{\"pos1\":350,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":902,\"sequenceNumber\":903,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":903,\"contents\":{\"pos1\":351,\"seg\":{\"text\":\"7hrz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":903,\"sequenceNumber\":904,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":904,\"contents\":{\"pos1\":355,\"seg\":{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":904,\"sequenceNumber\":905,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":905,\"contents\":{\"pos1\":390,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":905,\"sequenceNumber\":906,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":906,\"contents\":{\"pos1\":391,\"seg\":{\"text\":\"igl0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":906,\"sequenceNumber\":907,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":907,\"contents\":{\"pos1\":395,\"seg\":{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":907,\"sequenceNumber\":908,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":908,\"contents\":{\"pos1\":452,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":908,\"sequenceNumber\":909,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":909,\"contents\":{\"pos1\":453,\"seg\":{\"text\":\"2ak3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":909,\"sequenceNumber\":910,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":910,\"contents\":{\"pos1\":457,\"seg\":{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":910,\"sequenceNumber\":911,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":911,\"contents\":{\"pos1\":476,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":911,\"sequenceNumber\":912,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":912,\"contents\":{\"pos1\":477,\"seg\":{\"text\":\"rtd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":912,\"sequenceNumber\":913,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":913,\"contents\":{\"pos1\":480,\"seg\":{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":913,\"sequenceNumber\":914,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":914,\"contents\":{\"pos1\":501,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":914,\"sequenceNumber\":915,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":915,\"contents\":{\"pos1\":502,\"seg\":{\"text\":\"uzf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":915,\"sequenceNumber\":916,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":916,\"contents\":{\"pos1\":505,\"seg\":{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":916,\"sequenceNumber\":917,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":917,\"contents\":{\"pos1\":529,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":917,\"sequenceNumber\":918,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":918,\"contents\":{\"pos1\":530,\"seg\":{\"text\":\"4u87\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":918,\"sequenceNumber\":919,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":919,\"contents\":{\"pos1\":534,\"seg\":{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":919,\"sequenceNumber\":920,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":920,\"contents\":{\"pos1\":545,\"seg\":{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":920,\"sequenceNumber\":921,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":921,\"contents\":{\"pos1\":557,\"seg\":{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":921,\"sequenceNumber\":922,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":922,\"contents\":{\"pos1\":619,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":922,\"sequenceNumber\":923,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":923,\"contents\":{\"pos1\":620,\"seg\":{\"text\":\"f3ppfzm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":923,\"sequenceNumber\":924,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":924,\"contents\":{\"pos1\":627,\"seg\":{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":924,\"sequenceNumber\":925,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":925,\"contents\":{\"pos1\":662,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":925,\"sequenceNumber\":926,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":926,\"contents\":{\"pos1\":663,\"seg\":{\"text\":\"ye97hij\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":926,\"sequenceNumber\":927,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":927,\"contents\":{\"pos1\":670,\"seg\":{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":927,\"sequenceNumber\":928,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":928,\"contents\":{\"pos1\":750,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":928,\"sequenceNumber\":929,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":929,\"contents\":{\"pos1\":751,\"seg\":{\"text\":\"u62q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":929,\"sequenceNumber\":930,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":930,\"contents\":{\"pos1\":755,\"seg\":{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":930,\"sequenceNumber\":931,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":931,\"contents\":{\"pos1\":807,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":931,\"sequenceNumber\":932,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":932,\"contents\":{\"pos1\":808,\"seg\":{\"text\":\"j7dx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":932,\"sequenceNumber\":933,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":933,\"contents\":{\"pos1\":812,\"seg\":{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":933,\"sequenceNumber\":934,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":934,\"contents\":{\"pos1\":855,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":934,\"sequenceNumber\":935,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":935,\"contents\":{\"pos1\":856,\"seg\":{\"text\":\"vprm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":935,\"sequenceNumber\":936,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":936,\"contents\":{\"pos1\":860,\"seg\":{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":936,\"sequenceNumber\":937,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":937,\"contents\":{\"pos1\":901,\"seg\":{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":937,\"sequenceNumber\":938,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":938,\"contents\":{\"pos1\":951,\"seg\":{\"text\":\"j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":938,\"sequenceNumber\":939,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":939,\"contents\":{\"pos1\":952,\"seg\":{\"text\":\"g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":939,\"sequenceNumber\":940,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":940,\"contents\":{\"pos1\":953,\"seg\":{\"text\":\"z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":940,\"sequenceNumber\":941,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":941,\"contents\":{\"pos1\":954,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":941,\"sequenceNumber\":942,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":942,\"contents\":{\"pos1\":955,\"seg\":{\"text\":\"oi3q\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":942,\"sequenceNumber\":943,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":943,\"contents\":{\"pos1\":959,\"seg\":{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":943,\"sequenceNumber\":944,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":944,\"contents\":{\"pos1\":1060,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":944,\"sequenceNumber\":945,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":945,\"contents\":{\"pos1\":1061,\"seg\":{\"text\":\"g9xq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":945,\"sequenceNumber\":946,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":946,\"contents\":{\"pos1\":1065,\"seg\":{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":946,\"sequenceNumber\":947,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":947,\"contents\":{\"pos1\":1167,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":947,\"sequenceNumber\":948,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":948,\"contents\":{\"pos1\":1168,\"seg\":{\"text\":\"1zf7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":948,\"sequenceNumber\":949,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":949,\"contents\":{\"pos1\":1172,\"seg\":{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":949,\"sequenceNumber\":950,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":950,\"contents\":{\"pos1\":1275,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":950,\"sequenceNumber\":951,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":951,\"contents\":{\"pos1\":1276,\"seg\":{\"text\":\"79dy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":951,\"sequenceNumber\":952,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":952,\"contents\":{\"pos1\":1280,\"seg\":{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":952,\"sequenceNumber\":953,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":953,\"contents\":{\"pos1\":1359,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":953,\"sequenceNumber\":954,\"timestamp\":1562168939750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":954,\"contents\":{\"pos1\":1360,\"seg\":{\"text\":\"tpii\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":954,\"sequenceNumber\":955,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":955,\"contents\":{\"pos1\":1364,\"seg\":{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":955,\"sequenceNumber\":956,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":956,\"contents\":{\"pos1\":1388,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":956,\"sequenceNumber\":957,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":957,\"contents\":{\"pos1\":1389,\"seg\":{\"text\":\"o8ly\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":957,\"sequenceNumber\":958,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":958,\"contents\":{\"pos1\":1393,\"seg\":{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":958,\"sequenceNumber\":959,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":959,\"contents\":{\"pos1\":1414,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":959,\"sequenceNumber\":960,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":960,\"contents\":{\"pos1\":1415,\"seg\":{\"text\":\"fwb5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":960,\"sequenceNumber\":961,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":961,\"contents\":{\"pos1\":1419,\"seg\":{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":961,\"sequenceNumber\":962,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":962,\"contents\":{\"pos1\":1487,\"seg\":{\"text\":\"9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":962,\"sequenceNumber\":963,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":963,\"contents\":{\"pos1\":1488,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":963,\"sequenceNumber\":964,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":964,\"contents\":{\"pos1\":1489,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":964,\"sequenceNumber\":965,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":965,\"contents\":{\"pos1\":1490,\"seg\":{\"text\":\"aual\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":965,\"sequenceNumber\":966,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":966,\"contents\":{\"pos1\":1494,\"seg\":{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":966,\"sequenceNumber\":967,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":967,\"contents\":{\"pos1\":1616,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":967,\"sequenceNumber\":968,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":968,\"contents\":{\"pos1\":1617,\"seg\":{\"text\":\"msov\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":968,\"sequenceNumber\":969,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":969,\"contents\":{\"pos1\":1621,\"seg\":{\"text\":\"5w2twapirn327ps14ja46uqf3t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":969,\"sequenceNumber\":970,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":970,\"contents\":{\"pos1\":1647,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":970,\"sequenceNumber\":971,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":971,\"contents\":{\"pos1\":1648,\"seg\":{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":971,\"sequenceNumber\":972,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":972,\"contents\":{\"pos1\":1649,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":972,\"sequenceNumber\":973,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":973,\"contents\":{\"pos1\":1650,\"seg\":{\"text\":\"ojvgcji\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":973,\"sequenceNumber\":974,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":974,\"contents\":{\"pos1\":1657,\"seg\":{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":974,\"sequenceNumber\":975,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":975,\"contents\":{\"pos1\":1739,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":975,\"sequenceNumber\":976,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":976,\"contents\":{\"pos1\":1740,\"seg\":{\"text\":\"898n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":976,\"sequenceNumber\":977,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":977,\"contents\":{\"pos1\":1744,\"seg\":{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":977,\"sequenceNumber\":978,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":978,\"contents\":{\"pos1\":1881,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":978,\"sequenceNumber\":979,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":979,\"contents\":{\"pos1\":1882,\"seg\":{\"text\":\"1jw0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":979,\"sequenceNumber\":980,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":980,\"contents\":{\"pos1\":1886,\"seg\":{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":980,\"sequenceNumber\":981,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":981,\"contents\":{\"pos1\":1954,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":981,\"sequenceNumber\":982,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":982,\"contents\":{\"pos1\":1955,\"seg\":{\"text\":\"cytwp7l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":982,\"sequenceNumber\":983,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":983,\"contents\":{\"pos1\":1962,\"seg\":{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":983,\"sequenceNumber\":984,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":984,\"contents\":{\"pos1\":2042,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":984,\"sequenceNumber\":985,\"timestamp\":1562168939766,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":985,\"contents\":{\"pos1\":2043,\"seg\":{\"text\":\"p19hwul\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":985,\"sequenceNumber\":986,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":986,\"contents\":{\"pos1\":2050,\"seg\":{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":986,\"sequenceNumber\":987,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":987,\"contents\":{\"pos1\":2081,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":987,\"sequenceNumber\":988,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":988,\"contents\":{\"pos1\":2082,\"seg\":{\"text\":\"lfd5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":988,\"sequenceNumber\":989,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":989,\"contents\":{\"pos1\":2086,\"seg\":{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":989,\"sequenceNumber\":990,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":990,\"contents\":{\"pos1\":2162,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":990,\"sequenceNumber\":991,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":991,\"contents\":{\"pos1\":2163,\"seg\":{\"text\":\"4ob\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":991,\"sequenceNumber\":992,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":992,\"contents\":{\"pos1\":2166,\"seg\":{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":992,\"sequenceNumber\":993,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":993,\"contents\":{\"pos1\":2172,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":993,\"sequenceNumber\":994,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":994,\"contents\":{\"pos1\":2173,\"seg\":{\"text\":\"cukdzlo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":994,\"sequenceNumber\":995,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":995,\"contents\":{\"pos1\":2180,\"seg\":{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":995,\"sequenceNumber\":996,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":996,\"contents\":{\"pos1\":2236,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":996,\"sequenceNumber\":997,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":997,\"contents\":{\"pos1\":2237,\"seg\":{\"text\":\"7ut6gz8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":997,\"sequenceNumber\":998,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":998,\"contents\":{\"pos1\":2244,\"seg\":{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":998,\"sequenceNumber\":999,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":999,\"contents\":{\"pos1\":2285,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"type\":0},\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":999,\"sequenceNumber\":1000,\"timestamp\":1562168939813,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c08d27ca-3b63-4b75-b323-02ae349d838c\",\"clientSequenceNumber\":999,\"minimumSequenceNumber\":885,\"referenceSequenceNumber\":885,\"sequenceNumber\":1000,\"timestamp\":1562168939813,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_2000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_2000_0.json
@@ -1,0 +1,980 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":1911,\"sequenceNumber\":2000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c08d27ca-3b63-4b75-b323-02ae349d838c\",{\"client\":{\"user\":{\"id\":\"jhxl0xnae@example.com}\",\"name\":\"mppqkyqs108g0km\",\"email\":\"papty7coq@example.com}\"}},\"sequenceNumber\":1}],[\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",{\"client\":{\"user\":{\"id\":\"k92nx34v9@example.com}\",\"name\":\"tijtc008lpog5bt\",\"email\":\"iqntrm3oe@example.com}\"}},\"sequenceNumber\":1730}],[\"7b97d584-1466-4c53-9297-2d0cae2d5e1c\",{\"client\":{\"user\":{\"id\":\"kjgcn2te3@example.com}\",\"name\":\"gx4qqbjltl6i9a7\",\"email\":\"9mevoru4g@example.com}\"}},\"sequenceNumber\":1740}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":1531,\"refSeqNumber\":1988}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":214,\"chunkLengthChars\":5443,\"totalLengthChars\":5443,\"totalSegmentCount\":214,\"chunkSequenceNumber\":1911,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i9ktzboy2opzz1nv8htbvbfdh8faa425bocno\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"jgz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"oi3q54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"g9xq4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"1zf7c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"79dyvda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"tpiiyexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"o8lyd6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"fwb5m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl9e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"aualvz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"msov\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5w2twapirn327ps14ja46uqf3to\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}}},{\"text\":\"ojvgcjiiqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"898nyf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"1jw0n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"cytwp7l6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"p19hwulgy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"lfd59gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"4obaegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"cukdzlomr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"7ut6gz8o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"xe2dqidql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"e8jg1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"7xprovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"v4pdyv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"m4h30m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"m258g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"8t3zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"spq7m9ev3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"kjd5dh3yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"uneay2hofv23r730vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"htthtwbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ivwhadvrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yg73kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jnh426gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"fu5w7gnndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"p082wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"3mlucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"oao5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hghyf4i467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gpsh4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"glltphurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a061f717-2b6a-42d1-831b-cc6e216debfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"47124ab4-7701-4191-b544-75f8ad6c77fc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"bbd1229b-2a3e-42f2-a646-2b02c85cf324\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b45554a9-7a31-464d-bf1b-f6bef047af47\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"92affbeb-4b5e-4a4a-a1fd-2e85b7d07b49\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"4ghq3exqs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1eec8f5f-59bd-40e8-877b-18fce8cc13b9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jnnlk8wpfupkwckv8ys\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e397bba6-509c-4303-8af5-91a9da7ba3d4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"gyv78y5qoqp1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"0ca\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"ls0ms04nlujsvtwhnpeghf0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"94822582-bb63-4cdc-848b-cb5f4285c579\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"1jdgkuq04\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"nbj1gar2tlmjgkjfqoatilmbei\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"74877daa-2003-4ada-bac2-c5111cb9536d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"0gxo444vat\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"0wwf1mxdmern9c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"buqm84j9m1tg3bq7d9m3ebo78do17uvwi4ysgolpifg1rx0v1hgwk7ctr2rr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6a9351d-82db-4bfe-ada2-f418cd92dd23\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"b81f136e-28ec-4639-ac5a-3b1aaee33e31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"rwgjxxtai5jq5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"17d28ccc-63ea-40ce-b508-f68f52081d2f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"n2c8hxcihenz\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"gy50ut\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aa723b4b-132f-4804-81e1-9cfdde29144e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"qwz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"icu9qfrhw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"gm8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"2ugbrfmc4rljvho4u7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"2h\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ee714f14-f788-4457-99da-51885ac93609\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ku44wws9rzr916yfqexiuqawgdi5t6smq6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"7v6511nnwx6b8cnj7tb2aslto\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7ea38bf0-d963-4f1b-b880-8825f66625f9\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"druicpcflm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"n27d96yjveep1du8dk1n9l9quem\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"ixjgbv5jlq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"48e83f4d-051a-4bfa-ac75-956e35ba8135\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"prbma53je7le\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"v1op01nv3us2u3iqggx2dflju0v7sfil8g2w9z0w2o0cct9t6ne8bf8km3w\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c82c9a82-47b9-4b0f-845d-1326a503f2f8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"kv687pbnwjx26\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"hv6ekl1sgeviphz12m14bja3g2t7nirucyks3lys7z\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7d837078-a0d6-4767-b36c-380e2de72cf7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hr71o571a1nioxtfgbx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"70e3ef44-6843-4589-bd0b-69c6e0ead696\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ge3hb1foudgr4ew73jyr3fj6m625l27edm6bz0ajpwx5mn1\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"03ef2f16-426f-4230-a2d5-78f89a955c33\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ci79bzsb8m3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6dcd2c2c-c8a2-4e4f-b908-20ce0f739ac5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"fy5b09urawoskck\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":1911,\"totalLength\":5443,\"totalSegmentCount\":214}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":267,\"contents\":{\"pos1\":897,\"pos2\":901,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1912,\"sequenceNumber\":1913,\"timestamp\":1562170527822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":268,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"before\":true},\"relativePos2\":{\"id\":\"26fed600-3a68-4d39-a1c7-87663e529234\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1913,\"sequenceNumber\":1914,\"timestamp\":1562170528056,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":269,\"contents\":{\"pos1\":998,\"pos2\":999,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1914,\"sequenceNumber\":1915,\"timestamp\":1562170528056,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":999,\"pos2\":1003,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1923,\"sequenceNumber\":1924,\"timestamp\":1562170530478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":282,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"before\":true},\"relativePos2\":{\"id\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1924,\"sequenceNumber\":1925,\"timestamp\":1562170531139,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":283,\"contents\":{\"pos1\":1101,\"pos2\":1102,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1925,\"sequenceNumber\":1926,\"timestamp\":1562170531139,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":298,\"contents\":{\"pos1\":1102,\"pos2\":1106,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1935,\"sequenceNumber\":1936,\"timestamp\":1562170533436,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":300,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"before\":true},\"relativePos2\":{\"id\":\"cc643c34-99a0-4505-905e-a286f0234762\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1936,\"sequenceNumber\":1937,\"timestamp\":1562170534045,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":301,\"contents\":{\"pos1\":1205,\"pos2\":1206,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1937,\"sequenceNumber\":1938,\"timestamp\":1562170534045,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":313,\"contents\":{\"pos1\":1206,\"pos2\":1210,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1945,\"sequenceNumber\":1946,\"timestamp\":1562170535968,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":315,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"before\":true},\"relativePos2\":{\"id\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1946,\"sequenceNumber\":1947,\"timestamp\":1562170536952,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":316,\"contents\":{\"pos1\":1285,\"pos2\":1286,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1947,\"sequenceNumber\":1948,\"timestamp\":1562170536952,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":328,\"contents\":{\"pos1\":1286,\"pos2\":1290,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1955,\"sequenceNumber\":1956,\"timestamp\":1562170538781,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":330,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"before\":true},\"relativePos2\":{\"id\":\"85b9316c-a132-435c-b96f-83c2289bd48f\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1956,\"sequenceNumber\":1957,\"timestamp\":1562170539437,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":331,\"contents\":{\"pos1\":1310,\"pos2\":1311,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1957,\"sequenceNumber\":1958,\"timestamp\":1562170539437,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":343,\"contents\":{\"pos1\":1311,\"pos2\":1315,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1965,\"sequenceNumber\":1966,\"timestamp\":1562170541281,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":345,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"before\":true},\"relativePos2\":{\"id\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1966,\"sequenceNumber\":1967,\"timestamp\":1562170541906,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":346,\"contents\":{\"pos1\":1332,\"pos2\":1333,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1967,\"sequenceNumber\":1968,\"timestamp\":1562170541922,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":359,\"contents\":{\"pos1\":1333,\"pos2\":1337,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1975,\"sequenceNumber\":1976,\"timestamp\":1562170543689,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":361,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"before\":true},\"relativePos2\":{\"id\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1976,\"sequenceNumber\":1977,\"timestamp\":1562170544314,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":362,\"contents\":{\"pos1\":1403,\"pos2\":1404,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1977,\"sequenceNumber\":1978,\"timestamp\":1562170544314,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":374,\"contents\":{\"pos1\":1404,\"pos2\":1408,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1985,\"sequenceNumber\":1986,\"timestamp\":1562170546282,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":376,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"before\":true},\"relativePos2\":{\"id\":\"964b916f-fb84-4452-b4a6-52841d947481\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1986,\"sequenceNumber\":1987,\"timestamp\":1562170547001,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":377,\"contents\":{\"pos1\":1526,\"pos2\":1527,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1987,\"sequenceNumber\":1988,\"timestamp\":1562170547017,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":395,\"contents\":{\"pos1\":1527,\"pos2\":1531,\"type\":1},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1998,\"sequenceNumber\":1999,\"timestamp\":1562170550191,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":397,\"contents\":{\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0}},\"relativePos1\":{\"id\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"before\":true},\"relativePos2\":{\"id\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\"},\"type\":2},\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1562170551789,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"a9551fe4-92a2-4dc7-b1de-b16d338ba589\",\"clientSequenceNumber\":397,\"minimumSequenceNumber\":1911,\"referenceSequenceNumber\":1999,\"sequenceNumber\":2000,\"timestamp\":1562170551789,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_3000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_3000_0.json
@@ -1,0 +1,1088 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":2910,\"sequenceNumber\":3000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c08d27ca-3b63-4b75-b323-02ae349d838c\",{\"client\":{\"user\":{\"id\":\"jhxl0xnae@example.com}\",\"name\":\"mppqkyqs108g0km\",\"email\":\"papty7coq@example.com}\"}},\"sequenceNumber\":1}],[\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",{\"client\":{\"user\":{\"id\":\"3im436wix@example.com}\",\"name\":\"nsgitamvw2fqsq2\",\"email\":\"9lf72p5os@example.com}\"}},\"sequenceNumber\":2835}],[\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",{\"client\":{\"user\":{\"id\":\"0n0kni9oh@example.com}\",\"name\":\"zoviivk0w1mmkft\",\"email\":\"2zmejq0s6@example.com}\"}},\"sequenceNumber\":2841}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":182,\"refSeqNumber\":2996}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":163,\"chunkLengthChars\":4682,\"totalLengthChars\":4682,\"totalSegmentCount\":163,\"chunkSequenceNumber\":2910,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i9ktzboy2opzz1nv8htbvbfdh8faa425bocno\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":2910,\"totalLength\":4682,\"totalSegmentCount\":163}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":138,\"seg\":\"A\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2911,\"sequenceNumber\":2912,\"timestamp\":1562171163914,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":139,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2913,\"sequenceNumber\":2914,\"timestamp\":1562171164039,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":140,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2915,\"sequenceNumber\":2916,\"timestamp\":1562171164117,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":141,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2917,\"sequenceNumber\":2918,\"timestamp\":1562171164227,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":142,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2919,\"sequenceNumber\":2920,\"timestamp\":1562171164320,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":143,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2921,\"sequenceNumber\":2922,\"timestamp\":1562171164383,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":144,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2923,\"sequenceNumber\":2924,\"timestamp\":1562171164508,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":145,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2925,\"sequenceNumber\":2926,\"timestamp\":1562171164617,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":146,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2927,\"sequenceNumber\":2928,\"timestamp\":1562171164711,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":147,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2929,\"sequenceNumber\":2930,\"timestamp\":1562171164789,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":110,\"contents\":{\"pos1\":148,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2931,\"sequenceNumber\":2932,\"timestamp\":1562171164914,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":112,\"contents\":{\"pos1\":149,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2933,\"sequenceNumber\":2934,\"timestamp\":1562171164992,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":114,\"contents\":{\"pos1\":150,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2935,\"sequenceNumber\":2936,\"timestamp\":1562171165086,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":116,\"contents\":{\"pos1\":151,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2937,\"sequenceNumber\":2938,\"timestamp\":1562171165164,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":152,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2939,\"sequenceNumber\":2940,\"timestamp\":1562171165305,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":153,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2941,\"sequenceNumber\":2942,\"timestamp\":1562171165367,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":154,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2943,\"sequenceNumber\":2944,\"timestamp\":1562171165508,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":155,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2945,\"sequenceNumber\":2946,\"timestamp\":1562171165586,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":126,\"contents\":{\"pos1\":156,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2947,\"sequenceNumber\":2948,\"timestamp\":1562171165680,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":157,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2949,\"sequenceNumber\":2950,\"timestamp\":1562171165742,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":158,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2951,\"sequenceNumber\":2952,\"timestamp\":1562171165836,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":133,\"contents\":{\"pos1\":159,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2953,\"sequenceNumber\":2954,\"timestamp\":1562171166102,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":136,\"contents\":{\"pos1\":160,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2955,\"sequenceNumber\":2956,\"timestamp\":1562171167289,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":161,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2957,\"sequenceNumber\":2958,\"timestamp\":1562171168796,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":162,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2959,\"sequenceNumber\":2960,\"timestamp\":1562171168890,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":163,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2961,\"sequenceNumber\":2962,\"timestamp\":1562171168921,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":164,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2963,\"sequenceNumber\":2964,\"timestamp\":1562171169062,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":165,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2965,\"sequenceNumber\":2966,\"timestamp\":1562171169125,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":166,\"seg\":\"/\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2967,\"sequenceNumber\":2968,\"timestamp\":1562171169281,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":167,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2969,\"sequenceNumber\":2970,\"timestamp\":1562171169468,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":168,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2971,\"sequenceNumber\":2972,\"timestamp\":1562171169546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":169,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2973,\"sequenceNumber\":2974,\"timestamp\":1562171169671,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":170,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2975,\"sequenceNumber\":2976,\"timestamp\":1562171169828,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":171,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2977,\"sequenceNumber\":2978,\"timestamp\":1562171169890,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":172,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2979,\"sequenceNumber\":2980,\"timestamp\":1562171169984,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":163,\"contents\":{\"pos1\":173,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2981,\"sequenceNumber\":2982,\"timestamp\":1562171170062,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":165,\"contents\":{\"pos1\":174,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2983,\"sequenceNumber\":2984,\"timestamp\":1562171170156,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":175,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2985,\"sequenceNumber\":2986,\"timestamp\":1562171170296,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":176,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2987,\"sequenceNumber\":2988,\"timestamp\":1562171170359,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":177,\"seg\":\"?\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2989,\"sequenceNumber\":2990,\"timestamp\":1562171170546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":178,\"seg\":\" \",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2991,\"sequenceNumber\":2992,\"timestamp\":1562171170937,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":177,\"contents\":{\"pos1\":179,\"seg\":\"(\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2993,\"sequenceNumber\":2994,\"timestamp\":1562171172425,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":180,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2995,\"sequenceNumber\":2996,\"timestamp\":1562171172722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":181,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2997,\"sequenceNumber\":2998,\"timestamp\":1562171172816,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":182,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1562171172894,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"e449dbfb-8b13-4e0d-914d-cb68b5e46da0\",\"clientSequenceNumber\":184,\"minimumSequenceNumber\":2910,\"referenceSequenceNumber\":2999,\"sequenceNumber\":3000,\"timestamp\":1562171172894,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_4000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_4000_0.json
@@ -1,0 +1,1169 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":3895,\"sequenceNumber\":4000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"c08d27ca-3b63-4b75-b323-02ae349d838c\",{\"client\":{\"user\":{\"id\":\"jhxl0xnae@example.com}\",\"name\":\"mppqkyqs108g0km\",\"email\":\"papty7coq@example.com}\"}},\"sequenceNumber\":1}],[\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",{\"client\":{\"user\":{\"id\":\"0n0kni9oh@example.com}\",\"name\":\"zoviivk0w1mmkft\",\"email\":\"2zmejq0s6@example.com}\"}},\"sequenceNumber\":2841}],[\"06b48de8-ee84-4028-856a-ac6e860654ca\",{\"client\":{\"user\":{\"id\":\"7uynw9ggi@example.com}\",\"name\":\"3zfu8eca4pj4zhi\",\"email\":\"zac6kbd1i@example.com}\"}},\"sequenceNumber\":3553}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"06b48de8-ee84-4028-856a-ac6e860654ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":3889}},\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":110,\"refSeqNumber\":3997}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":175,\"chunkLengthChars\":4846,\"totalLengthChars\":4846,\"totalSegmentCount\":175,\"chunkSequenceNumber\":3895,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-2a3e-0000-000000000000}\":true,\"{00000000-0000-0837-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i9ktzboy2opzz1nv8htbvbfdh8faa425bocno\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Are the data loss bugs known/understood?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"476f0794-cdbe-4df8-8261-15304486b9c5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"text\":\"Status Updates\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"Compliance / GRC process is crystallizing\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"37d5dfaf-d80c-4cbd-951d-4992ec5dcd07\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Ales sync \",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d973f39-a5ed-4ddb-b8f8-9de6c0cc213e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Bugs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8ff7c1f2-b319-4783-aec8-99024565769a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"paragraph spacing doesn't have 8px bottom padding\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7540d01b-78e8-4994-b5c6-714422f45437\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83de54ec-a6e7-4049-bde3-4505acc293a6\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":3895,\"totalLength\":4846,\"totalSegmentCount\":175}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":117,\"contents\":{\"pos1\":81,\"pos2\":115,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3919,\"sequenceNumber\":3920,\"timestamp\":1562171715164,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":81,\"seg\":{\"text\":\"3\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3920,\"sequenceNumber\":3921,\"timestamp\":1562171715180,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":82,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3922,\"sequenceNumber\":3923,\"timestamp\":1562171715368,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3924,\"sequenceNumber\":3925,\"timestamp\":1562171715524,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":84,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3926,\"sequenceNumber\":3927,\"timestamp\":1562171715633,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":128,\"contents\":{\"pos1\":84,\"pos2\":85,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3929,\"sequenceNumber\":3930,\"timestamp\":1562171716149,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":130,\"contents\":{\"pos1\":83,\"pos2\":84,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3931,\"sequenceNumber\":3932,\"timestamp\":1562171716305,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":131,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3932,\"sequenceNumber\":3933,\"timestamp\":1562171716494,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":134,\"contents\":{\"pos1\":83,\"pos2\":84,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3935,\"sequenceNumber\":3936,\"timestamp\":1562171716743,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":135,\"contents\":{\"pos1\":83,\"seg\":{\"text\":\"d\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3936,\"sequenceNumber\":3937,\"timestamp\":1562171716822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":137,\"contents\":{\"pos1\":84,\"seg\":{\"text\":\"u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3938,\"sequenceNumber\":3939,\"timestamp\":1562171716884,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":139,\"contents\":{\"pos1\":85,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3940,\"sequenceNumber\":3941,\"timestamp\":1562171716962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":141,\"contents\":{\"pos1\":86,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3942,\"sequenceNumber\":3943,\"timestamp\":1562171716978,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":143,\"contents\":{\"pos1\":87,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3944,\"sequenceNumber\":3945,\"timestamp\":1562171717072,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":145,\"contents\":{\"pos1\":88,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3946,\"sequenceNumber\":3947,\"timestamp\":1562171717103,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":147,\"contents\":{\"pos1\":89,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3948,\"sequenceNumber\":3949,\"timestamp\":1562171717212,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":149,\"contents\":{\"pos1\":90,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3950,\"sequenceNumber\":3951,\"timestamp\":1562171717243,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":151,\"contents\":{\"pos1\":91,\"seg\":{\"text\":\"n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3952,\"sequenceNumber\":3953,\"timestamp\":1562171717290,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":153,\"contents\":{\"pos1\":92,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3954,\"sequenceNumber\":3955,\"timestamp\":1562171717384,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":155,\"contents\":{\"pos1\":93,\"seg\":{\"text\":\"S\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3956,\"sequenceNumber\":3957,\"timestamp\":1562171717478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":157,\"contents\":{\"pos1\":94,\"seg\":{\"text\":\"P\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3958,\"sequenceNumber\":3959,\"timestamp\":1562171717541,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":159,\"contents\":{\"pos1\":95,\"seg\":{\"text\":\"PO\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3960,\"sequenceNumber\":3961,\"timestamp\":1562171717712,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":161,\"contents\":{\"pos1\":97,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3962,\"sequenceNumber\":3963,\"timestamp\":1562171717822,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":165,\"contents\":{\"pos1\":97,\"pos2\":98,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3965,\"sequenceNumber\":3966,\"timestamp\":1562171718197,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":96,\"pos2\":97,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3967,\"sequenceNumber\":3968,\"timestamp\":1562171718337,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":95,\"pos2\":96,\"type\":1},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3969,\"sequenceNumber\":3970,\"timestamp\":1562171718478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":170,\"contents\":{\"pos1\":95,\"seg\":{\"text\":\"O\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3970,\"sequenceNumber\":3971,\"timestamp\":1562171718697,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":172,\"contents\":{\"pos1\":96,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3972,\"sequenceNumber\":3973,\"timestamp\":1562171718853,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":174,\"contents\":{\"pos1\":97,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3974,\"sequenceNumber\":3975,\"timestamp\":1562171719056,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":176,\"contents\":{\"pos1\":98,\"seg\":{\"text\":\"i\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3976,\"sequenceNumber\":3977,\"timestamp\":1562171719134,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":99,\"seg\":{\"text\":\"l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3978,\"sequenceNumber\":3979,\"timestamp\":1562171719165,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":100,\"seg\":{\"text\":\"e\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3980,\"sequenceNumber\":3981,\"timestamp\":1562171719212,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":101,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3982,\"sequenceNumber\":3983,\"timestamp\":1562171719275,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":102,\"seg\":{\"text\":\"f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3984,\"sequenceNumber\":3985,\"timestamp\":1562171719369,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":103,\"seg\":{\"text\":\"o\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3986,\"sequenceNumber\":3987,\"timestamp\":1562171719431,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":104,\"seg\":{\"text\":\"r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3988,\"sequenceNumber\":3989,\"timestamp\":1562171719478,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":105,\"seg\":{\"text\":\"m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3990,\"sequenceNumber\":3991,\"timestamp\":1562171719573,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":192,\"contents\":{\"pos1\":106,\"seg\":{\"text\":\"a\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3992,\"sequenceNumber\":3993,\"timestamp\":1562171719619,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":107,\"seg\":{\"text\":\"t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3994,\"sequenceNumber\":3995,\"timestamp\":1562171719698,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":196,\"contents\":{\"pos1\":108,\"seg\":{\"text\":\" \",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3996,\"sequenceNumber\":3997,\"timestamp\":1562171719791,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":198,\"contents\":{\"pos1\":109,\"seg\":{\"text\":\"c\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},\"type\":0},\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3998,\"sequenceNumber\":3999,\"timestamp\":1562171719885,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}},\"listRegistryList58\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0ad77daf-c3e8-4114-9152-375e1e520779\"}},\"listRegistryList75\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/661cc644-2445-498f-9ad6-496501ca8945\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2be13d6e-a695-4591-82d8-f92d34a88bdc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0ad77daf-c3e8-4114-9152-375e1e520779",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList58\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "661cc644-2445-498f-9ad6-496501ca8945",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList75\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2be13d6e-a695-4591-82d8-f92d34a88bdc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"c82ef0a0-f2a0-443c-a2c3-9a2ccd1a6792\",\"clientSequenceNumber\":199,\"minimumSequenceNumber\":3895,\"referenceSequenceNumber\":3998,\"sequenceNumber\":4000,\"timestamp\":1562171719901,\"type\":\"op\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_5000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_5000_0.json
@@ -1,0 +1,1169 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":4068,\"sequenceNumber\":5000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"06b48de8-ee84-4028-856a-ac6e860654ca\",{\"client\":{\"user\":{\"id\":\"7uynw9ggi@example.com}\",\"name\":\"3zfu8eca4pj4zhi\",\"email\":\"zac6kbd1i@example.com}\"}},\"sequenceNumber\":3553}],[\"4c467f5d-2e96-4961-896e-b90a67386c48\",{\"client\":{\"user\":{\"id\":\"rl6mk6lph@example.com}\",\"name\":\"j18jcxicufp56r2\",\"email\":\"64qao1gr1@example.com}\"}},\"sequenceNumber\":4039}],[\"55650c1d-99b3-4a73-9fcf-854770796c68\",{\"client\":{\"user\":{\"id\":\"aiyycx7fh@example.com}\",\"name\":\"lpkpg49jbxnao6g\",\"email\":\"snv0630zc@example.com}\"}},\"sequenceNumber\":4052}],[\"9b782ec3-cf63-49bd-a6de-896c121d6f69\",{\"client\":{\"user\":{\"id\":\"6ns6a2z0m@example.com}\",\"name\":\"j9p80mtaucpa9gq\",\"email\":\"xa72r4kao@example.com}\"}},\"sequenceNumber\":4069}],[\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",{\"client\":{\"user\":{\"id\":\"lsynyqq5i@example.com}\",\"name\":\"vrz7t8o15as4sox\",\"email\":\"d2wpb1138@example.com}\"}},\"sequenceNumber\":4524}],[\"061c803f-727c-4b5b-b9b4-865892dd3d58\",{\"client\":{\"user\":{\"id\":\"zl8mdon5u@example.com}\",\"name\":\"7m73fy8fy1620s4\",\"email\":\"2e5ylmcv0@example.com}\"}},\"sequenceNumber\":4965}],[\"2e4209f5-3ff2-4b5d-9c25-c16322a1c49a\",{\"client\":{\"user\":{\"id\":\"mi05agm78@example.com}\",\"name\":\"2qigofx4wfbfzia\",\"email\":\"1n8npatpl@example.com}\"}},\"sequenceNumber\":4974}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"06b48de8-ee84-4028-856a-ac6e860654ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":3889}},\"f4de0fce-ee06-42a8-af33-93b32b4239e4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":4068}},\"e3b97299-ae83-4bda-bce2-e970e0c22d53\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":276,\"refSeqNumber\":4942}},\"f1bebf46-f4e2-4d3e-98eb-6d15afb759bc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":167,\"pos\":179,\"refSeqNumber\":4766}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":175,\"chunkLengthChars\":4846,\"totalLengthChars\":4846,\"totalSegmentCount\":175,\"chunkSequenceNumber\":4068,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-2a3e-0000-000000000000}\":true,\"{00000000-0000-0837-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i93 due to an SPO file format changeo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Are the data loss bugs known/understood?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"476f0794-cdbe-4df8-8261-15304486b9c5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"text\":\"Status Updates\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"Compliance / GRC process is crystallizing\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"37d5dfaf-d80c-4cbd-951d-4992ec5dcd07\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Ales sync \",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d973f39-a5ed-4ddb-b8f8-9de6c0cc213e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Bugs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8ff7c1f2-b319-4783-aec8-99024565769a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"paragraph spacing doesn't have 8px bottom padding\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7540d01b-78e8-4994-b5c6-714422f45437\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83de54ec-a6e7-4049-bde3-4505acc293a6\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":4068,\"totalLength\":4846,\"totalSegmentCount\":175}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    },
+                                    {
+                                      "mode": "100644",
+                                      "path": "catchupOps",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "[{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":304,\"pos2\":324,\"props\":{\"styleName\":null,\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":null,\"{00000000-0000-0836-0000-000000000000}\":null,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-4a4f-0000-000000000000}\":null,\"{00000000-0000-4a51-0000-000000000000}\":null,\"{00000000-0000-4a43-0000-000000000000}\":null,\"{00000000-0000-6870-0000-000000000000}\":null,\"{00000000-0000-2a0c-0000-000000000000}\":null},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4459,\"sequenceNumber\":4460,\"timestamp\":1562186704962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":87,\"contents\":{\"pos1\":324,\"pos2\":325,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4460,\"sequenceNumber\":4461,\"timestamp\":1562186704962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":88,\"contents\":{\"pos1\":324,\"pos2\":325,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4461,\"sequenceNumber\":4462,\"timestamp\":1562186704962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":324,\"pos2\":325,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4462,\"sequenceNumber\":4463,\"timestamp\":1562186704962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":90,\"contents\":{\"pos1\":324,\"pos2\":325,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4463,\"sequenceNumber\":4464,\"timestamp\":1562186704962,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":304,\"pos2\":324,\"props\":{\"styleName\":null,\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":null,\"{00000000-0000-0836-0000-000000000000}\":null,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-4a4f-0000-000000000000}\":null,\"{00000000-0000-4a51-0000-000000000000}\":null,\"{00000000-0000-4a43-0000-000000000000}\":null,\"{00000000-0000-6870-0000-000000000000}\":null,\"{00000000-0000-2a0c-0000-000000000000}\":null},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4464,\"sequenceNumber\":4465,\"timestamp\":1562186707494,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":93,\"contents\":{\"pos1\":324,\"pos2\":325,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4465,\"sequenceNumber\":4466,\"timestamp\":1562186707494,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":3594,\"pos2\":3614,\"props\":{\"styleName\":null,\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":null,\"{00000000-0000-0836-0000-000000000000}\":null,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-4a4f-0000-000000000000}\":null,\"{00000000-0000-4a51-0000-000000000000}\":null,\"{00000000-0000-4a43-0000-000000000000}\":null,\"{00000000-0000-6870-0000-000000000000}\":null,\"{00000000-0000-2a0c-0000-000000000000}\":null},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4469,\"sequenceNumber\":4470,\"timestamp\":1562186717546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":101,\"contents\":{\"pos1\":3614,\"pos2\":3615,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4470,\"sequenceNumber\":4471,\"timestamp\":1562186717546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":3614,\"pos2\":3615,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4471,\"sequenceNumber\":4472,\"timestamp\":1562186717546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":103,\"contents\":{\"pos1\":3614,\"pos2\":3615,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4472,\"sequenceNumber\":4473,\"timestamp\":1562186717546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"606172e5-4114-4fca-a014-44f6f72b41f6\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":3614,\"pos2\":3615,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4473,\"sequenceNumber\":4474,\"timestamp\":1562186717546,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":24,\"contents\":{\"pos1\":248,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8a00a3d8-0bde-4330-b53b-7db40f702fa1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4540,\"sequenceNumber\":4541,\"timestamp\":1562187603823,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":27,\"contents\":{\"pos1\":248,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4542,\"sequenceNumber\":4543,\"timestamp\":1562187605761,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":29,\"contents\":{\"pos1\":249,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4544,\"sequenceNumber\":4545,\"timestamp\":1562187605933,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":31,\"contents\":{\"pos1\":250,\"seg\":\"s\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4546,\"sequenceNumber\":4547,\"timestamp\":1562187606027,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":33,\"contents\":{\"pos1\":251,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4548,\"sequenceNumber\":4549,\"timestamp\":1562187606089,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":35,\"contents\":{\"pos1\":252,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4550,\"sequenceNumber\":4551,\"timestamp\":1562187606277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":37,\"contents\":{\"pos1\":253,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4552,\"sequenceNumber\":4553,\"timestamp\":1562187606355,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":39,\"contents\":{\"pos1\":254,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4554,\"sequenceNumber\":4555,\"timestamp\":1562187606449,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":42,\"contents\":{\"pos1\":255,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4556,\"sequenceNumber\":4557,\"timestamp\":1562187606949,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":44,\"contents\":{\"pos1\":256,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4558,\"sequenceNumber\":4559,\"timestamp\":1562187607152,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":46,\"contents\":{\"pos1\":257,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4560,\"sequenceNumber\":4561,\"timestamp\":1562187607277,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":49,\"contents\":{\"pos1\":258,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4562,\"sequenceNumber\":4563,\"timestamp\":1562187609106,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":51,\"contents\":{\"pos1\":259,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4564,\"sequenceNumber\":4565,\"timestamp\":1562187609278,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":53,\"contents\":{\"pos1\":260,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4566,\"sequenceNumber\":4567,\"timestamp\":1562187609388,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":55,\"contents\":{\"pos1\":261,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4568,\"sequenceNumber\":4569,\"timestamp\":1562187609481,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":57,\"contents\":{\"pos1\":262,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4570,\"sequenceNumber\":4571,\"timestamp\":1562187609622,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":59,\"contents\":{\"pos1\":263,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4572,\"sequenceNumber\":4573,\"timestamp\":1562187609700,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":61,\"contents\":{\"pos1\":264,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4574,\"sequenceNumber\":4575,\"timestamp\":1562187609856,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":63,\"contents\":{\"pos1\":265,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4576,\"sequenceNumber\":4577,\"timestamp\":1562187609950,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":65,\"contents\":{\"pos1\":266,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4578,\"sequenceNumber\":4579,\"timestamp\":1562187610019,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":67,\"contents\":{\"pos1\":267,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4580,\"sequenceNumber\":4581,\"timestamp\":1562187610140,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":70,\"contents\":{\"pos1\":268,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4582,\"sequenceNumber\":4583,\"timestamp\":1562187611187,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":72,\"contents\":{\"pos1\":269,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4584,\"sequenceNumber\":4585,\"timestamp\":1562187611406,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":74,\"contents\":{\"pos1\":270,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4586,\"sequenceNumber\":4587,\"timestamp\":1562187611577,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":76,\"contents\":{\"pos1\":271,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4588,\"sequenceNumber\":4589,\"timestamp\":1562187611781,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":78,\"contents\":{\"pos1\":272,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4590,\"sequenceNumber\":4591,\"timestamp\":1562187611843,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":80,\"contents\":{\"pos1\":273,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4592,\"sequenceNumber\":4593,\"timestamp\":1562187612031,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":82,\"contents\":{\"pos1\":274,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4594,\"sequenceNumber\":4595,\"timestamp\":1562187612218,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":84,\"contents\":{\"pos1\":275,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4596,\"sequenceNumber\":4597,\"timestamp\":1562187612296,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":86,\"contents\":{\"pos1\":276,\"seg\":\"h\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4598,\"sequenceNumber\":4599,\"timestamp\":1562187612390,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":89,\"contents\":{\"pos1\":278,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5f8b30a1-86f4-43f7-b010-bb20ac443079\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4600,\"sequenceNumber\":4601,\"timestamp\":1562187613609,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":92,\"contents\":{\"pos1\":278,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4602,\"sequenceNumber\":4603,\"timestamp\":1562187618297,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":94,\"contents\":{\"pos1\":279,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4604,\"sequenceNumber\":4605,\"timestamp\":1562187618484,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":96,\"contents\":{\"pos1\":280,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4606,\"sequenceNumber\":4607,\"timestamp\":1562187618593,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":98,\"contents\":{\"pos1\":281,\"seg\":\"2\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4608,\"sequenceNumber\":4609,\"timestamp\":1562187618750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":100,\"contents\":{\"pos1\":282,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4610,\"sequenceNumber\":4611,\"timestamp\":1562187618906,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":102,\"contents\":{\"pos1\":283,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4612,\"sequenceNumber\":4613,\"timestamp\":1562187619062,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":104,\"contents\":{\"pos1\":284,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4614,\"sequenceNumber\":4615,\"timestamp\":1562187619140,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":106,\"contents\":{\"pos1\":285,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4616,\"sequenceNumber\":4617,\"timestamp\":1562187619234,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":108,\"contents\":{\"pos1\":286,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4618,\"sequenceNumber\":4619,\"timestamp\":1562187619328,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":111,\"contents\":{\"pos1\":287,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4620,\"sequenceNumber\":4621,\"timestamp\":1562187620469,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":113,\"contents\":{\"pos1\":288,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4622,\"sequenceNumber\":4623,\"timestamp\":1562187620656,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":115,\"contents\":{\"pos1\":289,\"seg\":\"1\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4624,\"sequenceNumber\":4625,\"timestamp\":1562187620750,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":118,\"contents\":{\"pos1\":290,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4626,\"sequenceNumber\":4627,\"timestamp\":1562187621109,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":120,\"contents\":{\"pos1\":291,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4628,\"sequenceNumber\":4629,\"timestamp\":1562187621312,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":122,\"contents\":{\"pos1\":292,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4630,\"sequenceNumber\":4631,\"timestamp\":1562187621453,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":124,\"contents\":{\"pos1\":293,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4632,\"sequenceNumber\":4633,\"timestamp\":1562187621562,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":164,\"contents\":{\"pos1\":295,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"209337a1-c7ae-4817-bfe6-221b550154ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4635,\"sequenceNumber\":4636,\"timestamp\":1562187629518,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":167,\"contents\":{\"pos1\":295,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4637,\"sequenceNumber\":4638,\"timestamp\":1562187630300,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":169,\"contents\":{\"pos1\":296,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4639,\"sequenceNumber\":4640,\"timestamp\":1562187630410,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":171,\"contents\":{\"pos1\":297,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4641,\"sequenceNumber\":4642,\"timestamp\":1562187630503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":173,\"contents\":{\"pos1\":298,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4643,\"sequenceNumber\":4644,\"timestamp\":1562187630582,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":175,\"contents\":{\"pos1\":299,\"seg\":\"q\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4645,\"sequenceNumber\":4646,\"timestamp\":1562187630628,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":178,\"contents\":{\"pos1\":300,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4647,\"sequenceNumber\":4648,\"timestamp\":1562187630910,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":180,\"contents\":{\"pos1\":301,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4649,\"sequenceNumber\":4650,\"timestamp\":1562187631082,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":182,\"contents\":{\"pos1\":302,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4651,\"sequenceNumber\":4652,\"timestamp\":1562187631144,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":184,\"contents\":{\"pos1\":303,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4653,\"sequenceNumber\":4654,\"timestamp\":1562187631238,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":186,\"contents\":{\"pos1\":304,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4655,\"sequenceNumber\":4656,\"timestamp\":1562187631332,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":188,\"contents\":{\"pos1\":305,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4657,\"sequenceNumber\":4658,\"timestamp\":1562187631410,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":190,\"contents\":{\"pos1\":306,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4659,\"sequenceNumber\":4660,\"timestamp\":1562187631519,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":192,\"contents\":{\"pos1\":307,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4661,\"sequenceNumber\":4662,\"timestamp\":1562187631644,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":194,\"contents\":{\"pos1\":308,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4663,\"sequenceNumber\":4664,\"timestamp\":1562187631753,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":197,\"contents\":{\"pos1\":309,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4665,\"sequenceNumber\":4666,\"timestamp\":1562187632300,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":199,\"contents\":{\"pos1\":310,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4667,\"sequenceNumber\":4668,\"timestamp\":1562187632394,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":201,\"contents\":{\"pos1\":311,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4669,\"sequenceNumber\":4670,\"timestamp\":1562187632503,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":203,\"contents\":{\"pos1\":312,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4671,\"sequenceNumber\":4672,\"timestamp\":1562187632613,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":205,\"contents\":{\"pos1\":313,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4673,\"sequenceNumber\":4674,\"timestamp\":1562187632722,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":207,\"contents\":{\"pos1\":314,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4675,\"sequenceNumber\":4676,\"timestamp\":1562187632769,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":209,\"contents\":{\"pos1\":315,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4677,\"sequenceNumber\":4678,\"timestamp\":1562187632863,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":211,\"contents\":{\"pos1\":316,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4679,\"sequenceNumber\":4680,\"timestamp\":1562187632988,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":213,\"contents\":{\"pos1\":317,\"seg\":\"e\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4681,\"sequenceNumber\":4682,\"timestamp\":1562187633099,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":215,\"contents\":{\"pos1\":318,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4683,\"sequenceNumber\":4684,\"timestamp\":1562187633239,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":217,\"contents\":{\"pos1\":319,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4685,\"sequenceNumber\":4686,\"timestamp\":1562187633458,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":219,\"contents\":{\"pos1\":320,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4687,\"sequenceNumber\":4688,\"timestamp\":1562187633552,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":221,\"contents\":{\"pos1\":321,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4689,\"sequenceNumber\":4690,\"timestamp\":1562187633661,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":223,\"contents\":{\"pos1\":322,\"seg\":\"y\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4691,\"sequenceNumber\":4692,\"timestamp\":1562187633739,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":225,\"contents\":{\"pos1\":323,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4693,\"sequenceNumber\":4694,\"timestamp\":1562187633911,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":227,\"contents\":{\"pos1\":324,\"seg\":\"i\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4695,\"sequenceNumber\":4696,\"timestamp\":1562187634021,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":229,\"contents\":{\"pos1\":325,\"seg\":\"3\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4697,\"sequenceNumber\":4698,\"timestamp\":1562187634208,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":231,\"contents\":{\"pos1\":326,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4699,\"sequenceNumber\":4700,\"timestamp\":1562187634364,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":233,\"contents\":{\"pos1\":327,\"seg\":\"r\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4701,\"sequenceNumber\":4702,\"timestamp\":1562187634458,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":235,\"contents\":{\"pos1\":328,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4703,\"sequenceNumber\":4704,\"timestamp\":1562187634536,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":237,\"contents\":{\"pos1\":329,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4705,\"sequenceNumber\":4706,\"timestamp\":1562187634682,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":239,\"contents\":{\"pos1\":330,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4707,\"sequenceNumber\":4708,\"timestamp\":1562187634871,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":241,\"contents\":{\"pos1\":331,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4709,\"sequenceNumber\":4710,\"timestamp\":1562187634979,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":243,\"contents\":{\"pos1\":332,\"seg\":\"z\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4711,\"sequenceNumber\":4712,\"timestamp\":1562187635073,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":245,\"contents\":{\"pos1\":333,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4713,\"sequenceNumber\":4714,\"timestamp\":1562187635182,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":334,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4715,\"sequenceNumber\":4716,\"timestamp\":1562187635276,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":335,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4717,\"sequenceNumber\":4718,\"timestamp\":1562187635432,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":335,\"pos2\":336,\"type\":1},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4720,\"sequenceNumber\":4721,\"timestamp\":1562187635854,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":254,\"contents\":{\"pos1\":335,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4721,\"sequenceNumber\":4722,\"timestamp\":1562187635979,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":256,\"contents\":{\"pos1\":336,\"seg\":\"p\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4723,\"sequenceNumber\":4724,\"timestamp\":1562187636136,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":258,\"contents\":{\"pos1\":337,\"seg\":\"g\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4725,\"sequenceNumber\":4726,\"timestamp\":1562187636323,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":260,\"contents\":{\"pos1\":338,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4727,\"sequenceNumber\":4728,\"timestamp\":1562187636401,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":262,\"contents\":{\"pos1\":339,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4729,\"sequenceNumber\":4730,\"timestamp\":1562187636604,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":264,\"contents\":{\"pos1\":340,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4731,\"sequenceNumber\":4732,\"timestamp\":1562187636620,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":267,\"contents\":{\"pos1\":341,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4733,\"sequenceNumber\":4734,\"timestamp\":1562187636948,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":269,\"contents\":{\"pos1\":342,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4735,\"sequenceNumber\":4736,\"timestamp\":1562187637152,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":271,\"contents\":{\"pos1\":343,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4737,\"sequenceNumber\":4738,\"timestamp\":1562187637246,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":273,\"contents\":{\"pos1\":344,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4739,\"sequenceNumber\":4740,\"timestamp\":1562187637480,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":275,\"contents\":{\"pos1\":345,\"seg\":\"9\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4741,\"sequenceNumber\":4742,\"timestamp\":1562187637621,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":278,\"contents\":{\"pos1\":346,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4743,\"sequenceNumber\":4744,\"timestamp\":1562187638027,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":280,\"contents\":{\"pos1\":347,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4745,\"sequenceNumber\":4746,\"timestamp\":1562187638168,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":282,\"contents\":{\"pos1\":348,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4747,\"sequenceNumber\":4748,\"timestamp\":1562187638261,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":284,\"contents\":{\"pos1\":349,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4749,\"sequenceNumber\":4750,\"timestamp\":1562187638340,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":286,\"contents\":{\"pos1\":350,\"seg\":\"m\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4751,\"sequenceNumber\":4752,\"timestamp\":1562187638418,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":288,\"contents\":{\"pos1\":351,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4753,\"sequenceNumber\":4754,\"timestamp\":1562187638621,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":290,\"contents\":{\"pos1\":352,\"seg\":\"l\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4755,\"sequenceNumber\":4756,\"timestamp\":1562187638684,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":292,\"contents\":{\"pos1\":353,\"seg\":\"w\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4757,\"sequenceNumber\":4758,\"timestamp\":1562187638777,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":294,\"contents\":{\"pos1\":354,\"seg\":\"a\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4759,\"sequenceNumber\":4760,\"timestamp\":1562187638855,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":302,\"contents\":{\"pos1\":287,\"pos2\":288,\"type\":1},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4764,\"sequenceNumber\":4765,\"timestamp\":1562187650259,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"48ac56f1-1219-464e-9e24-eac7e2c8d898\",\"clientSequenceNumber\":304,\"contents\":{\"pos1\":287,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4765,\"sequenceNumber\":4766,\"timestamp\":1562187652859,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":210,\"contents\":{\"pos1\":277,\"pos2\":278,\"type\":1},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4884,\"sequenceNumber\":4885,\"timestamp\":1562188317227,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":211,\"contents\":{\"pos1\":248,\"pos2\":277,\"type\":1},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4885,\"sequenceNumber\":4886,\"timestamp\":1562188317227,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":215,\"contents\":{\"pos1\":248,\"seg\":{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98368029-67c9-4c22-8f93-e3c9a6bb52b2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4887,\"sequenceNumber\":4888,\"timestamp\":1562188323275,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":218,\"contents\":{\"pos1\":248,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4889,\"sequenceNumber\":4890,\"timestamp\":1562188328716,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":220,\"contents\":{\"pos1\":249,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4891,\"sequenceNumber\":4892,\"timestamp\":1562188328951,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":222,\"contents\":{\"pos1\":250,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4893,\"sequenceNumber\":4894,\"timestamp\":1562188329123,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":224,\"contents\":{\"pos1\":251,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4895,\"sequenceNumber\":4896,\"timestamp\":1562188329310,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":226,\"contents\":{\"pos1\":252,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4897,\"sequenceNumber\":4898,\"timestamp\":1562188329388,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":228,\"contents\":{\"pos1\":253,\"seg\":\"k\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4899,\"sequenceNumber\":4900,\"timestamp\":1562188329607,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":230,\"contents\":{\"pos1\":254,\"seg\":\"j\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4901,\"sequenceNumber\":4902,\"timestamp\":1562188329748,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":232,\"contents\":{\"pos1\":255,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4903,\"sequenceNumber\":4904,\"timestamp\":1562188329841,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":234,\"contents\":{\"pos1\":256,\"seg\":\"o\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4905,\"sequenceNumber\":4906,\"timestamp\":1562188329982,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":236,\"contents\":{\"pos1\":257,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4907,\"sequenceNumber\":4908,\"timestamp\":1562188330013,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":238,\"contents\":{\"pos1\":258,\"seg\":\"b\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4909,\"sequenceNumber\":4910,\"timestamp\":1562188330107,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":241,\"contents\":{\"pos1\":259,\"seg\":\"c\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4911,\"sequenceNumber\":4912,\"timestamp\":1562188331170,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":243,\"contents\":{\"pos1\":260,\"seg\":\"n\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4913,\"sequenceNumber\":4914,\"timestamp\":1562188331295,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":245,\"contents\":{\"pos1\":261,\"seg\":\"8\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4915,\"sequenceNumber\":4916,\"timestamp\":1562188331405,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":247,\"contents\":{\"pos1\":262,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4917,\"sequenceNumber\":4918,\"timestamp\":1562188331576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":249,\"contents\":{\"pos1\":263,\"seg\":\"u\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4919,\"sequenceNumber\":4920,\"timestamp\":1562188331686,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":251,\"contents\":{\"pos1\":264,\"seg\":\"t\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4921,\"sequenceNumber\":4922,\"timestamp\":1562188331795,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":253,\"contents\":{\"pos1\":265,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4923,\"sequenceNumber\":4924,\"timestamp\":1562188331905,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":255,\"contents\":{\"pos1\":266,\"seg\":\"0\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4925,\"sequenceNumber\":4926,\"timestamp\":1562188331983,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":257,\"contents\":{\"pos1\":267,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4927,\"sequenceNumber\":4928,\"timestamp\":1562188332248,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":259,\"contents\":{\"pos1\":268,\"seg\":\"d\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4929,\"sequenceNumber\":4930,\"timestamp\":1562188332436,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":261,\"contents\":{\"pos1\":269,\"seg\":\"v\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4931,\"sequenceNumber\":4932,\"timestamp\":1562188332576,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":263,\"contents\":{\"pos1\":270,\"seg\":\"7\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4933,\"sequenceNumber\":4934,\"timestamp\":1562188332733,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":265,\"contents\":{\"pos1\":271,\"seg\":\"5\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4935,\"sequenceNumber\":4936,\"timestamp\":1562188332826,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":268,\"contents\":{\"pos1\":272,\"seg\":\"6\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4937,\"sequenceNumber\":4938,\"timestamp\":1562188333780,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":271,\"contents\":{\"pos1\":273,\"seg\":\"f\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4939,\"sequenceNumber\":4940,\"timestamp\":1562188334076,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":273,\"contents\":{\"pos1\":274,\"seg\":\"4\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4941,\"sequenceNumber\":4942,\"timestamp\":1562188334342,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"e3b97299-ae83-4bda-bce2-e970e0c22d53\",\"clientSequenceNumber\":275,\"contents\":{\"pos1\":275,\"seg\":\"x\",\"type\":0},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4943,\"sequenceNumber\":4944,\"timestamp\":1562188334452,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":44,\"contents\":{\"pos1\":411,\"pos2\":431,\"props\":{\"styleName\":null,\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":null,\"{00000000-0000-0836-0000-000000000000}\":null,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-4a4f-0000-000000000000}\":null,\"{00000000-0000-4a51-0000-000000000000}\":null,\"{00000000-0000-4a43-0000-000000000000}\":null,\"{00000000-0000-6870-0000-000000000000}\":null,\"{00000000-0000-2a0c-0000-000000000000}\":null},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4976,\"sequenceNumber\":4977,\"timestamp\":1562188499493,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":45,\"contents\":{\"pos1\":431,\"pos2\":432,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4977,\"sequenceNumber\":4978,\"timestamp\":1562188499493,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":46,\"contents\":{\"pos1\":431,\"pos2\":432,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4978,\"sequenceNumber\":4979,\"timestamp\":1562188499493,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":47,\"contents\":{\"pos1\":431,\"pos2\":432,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4979,\"sequenceNumber\":4980,\"timestamp\":1562188499493,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":48,\"contents\":{\"pos1\":431,\"pos2\":432,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4980,\"sequenceNumber\":4981,\"timestamp\":1562188499493,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":52,\"contents\":{\"pos1\":3701,\"pos2\":3721,\"props\":{\"styleName\":null,\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-0835-0000-000000000000}\":null,\"{00000000-0000-0836-0000-000000000000}\":null,\"{00000000-0000-2a48-0000-000000000000}\":0,\"{00000000-0000-4a4f-0000-000000000000}\":null,\"{00000000-0000-4a51-0000-000000000000}\":null,\"{00000000-0000-4a43-0000-000000000000}\":null,\"{00000000-0000-6870-0000-000000000000}\":null,\"{00000000-0000-2a0c-0000-000000000000}\":null},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4982,\"sequenceNumber\":4983,\"timestamp\":1562188506384,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":53,\"contents\":{\"pos1\":3721,\"pos2\":3722,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"bold\":false,\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4983,\"sequenceNumber\":4984,\"timestamp\":1562188506384,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":54,\"contents\":{\"pos1\":3721,\"pos2\":3722,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"highlight\":\"\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4984,\"sequenceNumber\":4985,\"timestamp\":1562188506384,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":55,\"contents\":{\"pos1\":3721,\"pos2\":3722,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4985,\"sequenceNumber\":4986,\"timestamp\":1562188506384,\"traces\":[],\"type\":\"op\",\"term\":1},{\"clientId\":\"920ecacf-ac18-42a6-828b-436b73105599\",\"clientSequenceNumber\":56,\"contents\":{\"pos1\":3721,\"pos2\":3722,\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}},\"type\":2},\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4986,\"sequenceNumber\":4987,\"timestamp\":1562188506384,\"traces\":[],\"type\":\"op\",\"term\":1}]",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}},\"listRegistryList58\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0ad77daf-c3e8-4114-9152-375e1e520779\"}},\"listRegistryList75\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/661cc644-2445-498f-9ad6-496501ca8945\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2be13d6e-a695-4591-82d8-f92d34a88bdc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0ad77daf-c3e8-4114-9152-375e1e520779",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList58\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "661cc644-2445-498f-9ad6-496501ca8945",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList75\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2be13d6e-a695-4591-82d8-f92d34a88bdc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"061c803f-727c-4b5b-b9b4-865892dd3d58\",\"clientSequenceNumber\":30,\"minimumSequenceNumber\":4068,\"referenceSequenceNumber\":4998,\"sequenceNumber\":5000,\"timestamp\":1562188611417,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_6000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_6000_0.json
@@ -1,0 +1,1214 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":5991,\"sequenceNumber\":6000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"06b48de8-ee84-4028-856a-ac6e860654ca\",{\"client\":{\"user\":{\"id\":\"7uynw9ggi@example.com}\",\"name\":\"3zfu8eca4pj4zhi\",\"email\":\"zac6kbd1i@example.com}\"}},\"sequenceNumber\":3553}],[\"4c467f5d-2e96-4961-896e-b90a67386c48\",{\"client\":{\"user\":{\"id\":\"rl6mk6lph@example.com}\",\"name\":\"j18jcxicufp56r2\",\"email\":\"64qao1gr1@example.com}\"}},\"sequenceNumber\":4039}],[\"55650c1d-99b3-4a73-9fcf-854770796c68\",{\"client\":{\"user\":{\"id\":\"aiyycx7fh@example.com}\",\"name\":\"lpkpg49jbxnao6g\",\"email\":\"snv0630zc@example.com}\"}},\"sequenceNumber\":4052}],[\"44e8cea9-1653-428b-a103-f42d7191b6b4\",{\"client\":{\"user\":{\"id\":\"2gxchziqi@example.com}\",\"name\":\"poacqw5jt7njadj\",\"email\":\"bbsq85v06@example.com}\"}},\"sequenceNumber\":5941}],[\"23ad5f64-ea80-4baa-a63f-3c2ed54c2903\",{\"client\":{\"user\":{\"id\":\"gi7m3zt7n@example.com}\",\"name\":\"f1n1ypiy2zd99yt\",\"email\":\"z4l59jj9w@example.com}\"}},\"sequenceNumber\":5969}],[\"07c5a642-9050-4792-8a83-f54a8366c127\",{\"client\":{\"user\":{\"id\":\"2dpeuv850@example.com}\",\"name\":\"g30vdcy5dxtf327\",\"email\":\"hqi99u36a@example.com}\"}},\"sequenceNumber\":5985}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"06b48de8-ee84-4028-856a-ac6e860654ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":3889}},\"f4de0fce-ee06-42a8-af33-93b32b4239e4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":4068}},\"f1bebf46-f4e2-4d3e-98eb-6d15afb759bc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":167,\"pos\":179,\"refSeqNumber\":4766}},\"061c803f-727c-4b5b-b9b4-865892dd3d58\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":118,\"refSeqNumber\":4987}},\"6ee0f77d-b544-469e-862e-3522dc8d4c30\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":346,\"refSeqNumber\":5142}},\"8cbf645e-f8c1-4bd6-904f-362555a20dcc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":280,\"refSeqNumber\":5169}},\"97ff3cef-85f1-472b-ac78-f0914f5eedf2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":133,\"refSeqNumber\":5232}},\"0920950b-4ee1-45af-aad0-0cf31f6fca37\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":276,\"refSeqNumber\":5244}},\"73a50b37-8527-4f9a-a8be-1d8480229e22\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":137,\"refSeqNumber\":5251}},\"7a4dd225-02da-4615-a0f6-fae254777d80\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5285}},\"5e2e948c-c474-4531-96db-119d1c159a64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5295}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":183,\"chunkLengthChars\":4981,\"totalLengthChars\":4981,\"totalSegmentCount\":183,\"chunkSequenceNumber\":5991,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-2a3e-0000-000000000000}\":true,\"{00000000-0000-0837-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i93 due to an SPO file format changeo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Are the data loss bugs known/understood?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"476f0794-cdbe-4df8-8261-15304486b9c5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"text\":\"Status Updates\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"Compliance / GRC process is crystallizing\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"37d5dfaf-d80c-4cbd-951d-4992ec5dcd07\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Ales sync \",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d973f39-a5ed-4ddb-b8f8-9de6c0cc213e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"n0tv5kjvo7bcn84utv0vdv756f4x\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98368029-67c9-4c22-8f93-e3c9a6bb52b2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"fu32jmq6jvt105bg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5f8b30a1-86f4-43f7-b010-bb20ac443079\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"p6qmx5r9xldj5q3o1kjbtip83qqh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16e3581f-b603-4792-bcad-a63f0bf00100\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"xoaoqggrpijjg96bzrww6me6z6yji3nrtk6czfl0pgddvd8v897uafmulwa\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"209337a1-c7ae-4817-bfe6-221b550154ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Bugs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8ff7c1f2-b319-4783-aec8-99024565769a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"paragraph spacing doesn't have 8px bottom padding\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7540d01b-78e8-4994-b5c6-714422f45437\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83de54ec-a6e7-4049-bde3-4505acc293a6\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":5991,\"totalLength\":4981,\"totalSegmentCount\":183}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}},\"listRegistryList58\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0ad77daf-c3e8-4114-9152-375e1e520779\"}},\"listRegistryList75\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/661cc644-2445-498f-9ad6-496501ca8945\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2be13d6e-a695-4591-82d8-f92d34a88bdc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0ad77daf-c3e8-4114-9152-375e1e520779",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList58\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "661cc644-2445-498f-9ad6-496501ca8945",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList75\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2be13d6e-a695-4591-82d8-f92d34a88bdc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":\"07c5a642-9050-4792-8a83-f54a8366c127\",\"clientSequenceNumber\":7,\"minimumSequenceNumber\":5991,\"referenceSequenceNumber\":5991,\"sequenceNumber\":6000,\"timestamp\":1562374303629,\"type\":\"noop\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_7000_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_7000_0.json
@@ -1,0 +1,1214 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":6997,\"sequenceNumber\":7000,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"06b48de8-ee84-4028-856a-ac6e860654ca\",{\"client\":{\"user\":{\"id\":\"7uynw9ggi@example.com}\",\"name\":\"3zfu8eca4pj4zhi\",\"email\":\"zac6kbd1i@example.com}\"}},\"sequenceNumber\":3553}],[\"4c467f5d-2e96-4961-896e-b90a67386c48\",{\"client\":{\"user\":{\"id\":\"rl6mk6lph@example.com}\",\"name\":\"j18jcxicufp56r2\",\"email\":\"64qao1gr1@example.com}\"}},\"sequenceNumber\":4039}],[\"55650c1d-99b3-4a73-9fcf-854770796c68\",{\"client\":{\"user\":{\"id\":\"aiyycx7fh@example.com}\",\"name\":\"lpkpg49jbxnao6g\",\"email\":\"snv0630zc@example.com}\"}},\"sequenceNumber\":4052}],[\"be4f169f-b99c-4865-aa7c-7925ce7cbe25\",{\"client\":{\"user\":{\"id\":\"rrdla58ni@example.com}\",\"name\":\"8ywuizswodcj0xb\",\"email\":\"m7jeax9ji@example.com}\"}},\"sequenceNumber\":6972}],[\"928930ed-eb79-4319-993d-f8856c5b57e0\",{\"client\":{\"user\":{\"id\":\"4ckg13prn@example.com}\",\"name\":\"sd29qxq6ur84irq\",\"email\":\"2dbutymbs@example.com}\"}},\"sequenceNumber\":6981}],[\"943d8901-95e8-499a-b6bb-30bc7d5df3fc\",{\"client\":{\"user\":{\"id\":\"huwtdgaez@example.com}\",\"name\":\"s1lupwbalkahs0f\",\"email\":\"10lxdp1u6@example.com}\"}},\"sequenceNumber\":6994}],[\"11f32b2e-143c-4781-87ff-d02bf05b5d50\",{\"client\":{\"user\":{\"id\":\"yguzjz83j@example.com}\",\"name\":\"4bwai98c3huq831\",\"email\":\"qufmf5keg@example.com}\"}},\"sequenceNumber\":6998}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"06b48de8-ee84-4028-856a-ac6e860654ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":3889}},\"f4de0fce-ee06-42a8-af33-93b32b4239e4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":4068}},\"f1bebf46-f4e2-4d3e-98eb-6d15afb759bc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":167,\"pos\":179,\"refSeqNumber\":4766}},\"061c803f-727c-4b5b-b9b4-865892dd3d58\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":118,\"refSeqNumber\":4987}},\"6ee0f77d-b544-469e-862e-3522dc8d4c30\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":346,\"refSeqNumber\":5142}},\"8cbf645e-f8c1-4bd6-904f-362555a20dcc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":280,\"refSeqNumber\":5169}},\"97ff3cef-85f1-472b-ac78-f0914f5eedf2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":133,\"refSeqNumber\":5232}},\"0920950b-4ee1-45af-aad0-0cf31f6fca37\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":276,\"refSeqNumber\":5244}},\"73a50b37-8527-4f9a-a8be-1d8480229e22\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":137,\"refSeqNumber\":5251}},\"7a4dd225-02da-4615-a0f6-fae254777d80\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5285}},\"5e2e948c-c474-4531-96db-119d1c159a64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5295}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":183,\"chunkLengthChars\":4981,\"totalLengthChars\":4981,\"totalSegmentCount\":183,\"chunkSequenceNumber\":6997,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-2a3e-0000-000000000000}\":true,\"{00000000-0000-0837-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i93 due to an SPO file format changeo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Are the data loss bugs known/understood?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"476f0794-cdbe-4df8-8261-15304486b9c5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"text\":\"Status Updates\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"Compliance / GRC process is crystallizing\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"37d5dfaf-d80c-4cbd-951d-4992ec5dcd07\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Ales sync \",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d973f39-a5ed-4ddb-b8f8-9de6c0cc213e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"n0tv5kjvo7bcn84utv0vdv756f4x\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98368029-67c9-4c22-8f93-e3c9a6bb52b2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"fu32jmq6jvt105bg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5f8b30a1-86f4-43f7-b010-bb20ac443079\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"p6qmx5r9xldj5q3o1kjbtip83qqh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16e3581f-b603-4792-bcad-a63f0bf00100\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"xoaoqggrpijjg96bzrww6me6z6yji3nrtk6czfl0pgddvd8v897uafmulwa\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"209337a1-c7ae-4817-bfe6-221b550154ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Bugs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8ff7c1f2-b319-4783-aec8-99024565769a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"paragraph spacing doesn't have 8px bottom padding\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7540d01b-78e8-4994-b5c6-714422f45437\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83de54ec-a6e7-4049-bde3-4505acc293a6\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"813f299e-6edc-4237-8a3c-8679536a0ade\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":6997,\"totalLength\":4981,\"totalSegmentCount\":183}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}},\"listRegistryList58\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0ad77daf-c3e8-4114-9152-375e1e520779\"}},\"listRegistryList75\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/661cc644-2445-498f-9ad6-496501ca8945\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2be13d6e-a695-4591-82d8-f92d34a88bdc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0ad77daf-c3e8-4114-9152-375e1e520779",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList58\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "661cc644-2445-498f-9ad6-496501ca8945",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList75\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2be13d6e-a695-4591-82d8-f92d34a88bdc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":6997,\"referenceSequenceNumber\":-1,\"sequenceNumber\":7000,\"timestamp\":1562575707832,\"type\":\"leave\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_7770_0.json
+++ b/snapshotTestContent/WedMeetingFileBug/src_snapshots/0.59.3000/snapshot_7770_0.json
@@ -1,0 +1,1241 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":7767,\"sequenceNumber\":7770,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"06b48de8-ee84-4028-856a-ac6e860654ca\",{\"client\":{\"user\":{\"id\":\"7uynw9ggi@example.com}\",\"name\":\"3zfu8eca4pj4zhi\",\"email\":\"zac6kbd1i@example.com}\"}},\"sequenceNumber\":3553}],[\"4c467f5d-2e96-4961-896e-b90a67386c48\",{\"client\":{\"user\":{\"id\":\"rl6mk6lph@example.com}\",\"name\":\"j18jcxicufp56r2\",\"email\":\"64qao1gr1@example.com}\"}},\"sequenceNumber\":4039}],[\"55650c1d-99b3-4a73-9fcf-854770796c68\",{\"client\":{\"user\":{\"id\":\"aiyycx7fh@example.com}\",\"name\":\"lpkpg49jbxnao6g\",\"email\":\"snv0630zc@example.com}\"}},\"sequenceNumber\":4052}],[\"587fb556-97b8-4d59-a8ad-f404555b82a5\",{\"client\":{\"user\":{\"id\":\"micnl4luf@example.com}\",\"name\":\"2l6igaop9cktutw\",\"email\":\"ykztqy9q4@example.com}\"}},\"sequenceNumber\":7303}],[\"b840d8bd-1749-4e51-9b3c-fe054e158417\",{\"client\":{\"user\":{\"id\":\"cmiqehdot@example.com}\",\"name\":\"mrng95ucxss4pt2\",\"email\":\"89rc32vwa@example.com}\"}},\"sequenceNumber\":7309}],[\"cbb3b134-f365-4660-91ba-fe0d79aa8990\",{\"client\":{\"user\":{\"id\":\"cz5th1pry@example.com}\",\"name\":\"si3jkfd7q9rczy2\",\"email\":\"pec3wpd00@example.com}\"}},\"sequenceNumber\":7373}],[\"fbb046ea-c47d-426d-a2e9-91d30939103b\",{\"client\":{\"user\":{\"id\":\"ocf6r6tnk@example.com}\",\"name\":\"fqabn0gzhiajd5j\",\"email\":\"iwqjnqr68@example.com}\"}},\"sequenceNumber\":7387}],[\"49eb702a-4968-4878-b140-b7ef9f4a3800\",{\"client\":{\"user\":{\"id\":\"jljp2byxe@example.com}\",\"name\":\"nqhgb4qnwubjni6\",\"email\":\"sg9ndb7q8@example.com}\"}},\"sequenceNumber\":7553}],[\"77480dde-65d4-4cee-a170-99fa18d5ecb8\",{\"client\":{\"user\":{\"id\":\"tgwxt9ak9@example.com}\",\"name\":\"tr81vf3z9qeazni\",\"email\":\"ftg4i03jb@example.com}\"}},\"sequenceNumber\":7571}],[\"04361a2a-cc8d-4562-acb7-0c4bcb3b147c\",{\"client\":{\"user\":{\"id\":\"i9px2ba91@example.com}\",\"name\":\"xusekt82jbhj5u3\",\"email\":\"da5ak923l@example.com}\"}},\"sequenceNumber\":7584}],[\"adcdaafd-48f1-48d6-b418-986d6491a473\",{\"client\":{\"user\":{\"id\":\"qubsi2jid@example.com}\",\"name\":\"iji7h9979q3mwt1\",\"email\":\"yca7eav3m@example.com}\"}},\"sequenceNumber\":7587}],[\"96d7e19d-e8c0-420e-8c0f-0a5f8685fe92\",{\"client\":{\"user\":{\"id\":\"ai6aobpv7@example.com}\",\"name\":\"m9fxruwobdcgrdx\",\"email\":\"p2ckzds2f@example.com}\"}},\"sequenceNumber\":7762}],[\"554ad409-5479-4f81-ab4f-15d4494265d5\",{\"client\":{\"user\":{\"id\":\"bla890wbi@example.com}\",\"name\":\"7v2g50m3j5vb469\",\"email\":\"nvps899dz@example.com}\"}},\"sequenceNumber\":7765}],[\"2902fc01-d6db-44d8-a361-138655071313\",{\"client\":{\"permission\":[],\"type\":\"browser\",\"user\":{\"id\":\"jjynpbn4n@example.com}\",\"name\":\"7i2boc9l013a4qd\",\"email\":\"fnwwiz7j2@example.com}\"}},\"sequenceNumber\":7770}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":3,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":2,\"value\":{\"package\":\"@ms/office-prague-container\"}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "discover",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/discover\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "catalog",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/catalog\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"presence\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2aaed5f1-497c-4041-925c-18504127df54\"}},\"language\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d87479a6-14f5-4891-b493-4a8229c9c7ab\"}},\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ecb7d730-cc68-4ab8-9bea-ad24324f9009\"}},\"text.ItemType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"endOfKeys\":{\"type\":\"Plain\",\"value\":true},\"text.documentStyleRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0aadefc0-1c16-47e9-931c-61a73b5b1e79\"}},\"text.documentListRegistry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/773470ad-42cf-4a7c-8c3e-485291c43de6\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2aaed5f1-497c-4041-925c-18504127df54",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"c08d27ca-3b63-4b75-b323-02ae349d838c\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":57,\"refSeqNumber\":1716}},\"06b48de8-ee84-4028-856a-ac6e860654ca\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":3889}},\"f4de0fce-ee06-42a8-af33-93b32b4239e4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":247,\"refSeqNumber\":4068}},\"f1bebf46-f4e2-4d3e-98eb-6d15afb759bc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":167,\"pos\":179,\"refSeqNumber\":4766}},\"061c803f-727c-4b5b-b9b4-865892dd3d58\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":118,\"refSeqNumber\":4987}},\"6ee0f77d-b544-469e-862e-3522dc8d4c30\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":346,\"refSeqNumber\":5142}},\"8cbf645e-f8c1-4bd6-904f-362555a20dcc\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":280,\"refSeqNumber\":5169}},\"97ff3cef-85f1-472b-ac78-f0914f5eedf2\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":133,\"refSeqNumber\":5232}},\"0920950b-4ee1-45af-aad0-0cf31f6fca37\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":276,\"refSeqNumber\":5244}},\"73a50b37-8527-4f9a-a8be-1d8480229e22\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":137,\"refSeqNumber\":5251}},\"7a4dd225-02da-4615-a0f6-fae254777d80\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5285}},\"5e2e948c-c474-4531-96db-119d1c159a64\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":5295}},\"61768286-3eb2-4272-b59c-a019b6a79ea4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7241}},\"dc5c40c3-7c5c-439d-a273-6aeefa271d76\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7241}},\"77ce16e1-1e81-4b45-bd01-b3271fc7e5b9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7266}},\"d2132fa8-759b-4b3e-8cb2-66f4fbd700f9\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7279}},\"e2d6fa0e-187c-4ce2-a8f0-c6fb3cefaec4\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7279}},\"587fb556-97b8-4d59-a8ad-f404555b82a5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7301}},\"b840d8bd-1749-4e51-9b3c-fe054e158417\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7301}},\"5f2f3e4e-ae10-4f44-885a-13839cc07ee1\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7328}},\"7df0c24a-4dfa-47a2-8fff-a0de79a8ca97\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7338}},\"8822989e-9e42-4496-99f6-159773fd5269\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7363}},\"cbb3b134-f365-4660-91ba-fe0d79aa8990\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7371}},\"11698b7b-e859-414f-8376-18daea1c863a\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7377}},\"c57396ac-93b9-484e-a0c1-f3851b1d19ac\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7642}},\"554ad409-5479-4f81-ab4f-15d4494265d5\":{\"type\":\"Plain\",\"value\":{\"type\":\"selection\",\"origMark\":-1,\"pos\":0,\"refSeqNumber\":7763}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d87479a6-14f5-4891-b493-4a8229c9c7ab",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "199ded11-9f44-4cb6-94ca-fc70d8ef24f5",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ecb7d730-cc68-4ab8-9bea-ad24324f9009",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"intervalCollections\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/199ded11-9f44-4cb6-94ca-fc70d8ef24f5\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":185,\"chunkLengthChars\":4983,\"totalLengthChars\":4983,\"totalSegmentCount\":185,\"chunkSequenceNumber\":7767,\"segmentTexts\":[{\"text\":\"yzonda3pyvpdnavki43jmcq9ejb7lpywar5qb7zrp2guto0h0j\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\",\"{00000000-0000-2a3e-0000-000000000000}\":true,\"{00000000-0000-0837-0000-000000000000}\":false}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0b2ce092-fcac-4a69-8a06-b75067b05dfb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":true,\"highlight\":\"\"}}},{\"text\":\"ncvrn3sgmqrewogh5mtvhhsffou7i93 due to an SPO file format changeo\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7e6fa238-1ac7-4abe-9915-4712730307a5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"02325cf0-ed38-41e2-947f-f9eccab95bec\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d1ec71c-5d4a-4141-a608-a9e427b1e141\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Agenda for 7/3/2019\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"249bf576-05f8-4f30-abe3-5d8114aa90e3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},\"Are the data loss bugs known/understood?\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0a82c3a2-d74f-4ea1-a7ba-02d126d8efdf\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"20be8d49-38ab-4e36-b905-21ad49e4e90b\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"476f0794-cdbe-4df8-8261-15304486b9c5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList58\"}}},{\"text\":\"Status Updates\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"84e821fc-9129-43fd-8d7b-283a5b4d809a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},\"Compliance / GRC process is crystallizing\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"37d5dfaf-d80c-4cbd-951d-4992ec5dcd07\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Ales sync \",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3d973f39-a5ed-4ddb-b8f8-9de6c0cc213e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"n0tv5kjvo7bcn84utv0vdv756f4x\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"98368029-67c9-4c22-8f93-e3c9a6bb52b2\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"fu32jmq6jvt105bg\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"5f8b30a1-86f4-43f7-b010-bb20ac443079\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"p6qmx5r9xldj5q3o1kjbtip83qqh\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"16e3581f-b603-4792-bcad-a63f0bf00100\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"xoaoqggrpijjg96bzrww6me6z6yji3nrtk6czfl0pgddvd8v897uafmulwa\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"209337a1-c7ae-4817-bfe6-221b550154ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"Bugs\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8ff7c1f2-b319-4783-aec8-99024565769a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList75\"}}},\"paragraph spacing doesn't have 8px bottom padding\",{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7540d01b-78e8-4994-b5c6-714422f45437\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList0\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"83de54ec-a6e7-4049-bde3-4505acc293a6\",\"ItemType\":\"Paragraph\",\"Properties\":{}}},{\"text\":\"aelbr8zs79ainpoa3q66\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6af05f09-0521-442d-be24-af723ca3721e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"5hn2ibx9ynsrd9kbde7zue6j45d0oqt6ehur8p6lrww9pttbj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9f93c982-c630-47d3-9a55-e7f9f295f68c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j0ewiix3fkgoqzxlrnrrsxlyjfjc3ayq5n8o6jqybdegld2c3ob0uj\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"06f9a905-551f-4a96-ab0a-e09bf601f2ed\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7yrze7kxah\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"40bb7dba-d03a-4763-86c9-6e10c53eaeb1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"1te6olnwd62lhf7fit\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2e8f808a-be95-4295-9c61-68ed609d0e68\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"jk8smvl19i7577ixqysn4ld1piv6nc9p0fk25t74i14uoyozsa2wyqqr50mjohgbgq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"7803c0f5-e1f8-4387-b5af-46ec97a0f928\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"apn7h0bjcp2c7x4w6zkvdb865auiizjuhav\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a990da9a-d512-46a3-b594-ced8e76e52e8\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"ssqx2lyfxudzh2lh86z1nwtm94qp7muahtboxm85e7ta6s9adwgvoeb1k\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1ba0e95d-90ec-4185-9e67-e8b6aaacd093\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"tb1vti3ed7u299o9c1l\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8e55946-b491-4e82-bbc4-5a570dd3c101\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"r6wp4o6zwrutqski8ivif\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"34c904d1-4bcc-4213-a181-7842c88496ce\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"aw0wepj6zx755e8fel469nan\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"30039ecc-e294-4c23-b34d-0723ac4f4c42\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7d2jd32viwy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"cuul7boxs1ns\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"qgczqmfykxipnil9uvp3vvdut65gn6pqvuul1gfysmo62hmg0a8no68nfd3ytr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a007c2ed-b84d-46b5-a9df-eebfd9903268\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList43\"}}},{\"text\":\"7a3b66ea6o364loxlvounfvllug52bbuqof\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"21984637-6015-4761-bd7d-1af6a1ae2280\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"ccj7djyqcor98lh6lrlpa2opvd2y66rt4780gh4k6nvpauhqdm6mvjjab8wvkv19kcw859b1h4h3jlak\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"708314f4-de6b-4310-8a50-b05b844c2b3a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"j4u3vmp5aaj1s98akyo9hi33rdocyyckv8q2nmswqzmor9q43hme\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"587198bd-067a-41b0-933b-7b899db341ab\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5t9a00imjcmrqmcxp2c37snvtnbbjymnfk6pgtt7h1u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d97bf2c3-4ef3-49db-9d70-a12d6debf874\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"9oqg5og6s47sqsx4u6iqxax7rpmd0lfr9xlnv8kqy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"bsbc652a57827vepyqd3abyfdu829bmok2o22pyemxi88xfp98\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"j😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"81c6347d-0fc4-4a4a-abcd-51378633ff1a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"54kdvamv9jh1re0sgt3mspo3l4xfu1769el8zkqkhxos8y333kyf3mqoot1itclzrbdodbhy7p1acp20l3sagxs7dm50474pfo16n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"26fed600-3a68-4d39-a1c7-87663e529234\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"4c8tfzdn99i8aqgwf5pjqqdlulhgql6r6hntqlzvumvxksopnkwtxgmftbl1mtt8kp1pq5w45id2kukcfw1eyxzae0gv8yd37k76f8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8d2fe749-6bb3-44d2-9f5a-42ecc829a0c4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"c9ig9vugbyih8defdx5cion093z6d75wf1ixroadulvbar0pq3k2qso1e7ojlfyfhkzk9lyaewnwu2s4jrthxgrzuw2psj51ceh33mw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cc643c34-99a0-4505-905e-a286f0234762\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vda6e4my7f8xfjmn9s6x5km3yadljzgno758dzd0tockbk5whakyqqfif2avyf5kqe8a99mamecadw5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"35fa85d5-8f2d-48e6-99fe-9b3a1800cbb3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"yexx3t0gcftmsopey8msr90u\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"85b9316c-a132-435c-b96f-83c2289bd48f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"d6jqi086u3n3kg79m0f9f\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d9cc141c-e2ce-424c-b840-eb7a9c368eeb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"m95d7l412jh1uscstel1chafqwack49qazyd9kgujsxm6ovutjhlrpt8l2dzmd7t5xvl😊\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"75b0fcd8-b306-4b37-a1e6-a0e2914dcf06\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"vz8g77bp9wfj7le5agxrgt3moe8v9mhtzqrq77kxgah7kfcsdqbulvogg40mk4i8s5sbo5sl33lex3gxggpaohags78poh69rfcav212c5g650zutkq9z43lz0\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"964b916f-fb84-4452-b4a6-52841d947481\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"5w2twapirn327ps14ja46uqf3t😉\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":true,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"caf3296f-d2e4-4d5d-8e84-a53b55acbdc4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-65\"}}},{\"text\":\"iqnjh9ow42lr7vabclthrfwm4he9dw89wer7o1q3ywafpxnfx9t00j0z552izvikoklsk3drvncnkps5iw\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6c363fe7-2d4e-48aa-9563-328723bbbbd4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"yf2p3lbftgbc2i0rzoj6us3wkhpeu9f5lztngd7eepqeqielba9aaker5gerzckkaodmy76fm6wr2gglpv0b8crxfpezk4xboce13p7v3y6uewb2lk0o9sq5gzkrvhwp0x25ia34b\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f6316d61-b47d-40a5-beb4-75843124f037\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"n91hnt1lmwa9xpwp0zpl39rc1frybr8wm9jo4t33p8ankck8smcamhst1mx5hh0sj8z6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d7d9004d-26a4-42d3-998d-6fe8cf7d359c\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-85\"}}},{\"text\":\"6p430u5q8j43dbre3mdlyb2oowvklpq4mdlfvwqr283t4mdqm3myviyyvqys4vvpbh5ge963mgc9e6g8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6cd86eb1-22df-4d0d-bf32-5759dd533793\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gy3zszxcn2vjbuis6nnoj93sb2kjpq7\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"19babd91-5e6e-4332-8d93-3b14f94adc52\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9gb1f8717upf9fcgmba9gmh3tbew4my3noahhveqxjs1s0hsbs9nxdsmnm3dk8bu4z8if13pdtyl\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1fa38f18-2f1f-48ab-ba4d-a11e88d2a025\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"aegxz9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f401e123-a474-4f6b-9a6c-fe838d061067\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList106\"}}},{\"text\":\"mr4i85gglte1u8roacg2egfhaim4x3m9ova4gky9n8k7y66sp7ou58ai\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"9567a34a-936f-4ba0-b500-b61487cd1309\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"o16g1wfqrzi5a53xiqyoaap4kqbj8slsuo3nseggk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0491bda5-6de8-4209-aaca-20a27bb9f520\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ql2npidex7ws5284a0g4p9vxaaq4mjn62261k4xchzrq8e96m6j0gvrnysdwfwvvhhk\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e6af2fee-b300-413b-ad01-11b89ef90e64\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"1tmjrtnp8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cac4cc64-5b90-4fb3-b407-2103d34d938f\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ovrxyhpcpzuagpxn2562dlzpfpxeaqngkyrb98t7jgmyq97z4aowkcdouw636fpmgm1vih9kuwqaeio0p928x86sdtefxolpwx722iqvob4qh5rqdqplg7gyfei9h2fc3t6ei0tpasx\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"368c0eac-18ec-4ce9-adb4-9f0955ac4e62\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv9h1omc4on4xb02geg9dn1hwngjn6v7t613cejwdr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d64e1acd-cf43-400f-bd81-1b928807c1f7\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"0m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d69dec2f-02a2-43f4-b211-f449d43cbb67\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"8g2n\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"177f9184-26d6-46c8-858e-0cee779f202e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"zq8hbw2hv6\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"3f6a3204-717c-46f2-8376-950b8509b189\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"v3rvsjijzra8obmwyc19sowe4ogtsdkwngp5va4j6v49w8wnoxs\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"addf64f0-e526-45bf-aa98-63962fd02fd0\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"yv2jbd8ubwiuvfzptz5b4e325isvb09w8\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"873a7f82-b60f-462e-a980-4377f219758d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ofv23r7'0vgymigu3fep1esdws01dygnbi15z9yy7zwnrszi6oc3fbbzmgim1koy6vauyh3dbx7eg9duoxrmpj089vld38j8mgmhd9cy8dnq46ecz0b3vfuf2rpa4rtomk8jypmg77rfs8lklpt4o19by8iv5ttcs99hjpe8mrkjh3hzw7rdgyq9t\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"4026e428-b292-4a38-9057-2ba87c2e30f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"twbpns6s08tf6kq8ttqvpxix1ki6sz8mpetsoqz4dd\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8989c881-644b-487e-9aa4-c53d36fbbeb6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"advrmsw0ikv7827m2vhujlf0ztp9lpst5p\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7e0d6d7-e54d-4d5a-8875-0608b326a2bc\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"kyl96azqskauunt0f3ujsih4jsqiqsylycdpau2cpn9ephh5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"c8b74a5d-d039-4646-81cd-c5f21c19b2af\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"26gkvkvp4m4qhligk3qbai41hb5xlrtt8r9gzihgca6u8p4uiod5oqivxyzfy5o0f5kjn8vfloddz3aqfquk0csajlaeaa9togacc2xp3xzm2pyunt18p3so\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"f07eeee9-0ab3-4561-9207-4cfc7ef90f85\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList60\"}}},{\"text\":\"ndvzx5j5x5kaxm07xph24lxigkvx8rc3sn60ggykr4vb20x6butjdvpagt5gc5xjuwy0ng20pcz9b2fkl6j7mbjfk9e9j7ib99un1yyy5jbhls\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"10c43455-3ef8-49e1-bfbd-c718653afea4\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList60\"}}},{\"text\":\"wi3o9mb\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d82c6e58-6b71-4da9-afd7-c4fc94d87718\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"ucblr0ir7p614wtxfyblxv9vetwzd3dm7k3atqxq68cbarkz2\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceb9cb91-cde2-421b-87cb-10ff5659f535\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"5zog2rntx36gbj0sw6e55vfbq6ne6oc9ax1qhuscg8uabdl4o5f29lgeclqoal36m6lkva9i884ub0wuif1r\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2f6a75eb-ad3a-4d25-8039-0d026600e686\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":1,\"listId\":\"listRegistryList90\"}}},{\"text\":\"467fz3x3fuqffwhb98hsvcjsoe8pup\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"2cb01b20-d7c7-4cc9-bed2-5eea33eb02ac\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"4vday8nz54jnfvb6hhkp7fod30firw65mkfewoam2wwg537n2wmz9zg2u6405rok2s80kinw79qjirur2qlxqiir4zbk6pa0akhcn3s\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"32cb3ca0-149e-47f5-a5e6-0bbb3b1618fb\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\",\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"text\":\"phurqhp41v9aq6nqpjflcfunxjdnlylm472dtuml11ajqakmm8h4r5vdimig3gqr73xmcfbb9\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e343982c-bfc2-40a8-ab5c-b60183ea6301\",\"ItemType\":\"Paragraph\",\"Properties\":{\"listItemFormatIndex\":0,\"listId\":\"listRegistryList90\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ceabe9b6-7f3d-40c5-9607-ae54f37ccf9a\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"jauwlk834zrex0nw1nhv\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"e7fbb97b-721f-4d11-a828-adfc2fc589b3\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 1\"}}},{\"text\":\"uqzsi4densste3jwfede3qag8f7qbgul49syy79supxhrcub7upl2pg8p76ytvqqrjrma07hhkdrf4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"a1ecd47a-5d44-4bba-8a99-7a16c78699de\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"9l9tha9f4mrapn4d9ipcim50vr85x0jng0qjlu5uc8bemhr8lc8f28klbs8p22qbklspbvgs72ngh1366\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"0745775f-5934-4efc-b7e3-c343009340ee\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList15\"}}},{\"text\":\"77bs5e1bh6ovg5hbzue9u3z7yty48a4iiowld2mn5kzznilcvu5vtez78i7gxuotsnllmpxr0b6efmm1m4m\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"09bbc11a-1655-48dd-b015-619af231ae45\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"k9wwh6lqzoic5ehqunoxl8oq0t4z96smj5dro009g9agr12ei68wugck8nk44eh674qgp0umifbe2gcjxqc0a7yj6xba3nln1la34mnvlrksq87ux5qr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"d548c722-5bda-46dc-a8d4-cfb92254a164\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"hpur1spi7udenvpknarklb009z9fsridmjly8ycu6rwbmnw20dbui25q01\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"64179c9f-9f3a-4c36-97dd-1cc075beca35\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList1\"}}},{\"text\":\"41eluqpilvloij9ma1xhsbe1sc2pdmeo2ym2vlek5w1jeo9nr53eor9d9qim\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"1dfd31cc-6d9d-44f1-b6a2-1715912adb38\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"gg8gfh44m\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"42548f66-1189-44c5-9852-47e8b0c368f1\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":1,\"listId\":\"listRegistryList-67\"}}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"8cc783df-ad2d-477a-b567-fb152583eb36\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"z81d\",\"props\":{\"{00000000-0000-2a3e-0000-000000000000}\":false,\"{00000000-0000-0837-0000-000000000000}\":false,\"{00000000-0000-2a48-0000-000000000000}\":0}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"600b7ea1-bf89-4bee-8d3f-9f86397108b5\",\"ItemType\":\"Paragraph\",\"Properties\":{\"styleName\":\"Heading 2\"}}},{\"text\":\"t0q5gm1tlyi3sq2m8yxkif4zr5bv92f84jk7qvh25rtca7qnyh8asoctlxo6bmu0kj01bipn9ujugvs6iumxr84bghr4\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"ab2526bc-4678-4dda-8841-d5219eee9130\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"krctwpwj9ej9yebrcjb1ad73p9v512aghd22r9a3wxcdbs3dq7p3at73w39uub0tsf5g\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"60ab638a-df01-4ca9-b5fa-7c05ed57f094\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"d1u08rq3s9gqy9loaz4qzfgsulb4y9erpn366bzdj4bkn6przu7zplt8lwriz9kgro2pq0532t76dlerxg2x68rk2iac7wj8b3k16s9ewati4t6pkg0m9cs52rjaiewusunwfhp0jsl5ty632rs73i0erdb4kc9pr0bsnjj9czonamnnrmf\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"022d9d9a-4111-4f55-8cbd-b233b22441e6\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}},{\"text\":\"56metjf3qj8fa7ic5gxxpw1ploqocqwq8qz09euulg4fh34zm1vwh5\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"5bh8alyt\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"6730a331-bd4c-4159-8b22-8b018311d34d\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"nz12wguqlldjtruewq98mi2ae6z3i8pdg60vp7zmgljaaeaoc63u7g1v68jup6gbia3m7\",\"props\":{}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"38d74472-effb-4676-8470-7f16f5ed2868\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"listItemFormatIndex\":0,\"listId\":\"listRegistryList-115\"}}},{\"text\":\"ljye5vvbkquzcq8r6j196x7qwbyeioa5qpo9nqkdupr\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"\"}},{\"text\":\"c6y7kstm\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"aba0b857-2744-4a0b-b670-f8228e256418\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"0o3g1wf0q1detuzcxvubig60rn97okge8jzadnrlvcbib31zxzupgedpu6le9hnookntmsmofoy\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"fbbcf004-ea50-48eb-bbc6-7d18f4edc98e\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"#ffffff\"}}},{\"text\":\"ad0fywdvpfd05bptk6st7557xuzy60r7q3qscniub0qu76juhqafffd2t7kgqnw87jtrtocymzj297knywsc3xad2fe5ckpdj63bsfp4m2fja739x8da5134tpkgymjvq\",\"props\":{\"{00000000-0000-0835-0000-000000000000}\":false,\"{00000000-0000-2a0c-0000-000000000000}\":\"#ffffff\"}},{\"marker\":{\"refType\":1},\"props\":{\"referenceTileLabels\":[\"Eop\"],\"markerId\":\"cfa97c2f-7766-4123-acbd-bbc68bf7fc31\",\"ItemType\":\"Paragraph\",\"Properties\":{\"isRtl\":false,\"bold\":false,\"highlight\":\"\"}}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":7767,\"totalLength\":4983,\"totalSegmentCount\":185}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0aadefc0-1c16-47e9-931c-61a73b5b1e79",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"},\"styleRegistryStyleHeading 1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c5c35926-1ae1-4bd1-a386-048660e066a7\"}},\"styleRegistryStyleHeading 2\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/53d9cccf-d1ac-4aa0-bf28-c827fda78ef1\"}},\"styleRegistryStyleBody\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a\"}},\"styleRegistryStyleStrong\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/3b03f95c-5b3e-4004-8dc6-826b3cf1ed44\"}},\"styleRegistryStyleEmphasis\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a70c0d5f-55c1-4d0d-b42a-b28b547187d2\"}},\"styleRegistryStyleTitle\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8728822b-5a61-4837-b6e2-74288cc47c80\"}},\"styleRegistryStyleFixed Table\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/85a5c79c-79d1-47b5-8998-5379b0e1aad7\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c5c35926-1ae1-4bd1-a386-048660e066a7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 1\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI SemiBold\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":24},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"1\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "53d9cccf-d1ac-4aa0-bf28-c827fda78ef1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Heading 2\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Segoe UI\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":18},\"propertiesfontColor\":{\"type\":\"Plain\",\"value\":\"#484644\"},\"propertiespaddingBottom\":{\"type\":\"Plain\",\"value\":15},\"propertiespaddingTop\":{\"type\":\"Plain\",\"value\":12},\"propertiesrole\":{\"type\":\"Plain\",\"value\":\"heading\"},\"propertiesariaLevel\":{\"type\":\"Plain\",\"value\":\"2\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "4f8809c2-0a71-46b1-ace5-8e7f1a78ff0a",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Body\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"defaultStyle\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "3b03f95c-5b3e-4004-8dc6-826b3cf1ed44",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Strong\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a70c0d5f-55c1-4d0d-b42a-b28b547187d2",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Emphasis\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"character\"},\"propertiesitalic\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8728822b-5a61-4837-b6e2-74288cc47c80",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Title\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"paragraph\"},\"propertiesfontName\":{\"type\":\"Plain\",\"value\":\"Calibri Light\"},\"propertiesfontSize\":{\"type\":\"Plain\",\"value\":28}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "85a5c79c-79d1-47b5-8998-5379b0e1aad7",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"Style\"},\"name\":{\"type\":\"Plain\",\"value\":\"Fixed Table\"},\"styleTarget\":{\"type\":\"Plain\",\"value\":\"table\"},\"propertiestableColumnWidth\":{\"type\":\"Plain\",\"value\":100},\"propertiesbold\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "773470ad-42cf-4a7c-8c3e-485291c43de6",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"listRegistryList-86\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/9ab56c68-a11e-4746-a080-f3d7b7955e2b\"}},\"listRegistryList-26\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/21706f58-9558-4814-a2c8-776bf9f0fc6d\"}},\"listRegistryList-11\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/c47d890b-d81a-4bf0-a002-9c12023a4d4f\"}},\"listRegistryList-34\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/33632013-873c-42ee-900a-14589f988d07\"}},\"listRegistryList-7\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/030a1b44-7d52-4806-8839-0711b4d13c76\"}},\"listRegistryList-35\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/d46facec-1e69-4fe7-8f36-c78aedb277eb\"}},\"listRegistryList117\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0057afd4-13a7-4307-b72f-b2ae569580f0\"}},\"listRegistryList-108\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/1986cc6a-3ad7-4188-88cc-b9b10276fda8\"}},\"listRegistryList15\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/73121fb4-acb5-4896-a1f6-ce50fa3d991b\"}},\"listRegistryList1\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ae92b7cd-2328-49b3-879b-06dbf761eb6b\"}},\"listRegistryList-67\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/b514202e-232c-499d-9284-64ad9bf3c9c8\"}},\"listRegistryList-115\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/48e838d8-68d4-4062-a2ef-62424910e440\"}},\"listRegistryList43\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/ca23fb91-3ca3-4858-8fe9-b14fa4321d10\"}},\"listRegistryList-65\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f\"}},\"listRegistryList-85\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41\"}},\"listRegistryList106\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/af74c154-8e24-4fc9-9ce9-2724c2bdeb26\"}},\"listRegistryList60\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/8f4ba7fc-1526-4700-bab9-09d25d9ae7dc\"}},\"listRegistryList90\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/46d5d03a-7b0c-44e9-8e78-e96a4204d42f\"}},\"listRegistryList58\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/0ad77daf-c3e8-4114-9152-375e1e520779\"}},\"listRegistryList75\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/661cc644-2445-498f-9ad6-496501ca8945\"}},\"listRegistryList0\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/defaultComponent/2be13d6e-a695-4591-82d8-f92d34a88bdc\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "9ab56c68-a11e-4746-a080-f3d7b7955e2b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-86\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "21706f58-9558-4814-a2c8-776bf9f0fc6d",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-26\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "c47d890b-d81a-4bf0-a002-9c12023a4d4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-11\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "33632013-873c-42ee-900a-14589f988d07",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-34\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "030a1b44-7d52-4806-8839-0711b4d13c76",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-7\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "d46facec-1e69-4fe7-8f36-c78aedb277eb",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-35\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0057afd4-13a7-4307-b72f-b2ae569580f0",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList117\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "1986cc6a-3ad7-4188-88cc-b9b10276fda8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-108\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "73121fb4-acb5-4896-a1f6-ce50fa3d991b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList15\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ae92b7cd-2328-49b3-879b-06dbf761eb6b",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList1\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "b514202e-232c-499d-9284-64ad9bf3c9c8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-67\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "48e838d8-68d4-4062-a2ef-62424910e440",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-115\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "ca23fb91-3ca3-4858-8fe9-b14fa4321d10",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList43\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a3ef7361-ef3f-418d-926d-f8fa3b8d3a4f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-65\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "a8c66d5f-c0f6-44dc-a3af-a7a19c65dc41",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList-85\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "af74c154-8e24-4fc9-9ce9-2724c2bdeb26",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList106\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8f4ba7fc-1526-4700-bab9-09d25d9ae7dc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList60\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "46d5d03a-7b0c-44e9-8e78-e96a4204d42f",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList90\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "0ad77daf-c3e8-4114-9152-375e1e520779",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList58\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "661cc644-2445-498f-9ad6-496501ca8945",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList75\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "2be13d6e-a695-4591-82d8-f92d34a88bdc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"ItemType\":{\"type\":\"Plain\",\"value\":\"List\"},\"listId\":{\"type\":\"Plain\",\"value\":\"listRegistryList0\"},\"listItemFormat0\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat1\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat2\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat3\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat4\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat5\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"},\"listItemFormat6\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc8226\"},\"listItemFormat7\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc111\"},\"listItemFormat8\":{\"type\":\"Plain\",\"value\":\"%cssClass-scriptor-listItem-marker-bullet;%cc168\"}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "atMentions",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "instances",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/atmentions\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "adb0d648-f3ca-4f84-bf50-12f0d060b943",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"endOfKeys\":{\"type\":\"Plain\",\"value\":true}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.59.3000\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/formula\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "registro",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/registro\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":0,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":7767,\"referenceSequenceNumber\":-1,\"sequenceNumber\":7770,\"timestamp\":1564075877003,\"type\":\"join\"}}",
+          "encoding": "utf-8"
+        }
+      }
+    ]
+  }
+}

--- a/snapshotTestContent/createContainerMetadata/src_snapshots/0.59.3000/snapshotVersion.json
+++ b/snapshotTestContent/createContainerMetadata/src_snapshots/0.59.3000/snapshotVersion.json
@@ -1,0 +1,1 @@
+{"snapshotVersion":"0.59.3000"}

--- a/snapshotTestContent/createContainerMetadata/src_snapshots/0.59.3000/snapshot_72_0.json
+++ b/snapshotTestContent/createContainerMetadata/src_snapshots/0.59.3000/snapshot_72_0.json
@@ -1,0 +1,467 @@
+{
+  "commits": {
+  },
+  "tree": {
+    "entries": [
+      {
+        "mode": "100644",
+        "path": ".attributes",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"minimumSequenceNumber\":72,\"sequenceNumber\":72,\"term\":1}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumMembers",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumProposals",
+        "type": "Blob",
+        "value": {
+          "contents": "[]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "100644",
+        "path": "quorumValues",
+        "type": "Blob",
+        "value": {
+          "contents": "[[\"code\",{\"approvalSequenceNumber\":7,\"commitSequenceNumber\":-1,\"key\":\"code\",\"sequenceNumber\":6,\"value\":{\"package\":{\"name\":\"@ms/office-fluid-container\",\"version\":\"20211216011\",\"fluid\":{\"browser\":{\"umd\":{\"files\":[\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/runtime.c5696f50bde6a5bb3992.js\",\"https://cdn.fluidpreview.office.net/fluid/df/container/hashed/officeContainer.a57f129c375fd1747945.js\"],\"library\":\"officeContainer\"}}}},\"config\":{}}}]]",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": ".channels",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "040000",
+              "path": "_scheduler",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"scheduler\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/_scheduler/8047978b-16bc-4de9-9ae2-9f1861216504\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/map\",\"snapshotFormatVersion\":\"0.2\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8047978b-16bc-4de9-9ae2-9f1861216504",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"leader\":{\"atomic\":{\"sequenceNumber\":68,\"value\":{\"type\":\"Plain\",\"value\":null}},\"versions\":[{\"sequenceNumber\":68,\"value\":{\"type\":\"Plain\",\"value\":null}}]}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/consensus-register-collection\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"_scheduler\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "defaultComponent",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"rootComponentConfig\":{\"type\":\"Plain\",\"value\":{\"canvasComponentType\":\"@ms/scriptor\"}},\"lastEditedId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c8333ec1-92e3-4451-9873-c53d48282cbc\"}},\"defaultViewId\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":true}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "c8333ec1-92e3-4451-9873-c53d48282cbc",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"lastEditedSharedSummaryBlockKey\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/c8333ec1-92e3-4451-9873-c53d48282cbc/8ec45b33-c82c-493d-9b6e-8ee1c04f6226\"}},\"lastEditCreatorKey\":{\"type\":\"Plain\",\"value\":{\"user\":{\"id\":\"mbjknz0djsm08533mpw1@test.com\",\"name\":\"ip mfn8\",\"email\":\"mbjknz0djsm08533mpw1@test.com\",\"oid\":\"a0d1c626-5205-44c7-8b91-301299ac86a9\"},\"timestamp\":1641336102541}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "8ec45b33-c82c-493d-9b6e-8ee1c04f6226",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/shared-summary-block\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "mode": "040000",
+              "path": "9552e6f6-028f-46f5-8f7c-f6e4d15c953f",
+              "type": "Tree",
+              "value": {
+                "entries": [
+                  {
+                    "mode": "040000",
+                    "path": ".channels",
+                    "type": "Tree",
+                    "value": {
+                      "entries": [
+                        {
+                          "mode": "040000",
+                          "path": "root",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"text\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/50b4442b-cea2-458a-9218-7e79974509b1\"}},\"text:nodeType\":{\"type\":\"Plain\",\"value\":\"StoryNode\"},\"defaultContentLocale\":{\"type\":\"Plain\",\"value\":\"en-us\"},\"defaultContentDirection\":{\"type\":\"Plain\",\"value\":\"ltr\"},\"text:style!registry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/03d14e28-6fef-4bf7-a61b-c2407d01f080\"}},\"text:list!registry\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/faf33ea9-7629-46b6-9c47-15897d998dd8\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "50b4442b-cea2-458a-9218-7e79974509b1",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "040000",
+                                "path": "content",
+                                "type": "Tree",
+                                "value": {
+                                  "entries": [
+                                    {
+                                      "mode": "100644",
+                                      "path": "header",
+                                      "type": "Blob",
+                                      "value": {
+                                        "contents": "{\"chunkStartSegmentIndex\":0,\"chunkSegmentCount\":2,\"chunkLengthChars\":13,\"totalLengthChars\":13,\"totalSegmentCount\":2,\"chunkSequenceNumber\":72,\"segmentTexts\":[{\"text\":\"new document\",\"props\":{\"attribution\":{\"id\":\"mbjknz0djsm08533mpw1@test.com\",\"name\":\"ip mfn8\",\"email\":\"mbjknz0djsm08533mpw1@test.com\",\"timestamp\":1641336000000}}},{\"marker\":{\"refType\":1},\"props\":{\"markerId\":\"1925c045-d6e5-4161-86b2-16201ee4cf7e\",\"nodeType\":\"Paragraph\",\"list!reference\":\"0;list!list-dbaa67b7-31f2-4fbf-b3a7-6c0b484c54060;0\",\"placeholder!attributeText\":\"Add item\"}}],\"headerMetadata\":{\"orderedChunkMetadata\":[{\"id\":\"header\"}],\"sequenceNumber\":72,\"totalLength\":13,\"totalSegmentCount\":2}}",
+                                        "encoding": "utf-8"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/mergeTree\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "03d14e28-6fef-4bf7-a61b-c2407d01f080",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"StyleRegistry\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "faf33ea9-7629-46b6-9c47-15897d998dd8",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"ListRegistry\"},\"list!list-dbaa67b7-31f2-4fbf-b3a7-6c0b484c54060\":{\"type\":\"Plain\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/153fb535-437e-443f-b2cf-f8b1456215cc\"}}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "mode": "040000",
+                          "path": "153fb535-437e-443f-b2cf-f8b1456215cc",
+                          "type": "Tree",
+                          "value": {
+                            "entries": [
+                              {
+                                "mode": "100644",
+                                "path": "header",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"blobs\":[],\"content\":{\"storage\":{\"nodeType\":{\"type\":\"Plain\",\"value\":\"List\"},\"list!id\":{\"type\":\"Plain\",\"value\":\"list!list-dbaa67b7-31f2-4fbf-b3a7-6c0b484c54060\"},\"list!itemFormat-0\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-1\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-2\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-3\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-4\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-5\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-6\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-7\":{\"type\":\"Plain\",\"value\":\"%cb\"},\"list!itemFormat-8\":{\"type\":\"Plain\",\"value\":\"%cb\"}}}}",
+                                  "encoding": "utf-8"
+                                }
+                              },
+                              {
+                                "mode": "100644",
+                                "path": ".attributes",
+                                "type": "Blob",
+                                "value": {
+                                  "contents": "{\"type\":\"https://graph.microsoft.com/types/directory\",\"snapshotFormatVersion\":\"0.1\",\"packageVersion\":\"0.53.0\"}",
+                                  "encoding": "utf-8"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "mode": "100644",
+                    "path": ".component",
+                    "type": "Blob",
+                    "value": {
+                      "contents": "{\"pkg\":\"[\\\"@ms/scriptor\\\"]\",\"summaryFormatVersion\":2,\"isRootDataStore\":false}",
+                      "encoding": "utf-8"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "mode": "100644",
+        "path": ".metadata",
+        "type": "Blob",
+        "value": {
+          "contents": "{\"createContainerRuntimeVersion\":\"0.53.0\",\"createContainerTimestamp\":1641336100567,\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":72,\"referenceSequenceNumber\":72,\"sequenceNumber\":72,\"timestamp\":1641336438129,\"type\":\"noClient\"}}",
+          "encoding": "utf-8"
+        }
+      },
+      {
+        "mode": "040000",
+        "path": "gc",
+        "type": "Tree",
+        "value": {
+          "entries": [
+            {
+              "mode": "100644",
+              "path": "__gc_root",
+              "type": "Blob",
+              "value": {
+                "contents": "{\"gcNodes\":{\"/_scheduler/8047978b-16bc-4de9-9ae2-9f1861216504\":{\"outboundRoutes\":[\"/_scheduler\"]},\"/_scheduler/root\":{\"outboundRoutes\":[\"/_scheduler/8047978b-16bc-4de9-9ae2-9f1861216504\",\"/_scheduler\"]},\"/_scheduler\":{\"outboundRoutes\":[\"/_scheduler/root\",\"/_scheduler/8047978b-16bc-4de9-9ae2-9f1861216504\"]},\"/defaultComponent/root\":{\"outboundRoutes\":[\"/c8333ec1-92e3-4451-9873-c53d48282cbc\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\",\"/defaultComponent\"]},\"/defaultComponent\":{\"outboundRoutes\":[\"/defaultComponent/root\"]},\"/c8333ec1-92e3-4451-9873-c53d48282cbc/8ec45b33-c82c-493d-9b6e-8ee1c04f6226\":{\"outboundRoutes\":[\"/c8333ec1-92e3-4451-9873-c53d48282cbc\"]},\"/c8333ec1-92e3-4451-9873-c53d48282cbc/root\":{\"outboundRoutes\":[\"/c8333ec1-92e3-4451-9873-c53d48282cbc/8ec45b33-c82c-493d-9b6e-8ee1c04f6226\",\"/c8333ec1-92e3-4451-9873-c53d48282cbc\"]},\"/c8333ec1-92e3-4451-9873-c53d48282cbc\":{\"outboundRoutes\":[\"/c8333ec1-92e3-4451-9873-c53d48282cbc/root\",\"/c8333ec1-92e3-4451-9873-c53d48282cbc/8ec45b33-c82c-493d-9b6e-8ee1c04f6226\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/03d14e28-6fef-4bf7-a61b-c2407d01f080\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/faf33ea9-7629-46b6-9c47-15897d998dd8\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/153fb535-437e-443f-b2cf-f8b1456215cc\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/153fb535-437e-443f-b2cf-f8b1456215cc\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/root\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/50b4442b-cea2-458a-9218-7e79974509b1\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/03d14e28-6fef-4bf7-a61b-c2407d01f080\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/faf33ea9-7629-46b6-9c47-15897d998dd8\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/50b4442b-cea2-458a-9218-7e79974509b1\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\"]},\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f\":{\"outboundRoutes\":[\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/root\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/50b4442b-cea2-458a-9218-7e79974509b1\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/03d14e28-6fef-4bf7-a61b-c2407d01f080\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/faf33ea9-7629-46b6-9c47-15897d998dd8\",\"/9552e6f6-028f-46f5-8f7c-f6e4d15c953f/153fb535-437e-443f-b2cf-f8b1456215cc\"]},\"/\":{\"outboundRoutes\":[\"/_scheduler\",\"/defaultComponent\"]}}}",
+                "encoding": "utf-8"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
These are the snapshot tests fixes that go along with these issues/PRs

Note: there was a manual fix to the source snapshots in 0.45 for [snapshot_461_0.json](https://github.com/microsoft/FluidFrameworkTestData/compare/remove-duplicate-gc-routes?expand=1#diff-8d2a5c8af7fec0d3b5142eabe7ec244ae421d8f0cabc4fa1e8eeebcd1bdd54cc) and in 0.47 for [snapshot_461_0.json](https://github.com/microsoft/FluidFrameworkTestData/compare/remove-duplicate-gc-routes?expand=1#diff-c4f72938fc177b657bd5d4dd2331a8d8dccaf8e10a71ca2322ed125206bb0630) so that the snapshot tests would pass with `fullGC = false`. Normally what would happen is that the summary would run with `fullGC = true`, but the coverage deemed for `fullGC = false` is more important as that caused a much bigger issue.

https://github.com/microsoft/FluidFramework/pull/10016
https://github.com/microsoft/FluidFramework/issues/9472