### PR TITLE
Added message to metadata blob in DeletedTables src_snapshots/0.45.0.  This is needed for GC to run.

### DIFF
--- a/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.45.0/snapshot_461_0.json
+++ b/snapshotTestContent/DeletedTables_0.43/src_snapshots/0.45.0/snapshot_461_0.json
@@ -5550,7 +5550,7 @@
         "mode": "100644",
         "type": "Blob",
         "value": {
-          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":1,\"sequenceNumber\":461}",
+          "contents": "{\"summaryFormatVersion\":1,\"gcFeature\":1,\"message\":{\"clientId\":null,\"clientSequenceNumber\":-1,\"minimumSequenceNumber\":461,\"referenceSequenceNumber\":461,\"sequenceNumber\":461,\"timestamp\":1627344403198,\"type\":\"noClient\"}}",
           "encoding": "utf-8"
         }
       },


### PR DESCRIPTION
With [11957](https://github.com/microsoft/FluidFramework/pull/11957) in Fluidframework, GC requires a timestamp in order to run. This timestamp either comes from the last processed op by a container or from the message in the metadata blob in the summary.
Prior to 0.47.0, the metadata blob did not have a message and one of the snapshot tests doesn't replay ops before summarizing / running GC. In the absence of ops, GC fails to run and the test fails because the snapshot generated does not have GC data.

This PR adds message to the metadata blob in 0.45.0 snapshot for DeletedTables folder. Note that this does not break real clients because summarize / GC does not run in absence of ops. So, if real clients were to load from an 0.45.0 (or older) snapshot and run GC, it would run fine because there will be ops.